### PR TITLE
feat: add stats dashboard and sessions browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Toast notification system** — Reusable toast provider with auto-dismiss, used by manual steps notifications.
 
 - **Configurable DEV_ROOT** — Set `devRoot` in `.minder.json` to scan a directory other than `C:\dev`. Header displays the configured path.
+- **Stats Dashboard** — Portfolio-wide analytics at `/stats`. Overview cards (projects, sessions, TODOs, costs), tech stack distribution (frameworks, ORMs, styling, services), project health (status, activity recency, TODO completion), and Claude Code usage (tokens, tools, models, errors). Inspired by [Sniffly](https://github.com/chiphuyen/sniffly).
+- **Sessions Browser** — Browse all Claude Code sessions at `/sessions`. Search by prompt, project, or branch. Sort by recency, duration, or tokens. Active session indicators (green pulse). Click into session detail with timeline, tool usage, file operations, and subagent tracking. Inspired by [claude-code-karma](https://github.com/JayantDevkar/claude-code-karma).
 
 ### Changed
 - **Background git dirty status** — Dashboard cards now show real uncommitted change counts (amber `+N`). A background worker checks repos in batches of 3, and the dashboard polls for results. Detail pages still fetch on-demand for instant accuracy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,16 @@ Project: **Project Minder** — local-only dashboard that auto-scans `C:\dev\*` 
 - `POST /api/manual-steps/[slug]` — toggle checkbox `{lineNumber}`
 - `GET /api/manual-steps/changes?since=ISO8601` — new-entry change events for notifications
 - `GET /api/git-status` — background git dirty status cache (polled by dashboard)
+- `GET /api/stats` — aggregated portfolio stats + Claude Code usage analytics
+- `GET /api/sessions` — all session summaries (2-min cache, `?project=slug` filter)
+- `GET /api/sessions/[sessionId]` — full session detail (timeline, file ops, subagents)
 
 ### UI (`src/components/`)
 - Dashboard: `DashboardGrid` with search, status filter, sort options, `ProjectCard` grid
 - Detail: `ProjectDetail` with tabs (Overview, Context, TODOs, Claude, Manual Steps) + `DevServerControl`
 - Manual Steps: `ManualStepsDashboard` cross-project page at `/manual-steps`, `ManualStepsList` per-project checklist, `ManualStepsCompact` badge on cards
+- Stats: `StatsDashboard` at `/stats` with `StatCard`, `BarChart`, `HealthBar` sub-components
+- Sessions: `SessionsBrowser` at `/sessions` lists all Claude Code sessions. `SessionDetailView` at `/sessions/[sessionId]` with timeline, file ops, subagents tabs. Parser (`claudeConversations.ts`) reads `~/.claude/projects/` JSONL files
 - `DevServerControl` — compact mode on cards (start/stop badge), full mode on detail page (start/stop/restart, open in browser, output viewer)
 - Hand-rolled UI primitives in `src/components/ui/` (badge, button, input, tabs, skeleton, toast)
 

--- a/docs/help/sessions.md
+++ b/docs/help/sessions.md
@@ -1,0 +1,38 @@
+# Sessions Browser
+
+The Sessions page shows all Claude Code sessions across your projects, parsed from `~/.claude/projects/` conversation logs.
+
+## Session List
+
+Each session card shows:
+- **Project name** and initial prompt preview
+- **Active indicator** — green pulse dot for sessions modified in the last 2 minutes
+- **Duration** — how long the session lasted
+- **Messages** — total message count
+- **Tokens** — combined input/output token count
+- **Tool calls** — total tool invocations
+- **Subagents** — number of spawned subagents (if any)
+- **Errors** — API error count (if any)
+- **Git branch** — the branch active during the session
+- **Model badges** — which Claude models were used
+
+## Search & Sort
+
+- **Search** — filter by prompt text, project name, session ID, or git branch
+- **Sort** — by most recent, longest duration, or most tokens
+
+## Session Detail
+
+Click a session to see the full detail view with tabs:
+
+### Timeline
+Chronological list of all events: user prompts, assistant responses, tool calls, thinking blocks, and errors. Each event shows a time offset from the session start.
+
+### Tools
+Bar chart showing which tools were used and how many times.
+
+### Files
+Table of file operations (read, write, edit, glob, grep) with file paths and tool names.
+
+### Subagents
+Cards for each spawned subagent showing type, description, and top tools used.

--- a/docs/help/stats.md
+++ b/docs/help/stats.md
@@ -1,0 +1,36 @@
+# Stats Dashboard
+
+The Stats page gives you a bird's-eye view of your entire development portfolio and Claude Code usage.
+
+## Overview Cards
+
+The top row shows key metrics at a glance:
+- **Projects** — total scanned projects (with hidden count)
+- **Claude Sessions** — total sessions across all projects
+- **Pending TODOs** — outstanding items across all TODO.md files
+- **Manual Steps** — pending manual steps across all projects
+- **Est. Cost** — rough estimated cost of all Claude Code usage
+
+## Claude Code Usage
+
+Aggregated from conversation logs in `~/.claude/projects/`:
+- **Token counts** — input, output, cache read/create tokens
+- **Top Tools** — which tools Claude uses most (Read, Write, Edit, Bash, etc.)
+- **Models** — which Claude models have been used
+- **Errors** — API error count across all conversations
+
+## Tech Stack Distribution
+
+Bar charts showing how many projects use each:
+- **Frameworks** — Next.js, Vite, Express, etc.
+- **ORMs** — Drizzle, Prisma, etc.
+- **Styling** — Tailwind, Sass, etc.
+- **External Services** — Stripe, Clerk, Supabase, etc.
+
+## Project Health
+
+Segmented bars showing:
+- **Status** — active vs paused vs archived distribution
+- **Activity Recency** — when projects were last active (today, this week, this month, older)
+- **TODO Completion** — completed vs pending across portfolio
+- **Manual Steps** — completed vs pending across portfolio

--- a/public/help/sessions.md
+++ b/public/help/sessions.md
@@ -1,0 +1,38 @@
+# Sessions Browser
+
+The Sessions page shows all Claude Code sessions across your projects, parsed from `~/.claude/projects/` conversation logs.
+
+## Session List
+
+Each session card shows:
+- **Project name** and initial prompt preview
+- **Active indicator** — green pulse dot for sessions modified in the last 2 minutes
+- **Duration** — how long the session lasted
+- **Messages** — total message count
+- **Tokens** — combined input/output token count
+- **Tool calls** — total tool invocations
+- **Subagents** — number of spawned subagents (if any)
+- **Errors** — API error count (if any)
+- **Git branch** — the branch active during the session
+- **Model badges** — which Claude models were used
+
+## Search & Sort
+
+- **Search** — filter by prompt text, project name, session ID, or git branch
+- **Sort** — by most recent, longest duration, or most tokens
+
+## Session Detail
+
+Click a session to see the full detail view with tabs:
+
+### Timeline
+Chronological list of all events: user prompts, assistant responses, tool calls, thinking blocks, and errors. Each event shows a time offset from the session start.
+
+### Tools
+Bar chart showing which tools were used and how many times.
+
+### Files
+Table of file operations (read, write, edit, glob, grep) with file paths and tool names.
+
+### Subagents
+Cards for each spawned subagent showing type, description, and top tools used.

--- a/public/help/stats.md
+++ b/public/help/stats.md
@@ -1,0 +1,36 @@
+# Stats Dashboard
+
+The Stats page gives you a bird's-eye view of your entire development portfolio and Claude Code usage.
+
+## Overview Cards
+
+The top row shows key metrics at a glance:
+- **Projects** — total scanned projects (with hidden count)
+- **Claude Sessions** — total sessions across all projects
+- **Pending TODOs** — outstanding items across all TODO.md files
+- **Manual Steps** — pending manual steps across all projects
+- **Est. Cost** — rough estimated cost of all Claude Code usage
+
+## Claude Code Usage
+
+Aggregated from conversation logs in `~/.claude/projects/`:
+- **Token counts** — input, output, cache read/create tokens
+- **Top Tools** — which tools Claude uses most (Read, Write, Edit, Bash, etc.)
+- **Models** — which Claude models have been used
+- **Errors** — API error count across all conversations
+
+## Tech Stack Distribution
+
+Bar charts showing how many projects use each:
+- **Frameworks** — Next.js, Vite, Express, etc.
+- **ORMs** — Drizzle, Prisma, etc.
+- **Styling** — Tailwind, Sass, etc.
+- **External Services** — Stripe, Clerk, Supabase, etc.
+
+## Project Health
+
+Segmented bars showing:
+- **Status** — active vs paused vs archived distribution
+- **Activity Recency** — when projects were last active (today, this week, this month, older)
+- **TODO Completion** — completed vs pending across portfolio
+- **Manual Steps** — completed vs pending across portfolio

--- a/src/app/api/sessions/[sessionId]/route.ts
+++ b/src/app/api/sessions/[sessionId]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { scanSessionDetail } from "@/lib/scanner/claudeConversations";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+  const detail = await scanSessionDetail(sessionId);
+
+  if (!detail) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(detail);
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { scanAllSessions } from "@/lib/scanner/claudeConversations";
+import { SessionSummary } from "@/lib/types";
+
+let cachedSessions: SessionSummary[] | null = null;
+let cachedAt = 0;
+const CACHE_TTL = 2 * 60_000; // 2 minutes
+
+export async function GET(request: NextRequest) {
+  const project = request.nextUrl.searchParams.get("project");
+
+  if (!cachedSessions || Date.now() - cachedAt > CACHE_TTL) {
+    cachedSessions = await scanAllSessions();
+    cachedAt = Date.now();
+  }
+
+  let results = cachedSessions;
+  if (project) {
+    results = results.filter((s) => s.projectSlug === project || s.projectName.includes(project));
+  }
+
+  return NextResponse.json(results);
+}

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { scanAllProjects } from "@/lib/scanner";
 import { getCachedScan, setCachedScan } from "@/lib/cache";
 import { computeStats } from "@/lib/stats";
-import { scanAllClaudeConversations } from "@/lib/scanner/claudeConversations";
+import { scanClaudeConversationsForProjects } from "@/lib/scanner/claudeConversations";
 import { ClaudeUsageStats } from "@/lib/types";
 
 // Cache Claude usage stats separately (expensive to compute)
@@ -17,10 +17,11 @@ export async function GET() {
     setCachedScan(result);
   }
 
-  // Fetch Claude usage stats (cached separately with longer TTL)
+  // Fetch Claude usage stats scoped to scanned projects only
   let claudeUsage = cachedClaudeUsage;
   if (!claudeUsage || Date.now() - claudeUsageCachedAt > CLAUDE_USAGE_TTL) {
-    claudeUsage = await scanAllClaudeConversations();
+    const projectPaths = result.projects.map((p) => p.path);
+    claudeUsage = await scanClaudeConversationsForProjects(projectPaths);
     cachedClaudeUsage = claudeUsage;
     claudeUsageCachedAt = Date.now();
   }

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { scanAllProjects } from "@/lib/scanner";
+import { getCachedScan, setCachedScan } from "@/lib/cache";
+import { computeStats } from "@/lib/stats";
+import { scanAllClaudeConversations } from "@/lib/scanner/claudeConversations";
+import { ClaudeUsageStats } from "@/lib/types";
+
+// Cache Claude usage stats separately (expensive to compute)
+let cachedClaudeUsage: ClaudeUsageStats | null = null;
+let claudeUsageCachedAt = 0;
+const CLAUDE_USAGE_TTL = 10 * 60_000; // 10 minutes
+
+export async function GET() {
+  let result = getCachedScan();
+  if (!result) {
+    result = await scanAllProjects();
+    setCachedScan(result);
+  }
+
+  // Fetch Claude usage stats (cached separately with longer TTL)
+  let claudeUsage = cachedClaudeUsage;
+  if (!claudeUsage || Date.now() - claudeUsageCachedAt > CLAUDE_USAGE_TTL) {
+    claudeUsage = await scanAllClaudeConversations();
+    cachedClaudeUsage = claudeUsage;
+    claudeUsageCachedAt = Date.now();
+  }
+
+  const stats = computeStats(result.projects, result.hiddenCount, claudeUsage);
+  return NextResponse.json(stats);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,18 @@ export default async function RootLayout({
                   </a>
                   <nav className="flex items-center gap-4">
                     <ManualStepsNavBadge />
+                    <a
+                      href="/sessions"
+                      className="flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                    >
+                      Sessions
+                    </a>
+                    <a
+                      href="/stats"
+                      className="flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                    >
+                      Stats
+                    </a>
                   </nav>
                 </div>
                 <div className="flex items-center gap-3">

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { use } from "react";
+import { SessionDetailView } from "@/components/SessionDetailView";
+
+export default function SessionDetailPage({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>;
+}) {
+  const { sessionId } = use(params);
+  return <SessionDetailView sessionId={sessionId} />;
+}

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionsBrowser } from "@/components/SessionsBrowser";
+
+export default function SessionsPage() {
+  return <SessionsBrowser />;
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { StatsDashboard } from "@/components/StatsDashboard";
+
+export default function StatsPage() {
+  return <StatsDashboard />;
+}

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -18,6 +18,8 @@ const slugTitles: Record<HelpSlug, string> = {
   "tech-stack": "Tech Stack Detection",
   "quick-actions": "Quick Actions",
   "manual-steps": "Manual Steps",
+  stats: "Stats Dashboard",
+  sessions: "Sessions Browser",
 };
 
 export function HelpPanel() {

--- a/src/components/HelpProvider.tsx
+++ b/src/components/HelpProvider.tsx
@@ -38,6 +38,9 @@ export function HelpProvider({ children }: { children: ReactNode }) {
     if (!slug && pathname.startsWith("/project/")) {
       slug = helpMapping["/project/[slug]"];
     }
+    if (!slug && pathname.startsWith("/sessions/")) {
+      slug = helpMapping["/sessions/[sessionId]"];
+    }
     setActiveSlug((slug ?? "getting-started") as HelpSlug);
   }, []);
 

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useSessionDetail } from "@/hooks/useSessions";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+import { Skeleton } from "./ui/skeleton";
+import { StatCard } from "./stats/StatCard";
+import { BarChart } from "./stats/BarChart";
+import { SessionTimeline } from "./SessionTimeline";
+import { SessionFileOps } from "./SessionFileOps";
+import { SessionSubagents } from "./SessionSubagents";
+import {
+  ArrowLeft,
+  Clock,
+  MessageSquare,
+  Cpu,
+  DollarSign,
+  AlertCircle,
+  GitBranch,
+  Bot,
+  File,
+} from "lucide-react";
+import Link from "next/link";
+
+function formatDuration(ms?: number): string {
+  if (!ms) return "—";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatCost(n: number): string {
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  if (n >= 0.01) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(4)}`;
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString();
+}
+
+export function SessionDetailView({ sessionId }: { sessionId: string }) {
+  const { data, loading } = useSessionDetail(sessionId);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 rounded-lg" />
+          ))}
+        </div>
+        <Skeleton className="h-96 rounded-lg" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="space-y-4">
+        <Link href="/sessions">
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="h-4 w-4 mr-1" /> Back
+          </Button>
+        </Link>
+        <p className="text-[var(--muted-foreground)] text-center py-12">
+          Session not found.
+        </p>
+      </div>
+    );
+  }
+
+  const totalTools = Object.values(data.toolUsage).reduce((s, c) => s + c, 0);
+
+  return (
+    <div className="space-y-6">
+      <Link href="/sessions">
+        <Button variant="ghost" size="sm">
+          <ArrowLeft className="h-4 w-4 mr-1" /> Back to Sessions
+        </Button>
+      </Link>
+
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-3">
+          {data.isActive && (
+            <span className="relative flex h-3 w-3">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500" />
+            </span>
+          )}
+          <h1 className="text-xl font-bold">{data.projectName}</h1>
+          {data.gitBranch && (
+            <Badge variant="outline" className="text-xs">
+              <GitBranch className="h-3 w-3 mr-1" />
+              {data.gitBranch}
+            </Badge>
+          )}
+        </div>
+        {data.initialPrompt && (
+          <p className="text-sm text-[var(--muted-foreground)]">
+            {data.initialPrompt}
+          </p>
+        )}
+        <p className="text-xs text-[var(--muted-foreground)] font-mono">
+          {formatDate(data.startTime)} &middot; {formatDuration(data.durationMs)} &middot; {data.sessionId.slice(0, 8)}
+        </p>
+      </div>
+
+      {/* Stat Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3">
+        <StatCard
+          label="Messages"
+          value={data.messageCount}
+          icon={<MessageSquare className="h-4 w-4" />}
+          detail={`${data.userMessageCount} user / ${data.assistantMessageCount} assistant`}
+        />
+        <StatCard
+          label="Duration"
+          value={formatDuration(data.durationMs)}
+          icon={<Clock className="h-4 w-4" />}
+        />
+        <StatCard
+          label="Tokens"
+          value={formatTokens(data.inputTokens + data.outputTokens)}
+          icon={<Cpu className="h-4 w-4" />}
+          detail={`${formatTokens(data.inputTokens)} in / ${formatTokens(data.outputTokens)} out`}
+        />
+        <StatCard
+          label="Cost"
+          value={formatCost(data.costEstimate)}
+          icon={<DollarSign className="h-4 w-4" />}
+        />
+        <StatCard
+          label="Tool Calls"
+          value={totalTools}
+          detail={`${Object.keys(data.toolUsage).length} unique tools`}
+        />
+        <StatCard
+          label="Errors"
+          value={data.errorCount}
+          icon={<AlertCircle className="h-4 w-4" />}
+        />
+      </div>
+
+      {/* Models */}
+      <div className="flex flex-wrap gap-1">
+        {data.modelsUsed.map((m) => (
+          <Badge key={m} variant="outline">
+            {m}
+          </Badge>
+        ))}
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="timeline">
+        <TabsList>
+          <TabsTrigger value="timeline">Timeline</TabsTrigger>
+          <TabsTrigger value="tools">Tools</TabsTrigger>
+          <TabsTrigger value="files">
+            Files ({data.fileOperations.length})
+          </TabsTrigger>
+          {data.subagents.length > 0 && (
+            <TabsTrigger value="subagents">
+              <Bot className="h-3 w-3 mr-1" />
+              Subagents ({data.subagents.length})
+            </TabsTrigger>
+          )}
+        </TabsList>
+
+        <TabsContent value="timeline">
+          <div className="rounded-lg border p-4 max-h-[600px] overflow-y-auto">
+            <SessionTimeline timeline={data.timeline} sessionStart={data.startTime} />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="tools">
+          <div className="rounded-lg border p-4">
+            <BarChart data={data.toolUsage} colorClass="bg-violet-500" />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="files">
+          <div className="rounded-lg border p-4">
+            <SessionFileOps operations={data.fileOperations} />
+          </div>
+        </TabsContent>
+
+        {data.subagents.length > 0 && (
+          <TabsContent value="subagents">
+            <SessionSubagents subagents={data.subagents} />
+          </TabsContent>
+        )}
+      </Tabs>
+    </div>
+  );
+}

--- a/src/components/SessionFileOps.tsx
+++ b/src/components/SessionFileOps.tsx
@@ -1,0 +1,71 @@
+import { FileOperation } from "@/lib/types";
+import { File, Edit3, Eye, Search, Terminal } from "lucide-react";
+
+const OP_ICONS: Record<string, typeof File> = {
+  read: Eye,
+  write: File,
+  edit: Edit3,
+  glob: Search,
+  grep: Search,
+  bash: Terminal,
+};
+
+const OP_COLORS: Record<string, string> = {
+  read: "text-blue-400",
+  write: "text-emerald-400",
+  edit: "text-amber-400",
+  glob: "text-violet-400",
+  grep: "text-violet-400",
+  bash: "text-gray-400",
+};
+
+export function SessionFileOps({ operations }: { operations: FileOperation[] }) {
+  if (operations.length === 0) {
+    return (
+      <p className="text-sm text-[var(--muted-foreground)] text-center py-8">
+        No file operations recorded.
+      </p>
+    );
+  }
+
+  // Filter out bash commands that aren't real file paths
+  const fileOps = operations.filter(
+    (op) => op.operation !== "bash" || op.path.includes("/") || op.path.includes("\\")
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-xs text-[var(--muted-foreground)]">
+            <th className="py-2 pr-4">Operation</th>
+            <th className="py-2 pr-4">Path</th>
+            <th className="py-2">Tool</th>
+          </tr>
+        </thead>
+        <tbody>
+          {fileOps.map((op, i) => {
+            const Icon = OP_ICONS[op.operation] || File;
+            const color = OP_COLORS[op.operation] || "text-gray-400";
+            return (
+              <tr key={i} className="border-b border-[var(--border)] hover:bg-[var(--muted)] transition-colors">
+                <td className="py-1.5 pr-4">
+                  <span className={`flex items-center gap-1.5 ${color}`}>
+                    <Icon className="h-3 w-3" />
+                    {op.operation}
+                  </span>
+                </td>
+                <td className="py-1.5 pr-4 font-mono text-xs truncate max-w-md">
+                  {op.path}
+                </td>
+                <td className="py-1.5 text-[var(--muted-foreground)]">
+                  {op.toolName}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/SessionSubagents.tsx
+++ b/src/components/SessionSubagents.tsx
@@ -1,0 +1,45 @@
+import { SubagentInfo } from "@/lib/types";
+import { Bot, Wrench } from "lucide-react";
+import { Badge } from "./ui/badge";
+
+export function SessionSubagents({ subagents }: { subagents: SubagentInfo[] }) {
+  if (subagents.length === 0) {
+    return (
+      <p className="text-sm text-[var(--muted-foreground)] text-center py-8">
+        No subagents spawned in this session.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {subagents.map((agent) => {
+        const topTools = Object.entries(agent.toolUsage)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 5);
+
+        return (
+          <div key={agent.agentId} className="rounded-lg border p-4 space-y-2">
+            <div className="flex items-center gap-2">
+              <Bot className="h-4 w-4 text-violet-400" />
+              <span className="text-sm font-medium">{agent.type}</span>
+            </div>
+            <p className="text-xs text-[var(--muted-foreground)] line-clamp-2">
+              {agent.description}
+            </p>
+            {topTools.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {topTools.map(([tool, count]) => (
+                  <Badge key={tool} variant="outline" className="text-[10px] px-1.5 py-0">
+                    <Wrench className="h-2.5 w-2.5 mr-0.5" />
+                    {tool} ({count})
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/SessionTimeline.tsx
+++ b/src/components/SessionTimeline.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { TimelineEvent } from "@/lib/types";
+import {
+  User,
+  Bot,
+  Wrench,
+  Brain,
+  AlertCircle,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+
+const EVENT_STYLES: Record<
+  TimelineEvent["type"],
+  { icon: typeof User; colorClass: string; bgClass: string }
+> = {
+  user: { icon: User, colorClass: "text-blue-400", bgClass: "bg-blue-500/10" },
+  assistant: { icon: Bot, colorClass: "text-emerald-400", bgClass: "bg-emerald-500/10" },
+  tool_use: { icon: Wrench, colorClass: "text-violet-400", bgClass: "bg-violet-500/10" },
+  thinking: { icon: Brain, colorClass: "text-gray-400", bgClass: "bg-gray-500/10" },
+  error: { icon: AlertCircle, colorClass: "text-red-400", bgClass: "bg-red-500/10" },
+};
+
+function formatOffset(timestamp: string | undefined, sessionStart: string | undefined): string {
+  if (!timestamp || !sessionStart) return "";
+  const offset = new Date(timestamp).getTime() - new Date(sessionStart).getTime();
+  if (offset < 0) return "";
+  const seconds = Math.floor(offset / 1000);
+  const minutes = Math.floor(seconds / 60);
+  if (minutes === 0) return `+${seconds}s`;
+  return `+${minutes}m${seconds % 60}s`;
+}
+
+function TimelineItem({
+  event,
+  sessionStart,
+}: {
+  event: TimelineEvent;
+  sessionStart?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const style = EVENT_STYLES[event.type];
+  const Icon = style.icon;
+  const isLong = event.content.length > 150;
+  const displayText = isLong && !expanded ? event.content.slice(0, 150) + "..." : event.content;
+
+  return (
+    <div className={`flex gap-3 p-2 rounded ${style.bgClass}`}>
+      <div className={`mt-0.5 shrink-0 ${style.colorClass}`}>
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0 space-y-0.5">
+        <div className="flex items-center gap-2">
+          <span className={`text-xs font-medium ${style.colorClass}`}>
+            {event.type === "tool_use" ? event.toolName || "Tool" : event.type}
+          </span>
+          <span className="text-[10px] text-[var(--muted-foreground)] font-mono">
+            {formatOffset(event.timestamp, sessionStart)}
+          </span>
+          {event.tokenCount && (
+            <span className="text-[10px] text-[var(--muted-foreground)]">
+              {event.tokenCount} tokens
+            </span>
+          )}
+        </div>
+        <p className="text-sm whitespace-pre-wrap break-words">{displayText}</p>
+        {isLong && (
+          <button
+            className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] flex items-center gap-0.5"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? (
+              <><ChevronDown className="h-3 w-3" /> Show less</>
+            ) : (
+              <><ChevronRight className="h-3 w-3" /> Show more</>
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function SessionTimeline({
+  timeline,
+  sessionStart,
+}: {
+  timeline: TimelineEvent[];
+  sessionStart?: string;
+}) {
+  if (timeline.length === 0) {
+    return (
+      <p className="text-sm text-[var(--muted-foreground)] text-center py-8">
+        No timeline events.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {timeline.map((event, i) => (
+        <TimelineItem key={i} event={event} sessionStart={sessionStart} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -156,8 +156,9 @@ export function SessionsBrowser() {
           return (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens);
         case "recent":
         default: {
-          const ta = a.startTime ? new Date(a.startTime).getTime() : 0;
-          const tb = b.startTime ? new Date(b.startTime).getTime() : 0;
+          // Sort by endTime so active/long-running sessions appear at top
+          const ta = a.endTime ? new Date(a.endTime).getTime() : 0;
+          const tb = b.endTime ? new Date(b.endTime).getTime() : 0;
           return tb - ta;
         }
       }

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useAllSessions } from "@/hooks/useSessions";
+import { SessionSummary } from "@/lib/types";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
+import { Skeleton } from "./ui/skeleton";
+import {
+  Search,
+  Clock,
+  Cpu,
+  MessageSquare,
+  GitBranch,
+  Bot,
+  Wrench,
+  SortAsc,
+  AlertCircle,
+} from "lucide-react";
+import Link from "next/link";
+
+type SortOption = "recent" | "longest" | "tokens";
+
+function formatDuration(ms?: number): string {
+  if (!ms) return "—";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString();
+}
+
+function SessionCard({ session }: { session: SessionSummary }) {
+  const totalTools = Object.values(session.toolUsage).reduce((s, c) => s + c, 0);
+
+  return (
+    <Link href={`/sessions/${session.sessionId}`}>
+      <div className="rounded-lg border bg-[var(--card)] p-4 hover:shadow-md transition-shadow cursor-pointer space-y-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            {session.isActive && (
+              <span className="relative flex h-2.5 w-2.5 shrink-0">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500" />
+              </span>
+            )}
+            <span className="text-xs text-[var(--muted-foreground)] font-mono truncate">
+              {session.projectName}
+            </span>
+          </div>
+          <span className="text-xs text-[var(--muted-foreground)] shrink-0">
+            {formatDate(session.startTime)}
+          </span>
+        </div>
+
+        {session.initialPrompt && (
+          <p className="text-sm line-clamp-2">{session.initialPrompt}</p>
+        )}
+
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-[var(--muted-foreground)]">
+          <span className="flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            {formatDuration(session.durationMs)}
+          </span>
+          <span className="flex items-center gap-1">
+            <MessageSquare className="h-3 w-3" />
+            {session.messageCount}
+          </span>
+          <span className="flex items-center gap-1">
+            <Cpu className="h-3 w-3" />
+            {formatTokens(session.inputTokens + session.outputTokens)}
+          </span>
+          <span className="flex items-center gap-1">
+            <Wrench className="h-3 w-3" />
+            {totalTools}
+          </span>
+          {session.subagentCount > 0 && (
+            <span className="flex items-center gap-1">
+              <Bot className="h-3 w-3" />
+              {session.subagentCount}
+            </span>
+          )}
+          {session.errorCount > 0 && (
+            <span className="flex items-center gap-1 text-red-400">
+              <AlertCircle className="h-3 w-3" />
+              {session.errorCount}
+            </span>
+          )}
+          {session.gitBranch && (
+            <span className="flex items-center gap-1">
+              <GitBranch className="h-3 w-3" />
+              {session.gitBranch}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1">
+          {session.modelsUsed.map((m) => (
+            <Badge key={m} variant="outline" className="text-[10px] px-1.5 py-0">
+              {m}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export function SessionsBrowser() {
+  const { data, loading } = useAllSessions();
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState<SortOption>("recent");
+
+  const filtered = useMemo(() => {
+    let result = data;
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (s) =>
+          s.initialPrompt?.toLowerCase().includes(q) ||
+          s.projectName.toLowerCase().includes(q) ||
+          s.sessionId.includes(q) ||
+          s.gitBranch?.toLowerCase().includes(q)
+      );
+    }
+
+    return [...result].sort((a, b) => {
+      switch (sortBy) {
+        case "longest":
+          return (b.durationMs || 0) - (a.durationMs || 0);
+        case "tokens":
+          return (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens);
+        case "recent":
+        default: {
+          const ta = a.startTime ? new Date(a.startTime).getTime() : 0;
+          const tb = b.startTime ? new Date(b.startTime).getTime() : 0;
+          return tb - ta;
+        }
+      }
+    });
+  }, [data, search, sortBy]);
+
+  const activeSessions = data.filter((s) => s.isActive).length;
+
+  const sortOptions: { value: SortOption; label: string }[] = [
+    { value: "recent", label: "Recent" },
+    { value: "longest", label: "Longest" },
+    { value: "tokens", label: "Most Tokens" },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <MessageSquare className="h-5 w-5" />
+          <h1 className="text-2xl font-bold">Sessions</h1>
+          <span className="text-sm text-[var(--muted-foreground)]">
+            {data.length} total
+          </span>
+          {activeSessions > 0 && (
+            <span className="text-xs bg-emerald-500/20 text-emerald-400 px-2 py-0.5 rounded-full font-medium">
+              {activeSessions} active
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--muted-foreground)]" />
+          <Input
+            placeholder="Search sessions..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-10"
+          />
+        </div>
+        <div className="flex gap-1">
+          {sortOptions.map((opt) => (
+            <Button
+              key={opt.value}
+              variant={sortBy === opt.value ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => setSortBy(opt.value)}
+            >
+              <SortAsc className="h-3 w-3 mr-1" />
+              {opt.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-40 rounded-lg" />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="text-center py-12 text-[var(--muted-foreground)]">
+          <MessageSquare className="h-12 w-12 mx-auto mb-3 opacity-50" />
+          <p>No sessions found.</p>
+          {search && <p className="text-sm mt-1">Try a different search term.</p>}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((session) => (
+            <SessionCard key={session.sessionId} session={session} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useStats } from "@/hooks/useStats";
+import { StatCard } from "./stats/StatCard";
+import { BarChart } from "./stats/BarChart";
+import { HealthBar } from "./stats/HealthBar";
+import { Skeleton } from "./ui/skeleton";
+import {
+  FolderOpen,
+  Bot,
+  CheckCircle2,
+  ClipboardList,
+  GitBranch,
+  Cpu,
+  DollarSign,
+  Wrench,
+  Activity,
+} from "lucide-react";
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatCost(n: number): string {
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  if (n >= 0.01) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(4)}`;
+}
+
+export function StatsDashboard() {
+  const { data, loading } = useStats();
+
+  if (loading || !data) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold">Stats</h1>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 rounded-lg" />
+          ))}
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const cu = data.claudeUsage;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center gap-3">
+        <Activity className="h-6 w-6" />
+        <h1 className="text-2xl font-bold">Stats</h1>
+      </div>
+
+      {/* Overview Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        <StatCard
+          label="Projects"
+          value={data.projectCount}
+          icon={<FolderOpen className="h-4 w-4" />}
+          detail={data.hiddenCount > 0 ? `${data.hiddenCount} hidden` : undefined}
+        />
+        <StatCard
+          label="Claude Sessions"
+          value={data.claudeSessions.total}
+          icon={<Bot className="h-4 w-4" />}
+          detail={`${data.claudeSessions.projectsWithSessions} projects`}
+        />
+        <StatCard
+          label="Pending TODOs"
+          value={data.todoHealth.pending}
+          icon={<CheckCircle2 className="h-4 w-4" />}
+          detail={`${data.todoHealth.completed} completed`}
+        />
+        <StatCard
+          label="Manual Steps"
+          value={data.manualStepsHealth.pending}
+          icon={<ClipboardList className="h-4 w-4" />}
+          detail={`${data.manualStepsHealth.completed} completed`}
+        />
+        {cu && (
+          <StatCard
+            label="Est. Cost"
+            value={formatCost(cu.costEstimate)}
+            icon={<DollarSign className="h-4 w-4" />}
+            detail={`${cu.conversationCount} conversations`}
+          />
+        )}
+      </div>
+
+      {/* Claude Usage Section */}
+      {cu && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <Bot className="h-5 w-5" />
+            Claude Code Usage
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard
+              label="Input Tokens"
+              value={formatTokens(cu.inputTokens)}
+              icon={<Cpu className="h-4 w-4" />}
+            />
+            <StatCard
+              label="Output Tokens"
+              value={formatTokens(cu.outputTokens)}
+            />
+            <StatCard
+              label="Cache Read"
+              value={formatTokens(cu.cacheReadTokens)}
+              detail={`${formatTokens(cu.cacheCreateTokens)} created`}
+            />
+            <StatCard
+              label="Errors"
+              value={cu.errorCount}
+              detail={`${cu.totalTurns} total turns`}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="rounded-lg border p-4 space-y-3">
+              <h3 className="text-sm font-medium flex items-center gap-2">
+                <Wrench className="h-4 w-4" />
+                Top Tools
+              </h3>
+              <BarChart data={cu.toolUsage} colorClass="bg-violet-500" />
+            </div>
+            <div className="rounded-lg border p-4 space-y-3">
+              <h3 className="text-sm font-medium">Models Used</h3>
+              {cu.modelsUsed.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {cu.modelsUsed.map((m) => (
+                    <span
+                      key={m}
+                      className="text-xs bg-[var(--muted)] px-2 py-1 rounded font-mono"
+                    >
+                      {m}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-[var(--muted-foreground)]">No model data</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Tech Stack Section */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Tech Stack Distribution</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium">Frameworks</h3>
+            <BarChart data={data.frameworks} colorClass="bg-emerald-500" />
+          </div>
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium">ORMs</h3>
+            <BarChart data={data.orms} colorClass="bg-blue-500" />
+          </div>
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium">Styling</h3>
+            <BarChart data={data.styling} colorClass="bg-pink-500" />
+          </div>
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium">External Services</h3>
+            <BarChart data={data.services} colorClass="bg-amber-500" />
+          </div>
+        </div>
+      </div>
+
+      {/* Project Health Section */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Project Health</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium">Status Distribution</h3>
+            <HealthBar
+              segments={[
+                { value: data.statuses["active"] || 0, colorClass: "bg-emerald-500", label: "Active" },
+                { value: data.statuses["paused"] || 0, colorClass: "bg-amber-500", label: "Paused" },
+                { value: data.statuses["archived"] || 0, colorClass: "bg-gray-400", label: "Archived" },
+              ]}
+            />
+          </div>
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium flex items-center gap-2">
+              <GitBranch className="h-4 w-4" />
+              Activity Recency
+            </h3>
+            <HealthBar
+              segments={[
+                { value: data.activity.today, colorClass: "bg-emerald-500", label: "Today" },
+                { value: data.activity.thisWeek, colorClass: "bg-blue-500", label: "This Week" },
+                { value: data.activity.thisMonth, colorClass: "bg-amber-500", label: "This Month" },
+                { value: data.activity.older, colorClass: "bg-gray-400", label: "Older" },
+                { value: data.activity.none, colorClass: "bg-gray-600", label: "No Activity" },
+              ]}
+            />
+          </div>
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium">TODO Completion</h3>
+            <HealthBar
+              segments={[
+                { value: data.todoHealth.completed, colorClass: "bg-emerald-500", label: "Completed" },
+                { value: data.todoHealth.pending, colorClass: "bg-amber-500", label: "Pending" },
+              ]}
+            />
+          </div>
+          <div className="rounded-lg border p-4 space-y-3">
+            <h3 className="text-sm font-medium">Manual Steps</h3>
+            <HealthBar
+              segments={[
+                { value: data.manualStepsHealth.completed, colorClass: "bg-emerald-500", label: "Completed" },
+                { value: data.manualStepsHealth.pending, colorClass: "bg-amber-500", label: "Pending" },
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Database Section */}
+      {Object.keys(data.databases).length > 0 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold">Databases</h2>
+          <div className="rounded-lg border p-4 max-w-md">
+            <BarChart data={data.databases} colorClass="bg-cyan-500" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/stats/BarChart.tsx
+++ b/src/components/stats/BarChart.tsx
@@ -1,0 +1,42 @@
+interface BarChartProps {
+  data: Record<string, number>;
+  maxItems?: number;
+  colorClass?: string;
+}
+
+export function BarChart({
+  data,
+  maxItems = 10,
+  colorClass = "bg-blue-500",
+}: BarChartProps) {
+  const sorted = Object.entries(data)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxItems);
+
+  if (sorted.length === 0) {
+    return (
+      <p className="text-sm text-[var(--muted-foreground)]">No data</p>
+    );
+  }
+
+  const max = sorted[0][1];
+
+  return (
+    <div className="space-y-1.5">
+      {sorted.map(([label, count]) => (
+        <div key={label} className="flex items-center gap-2">
+          <span className="text-xs text-[var(--muted-foreground)] w-28 truncate text-right shrink-0">
+            {label}
+          </span>
+          <div className="flex-1 bg-[var(--muted)] rounded-full h-4 overflow-hidden">
+            <div
+              className={`${colorClass} h-4 rounded-full transition-all`}
+              style={{ width: `${max > 0 ? (count / max) * 100 : 0}%` }}
+            />
+          </div>
+          <span className="text-xs font-mono w-8 text-right shrink-0">{count}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/stats/HealthBar.tsx
+++ b/src/components/stats/HealthBar.tsx
@@ -1,0 +1,45 @@
+interface Segment {
+  value: number;
+  colorClass: string;
+  label: string;
+}
+
+interface HealthBarProps {
+  segments: Segment[];
+}
+
+export function HealthBar({ segments }: HealthBarProps) {
+  const total = segments.reduce((sum, s) => sum + s.value, 0);
+  if (total === 0) {
+    return (
+      <p className="text-sm text-[var(--muted-foreground)]">No data</p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex h-4 rounded-full overflow-hidden bg-[var(--muted)]">
+        {segments.map(
+          (seg) =>
+            seg.value > 0 && (
+              <div
+                key={seg.label}
+                className={`${seg.colorClass} transition-all`}
+                style={{ width: `${(seg.value / total) * 100}%` }}
+                title={`${seg.label}: ${seg.value}`}
+              />
+            )
+        )}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {segments.map((seg) => (
+          <div key={seg.label} className="flex items-center gap-1.5 text-xs">
+            <div className={`w-2.5 h-2.5 rounded-full ${seg.colorClass}`} />
+            <span className="text-[var(--muted-foreground)]">{seg.label}</span>
+            <span className="font-mono">{seg.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/stats/StatCard.tsx
+++ b/src/components/stats/StatCard.tsx
@@ -1,0 +1,25 @@
+import { type ReactNode } from "react";
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  icon?: ReactNode;
+  detail?: string;
+}
+
+export function StatCard({ label, value, icon, detail }: StatCardProps) {
+  return (
+    <div className="rounded-lg border bg-[var(--card)] p-4 space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-[var(--muted-foreground)] uppercase tracking-wide">
+          {label}
+        </span>
+        {icon && <span className="text-[var(--muted-foreground)]">{icon}</span>}
+      </div>
+      <p className="text-2xl font-bold font-mono">{value}</p>
+      {detail && (
+        <p className="text-xs text-[var(--muted-foreground)]">{detail}</p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { SessionSummary, SessionDetail } from "@/lib/types";
+
+export function useAllSessions() {
+  const [data, setData] = useState<SessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/sessions");
+      if (res.ok) setData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, refresh };
+}
+
+export function useSessionDetail(sessionId: string) {
+  const [data, setData] = useState<SessionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/sessions/${sessionId}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((d) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [sessionId]);
+
+  return { data, loading };
+}

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { StatsData } from "@/lib/types";
+
+export function useStats() {
+  const [data, setData] = useState<StatsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/stats")
+      .then((res) => res.json())
+      .then((stats) => {
+        setData(stats);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  return { data, loading };
+}

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -6,6 +6,9 @@ export const helpMapping: Record<string, string> = {
   '/': 'getting-started',
   '/project/[slug]': 'project-details',
   '/manual-steps': 'manual-steps',
+  '/stats': 'stats',
+  '/sessions': 'sessions',
+  '/sessions/[sessionId]': 'sessions',
 }
 
 /**
@@ -31,6 +34,8 @@ export const helpSlugs = [
   'tech-stack',
   'quick-actions',
   'manual-steps',
+  'stats',
+  'sessions',
 ] as const
 
 export type HelpSlug = (typeof helpSlugs)[number]

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -1,0 +1,587 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import {
+  ClaudeUsageStats,
+  SessionSummary,
+  SessionDetail,
+  TimelineEvent,
+  FileOperation,
+  SubagentInfo,
+} from "../types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface ConversationEntry {
+  type?: string;
+  timestamp?: string;
+  sessionId?: string;
+  gitBranch?: string;
+  isSidechain?: boolean;
+  isApiErrorMessage?: boolean;
+  isMeta?: boolean;
+  message?: {
+    model?: string;
+    role?: string;
+    content?: any[];
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+  // For tool_result user messages
+  content?: any[];
+}
+
+// Approximate cost per token (USD)
+const INPUT_COST_PER_TOKEN = 0.000015;
+const OUTPUT_COST_PER_TOKEN = 0.000075;
+const CACHE_WRITE_COST_PER_TOKEN = 0.00001875;
+const CACHE_READ_COST_PER_TOKEN = 0.0000015;
+
+function computeCost(
+  inputTokens: number,
+  outputTokens: number,
+  cacheCreate: number,
+  cacheRead: number
+): number {
+  return (
+    inputTokens * INPUT_COST_PER_TOKEN +
+    outputTokens * OUTPUT_COST_PER_TOKEN +
+    cacheCreate * CACHE_WRITE_COST_PER_TOKEN +
+    cacheRead * CACHE_READ_COST_PER_TOKEN
+  );
+}
+
+function encodePath(projectPath: string): string {
+  return projectPath.replace(/[:\\/]/g, "-");
+}
+
+function decodeDirName(dirName: string): string {
+  // C--dev-project-minder → C:\dev\project-minder (approximate)
+  return dirName.replace(/^([A-Z])-/, "$1:").replace(/-/g, "\\");
+}
+
+function toSlug(dirName: string): string {
+  // Extract last segment as project name, slugify
+  const parts = dirName.split("-");
+  // Skip drive letter prefix like "C-"
+  const meaningful = parts.slice(parts.findIndex((p) => p.length > 1));
+  return meaningful.join("-").toLowerCase().replace(/[^a-z0-9-]/g, "-");
+}
+
+function extractTextContent(content: any[]): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b: any) => b.type === "text" && b.text)
+    .map((b: any) => b.text)
+    .join("\n")
+    .slice(0, 200);
+}
+
+// ─── Lightweight scan for session summaries ───────────────────────────
+
+async function scanSessionFile(
+  filePath: string,
+  projectDirName: string,
+  mtime: Date
+): Promise<SessionSummary | null> {
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n").filter(Boolean);
+    if (lines.length === 0) return null;
+
+    const sessionId = path.basename(filePath, ".jsonl");
+    let startTime: string | undefined;
+    let endTime: string | undefined;
+    let initialPrompt: string | undefined;
+    let gitBranch: string | undefined;
+    let messageCount = 0;
+    let userMessageCount = 0;
+    let assistantMessageCount = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheReadTokens = 0;
+    let cacheCreateTokens = 0;
+    const tools: Record<string, number> = {};
+    const models = new Set<string>();
+    let subagentCount = 0;
+    let errorCount = 0;
+
+    for (const line of lines) {
+      try {
+        const entry: ConversationEntry = JSON.parse(line);
+
+        if (entry.timestamp) {
+          if (!startTime) startTime = entry.timestamp;
+          endTime = entry.timestamp;
+        }
+        if (entry.gitBranch && !gitBranch) gitBranch = entry.gitBranch;
+
+        if (entry.type === "user" && !entry.isMeta) {
+          userMessageCount++;
+          messageCount++;
+          // Capture first real user message as initial prompt
+          if (!initialPrompt && entry.message?.content) {
+            const text = extractTextContent(entry.message.content);
+            if (text) initialPrompt = text;
+          } else if (!initialPrompt && Array.isArray(entry.content)) {
+            // Some user messages have content at top level
+            const text = extractTextContent(entry.content);
+            if (text) initialPrompt = text;
+          }
+        }
+
+        if (entry.type === "assistant" && entry.message) {
+          assistantMessageCount++;
+          messageCount++;
+          const msg = entry.message;
+          const model = msg.model;
+          if (model && model !== "<synthetic>") models.add(model);
+
+          const usage = msg.usage;
+          if (usage) {
+            inputTokens += usage.input_tokens || 0;
+            outputTokens += usage.output_tokens || 0;
+            cacheCreateTokens += usage.cache_creation_input_tokens || 0;
+            cacheReadTokens += usage.cache_read_input_tokens || 0;
+          }
+
+          if (entry.isApiErrorMessage) errorCount++;
+
+          if (Array.isArray(msg.content)) {
+            for (const block of msg.content) {
+              if (block.type === "tool_use" && block.name) {
+                tools[block.name] = (tools[block.name] || 0) + 1;
+                if (block.name === "Agent") subagentCount++;
+              }
+            }
+          }
+        }
+      } catch {
+        // Skip invalid lines
+      }
+    }
+
+    if (messageCount === 0) return null;
+
+    const isActive = Date.now() - mtime.getTime() < 2 * 60_000;
+    const durationMs =
+      startTime && endTime
+        ? new Date(endTime).getTime() - new Date(startTime).getTime()
+        : undefined;
+
+    const projectPath = decodeDirName(projectDirName);
+    const projectSlug = toSlug(projectDirName);
+    // Use last path segment as display name
+    const projectName = projectDirName.split("-").slice(-1)[0] || projectDirName;
+
+    return {
+      sessionId,
+      projectPath,
+      projectSlug,
+      projectName: projectDirName,
+      startTime,
+      endTime,
+      durationMs,
+      initialPrompt,
+      messageCount,
+      userMessageCount,
+      assistantMessageCount,
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreateTokens,
+      costEstimate: computeCost(inputTokens, outputTokens, cacheCreateTokens, cacheReadTokens),
+      toolUsage: tools,
+      modelsUsed: Array.from(models),
+      gitBranch,
+      subagentCount,
+      errorCount,
+      isActive,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scan all sessions across all projects. Returns lightweight summaries.
+ */
+export async function scanAllSessions(): Promise<SessionSummary[]> {
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const sessions: SessionSummary[] = [];
+
+  let dirs: string[];
+  try {
+    dirs = await fs.readdir(projectsDir);
+  } catch {
+    return sessions;
+  }
+
+  for (const dir of dirs) {
+    const dirPath = path.join(projectsDir, dir);
+    try {
+      const stat = await fs.stat(dirPath);
+      if (!stat.isDirectory()) continue;
+
+      const entries = await fs.readdir(dirPath);
+      const jsonlFiles = entries.filter((e) => e.endsWith(".jsonl"));
+
+      // Process in batches of 5
+      for (let i = 0; i < jsonlFiles.length; i += 5) {
+        const batch = jsonlFiles.slice(i, i + 5);
+        const results = await Promise.all(
+          batch.map(async (f) => {
+            const filePath = path.join(dirPath, f);
+            const fstat = await fs.stat(filePath);
+            return scanSessionFile(filePath, dir, fstat.mtime);
+          })
+        );
+        for (const r of results) {
+          if (r) sessions.push(r);
+        }
+      }
+    } catch {
+      // Skip inaccessible directories
+    }
+  }
+
+  // Sort by most recent first
+  sessions.sort((a, b) => {
+    const ta = a.startTime ? new Date(a.startTime).getTime() : 0;
+    const tb = b.startTime ? new Date(b.startTime).getTime() : 0;
+    return tb - ta;
+  });
+
+  return sessions;
+}
+
+// ─── Detailed session scan (timeline, files, subagents) ─────────────
+
+const FILE_TOOL_OPERATIONS: Record<string, string> = {
+  Read: "read",
+  Write: "write",
+  Edit: "edit",
+  Glob: "glob",
+  Grep: "grep",
+};
+
+/**
+ * Full parse of a single session JSONL file for the detail view.
+ */
+export async function scanSessionDetail(
+  sessionId: string
+): Promise<SessionDetail | null> {
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+
+  // Find the session file across all project directories
+  let filePath: string | null = null;
+  let projectDirName = "";
+  try {
+    const dirs = await fs.readdir(projectsDir);
+    for (const dir of dirs) {
+      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
+      try {
+        await fs.access(candidate);
+        filePath = candidate;
+        projectDirName = dir;
+        break;
+      } catch {
+        // Not in this directory
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  if (!filePath) return null;
+
+  const fstat = await fs.stat(filePath);
+  const summary = await scanSessionFile(filePath, projectDirName, fstat.mtime);
+  if (!summary) return null;
+
+  // Now do the detailed parse for timeline, file ops, subagents
+  const timeline: TimelineEvent[] = [];
+  const fileOperations: FileOperation[] = [];
+  const subagentMap = new Map<string, SubagentInfo>();
+
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n").filter(Boolean);
+
+    for (const line of lines) {
+      try {
+        const entry: ConversationEntry = JSON.parse(line);
+
+        if (entry.type === "user" && !entry.isMeta && !entry.isSidechain) {
+          const text = entry.message?.content
+            ? extractTextContent(entry.message.content)
+            : Array.isArray(entry.content)
+              ? extractTextContent(entry.content)
+              : "";
+          if (text) {
+            timeline.push({
+              type: "user",
+              timestamp: entry.timestamp,
+              content: text,
+            });
+          }
+        }
+
+        if (entry.type === "assistant" && entry.message && !entry.isSidechain) {
+          const msg = entry.message;
+
+          if (entry.isApiErrorMessage) {
+            const errorText = extractTextContent(msg.content || []);
+            timeline.push({
+              type: "error",
+              timestamp: entry.timestamp,
+              content: errorText || "API error",
+            });
+            continue;
+          }
+
+          if (Array.isArray(msg.content)) {
+            for (const block of msg.content) {
+              if (block.type === "thinking" && block.thinking) {
+                timeline.push({
+                  type: "thinking",
+                  timestamp: entry.timestamp,
+                  content: String(block.thinking).slice(0, 300),
+                });
+              } else if (block.type === "text" && block.text) {
+                timeline.push({
+                  type: "assistant",
+                  timestamp: entry.timestamp,
+                  content: String(block.text).slice(0, 300),
+                  tokenCount:
+                    (msg.usage?.output_tokens || 0) > 0
+                      ? msg.usage!.output_tokens
+                      : undefined,
+                });
+              } else if (block.type === "tool_use") {
+                const toolName = block.name || "unknown";
+                const input = block.input || {};
+
+                // Timeline event
+                let summary = toolName;
+                if (input.file_path) summary = `${toolName}: ${input.file_path}`;
+                else if (input.command) summary = `${toolName}: ${String(input.command).slice(0, 100)}`;
+                else if (input.pattern) summary = `${toolName}: ${input.pattern}`;
+                else if (input.prompt) summary = `${toolName}: ${String(input.prompt).slice(0, 100)}`;
+                else if (input.description) summary = `${toolName}: ${String(input.description).slice(0, 100)}`;
+
+                timeline.push({
+                  type: "tool_use",
+                  timestamp: entry.timestamp,
+                  content: summary,
+                  toolName,
+                });
+
+                // File operations
+                const op = FILE_TOOL_OPERATIONS[toolName];
+                if (op && input.file_path) {
+                  fileOperations.push({
+                    path: input.file_path,
+                    operation: op,
+                    timestamp: entry.timestamp,
+                    toolName,
+                  });
+                }
+                if (toolName === "Bash" && input.command) {
+                  // Bash commands that write files
+                  fileOperations.push({
+                    path: String(input.command).slice(0, 100),
+                    operation: "bash",
+                    timestamp: entry.timestamp,
+                    toolName: "Bash",
+                  });
+                }
+
+                // Subagent tracking
+                if (toolName === "Agent" && input.prompt) {
+                  const agentId = block.id || "unknown";
+                  subagentMap.set(agentId, {
+                    agentId,
+                    type: input.subagent_type || "general-purpose",
+                    description: String(input.description || input.prompt).slice(0, 200),
+                    messageCount: 0,
+                    toolUsage: {},
+                  });
+                }
+              }
+            }
+          }
+        }
+      } catch {
+        // Skip invalid lines
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return {
+    ...summary,
+    timeline,
+    fileOperations,
+    subagents: Array.from(subagentMap.values()),
+  };
+}
+
+// ─── Aggregate stats (existing, used by stats page) ─────────────────
+
+async function scanConversationFile(filePath: string): Promise<{
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreateTokens: number;
+  cacheReadTokens: number;
+  turns: number;
+  tools: Record<string, number>;
+  errors: number;
+  models: Set<string>;
+}> {
+  const result = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    turns: 0,
+    tools: {} as Record<string, number>,
+    errors: 0,
+    models: new Set<string>(),
+  };
+
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n").filter(Boolean);
+
+    for (const line of lines) {
+      try {
+        const entry: ConversationEntry = JSON.parse(line);
+        if (entry.type === "user") result.turns++;
+        if (entry.type === "assistant" && entry.message) {
+          result.turns++;
+          const msg = entry.message;
+          const model = msg.model;
+          if (model && model !== "<synthetic>") result.models.add(model);
+          const usage = msg.usage;
+          if (usage) {
+            result.inputTokens += usage.input_tokens || 0;
+            result.outputTokens += usage.output_tokens || 0;
+            result.cacheCreateTokens += usage.cache_creation_input_tokens || 0;
+            result.cacheReadTokens += usage.cache_read_input_tokens || 0;
+          }
+          if (entry.isApiErrorMessage) result.errors++;
+          if (Array.isArray(msg.content)) {
+            for (const block of msg.content) {
+              if (block.type === "tool_use" && block.name) {
+                result.tools[block.name] = (result.tools[block.name] || 0) + 1;
+              }
+            }
+          }
+        }
+      } catch {
+        // skip
+      }
+    }
+  } catch {
+    // file error
+  }
+
+  return result;
+}
+
+export async function scanClaudeConversations(
+  projectPath: string
+): Promise<ClaudeUsageStats | undefined> {
+  const encoded = encodePath(projectPath);
+  const projectDir = path.join(os.homedir(), ".claude", "projects", encoded);
+
+  let jsonlFiles: string[];
+  try {
+    const entries = await fs.readdir(projectDir);
+    jsonlFiles = entries.filter((e) => e.endsWith(".jsonl"));
+  } catch {
+    return undefined;
+  }
+
+  if (jsonlFiles.length === 0) return undefined;
+
+  const stats: ClaudeUsageStats = {
+    totalTokens: 0, inputTokens: 0, outputTokens: 0,
+    cacheCreateTokens: 0, cacheReadTokens: 0,
+    totalTurns: 0, toolUsage: {}, errorCount: 0,
+    modelsUsed: [], costEstimate: 0, conversationCount: jsonlFiles.length,
+  };
+
+  const allModels = new Set<string>();
+  for (let i = 0; i < jsonlFiles.length; i += 5) {
+    const batch = jsonlFiles.slice(i, i + 5);
+    const results = await Promise.all(
+      batch.map((f) => scanConversationFile(path.join(projectDir, f)))
+    );
+    for (const r of results) {
+      stats.inputTokens += r.inputTokens;
+      stats.outputTokens += r.outputTokens;
+      stats.cacheCreateTokens += r.cacheCreateTokens;
+      stats.cacheReadTokens += r.cacheReadTokens;
+      stats.totalTurns += r.turns;
+      stats.errorCount += r.errors;
+      for (const model of r.models) allModels.add(model);
+      for (const [tool, count] of Object.entries(r.tools)) {
+        stats.toolUsage[tool] = (stats.toolUsage[tool] || 0) + count;
+      }
+    }
+  }
+
+  stats.totalTokens = stats.inputTokens + stats.outputTokens;
+  stats.modelsUsed = Array.from(allModels);
+  stats.costEstimate = computeCost(stats.inputTokens, stats.outputTokens, stats.cacheCreateTokens, stats.cacheReadTokens);
+  return stats;
+}
+
+export async function scanAllClaudeConversations(): Promise<ClaudeUsageStats> {
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const aggregate: ClaudeUsageStats = {
+    totalTokens: 0, inputTokens: 0, outputTokens: 0,
+    cacheCreateTokens: 0, cacheReadTokens: 0,
+    totalTurns: 0, toolUsage: {}, errorCount: 0,
+    modelsUsed: [], costEstimate: 0, conversationCount: 0,
+  };
+
+  let dirs: string[];
+  try { dirs = await fs.readdir(projectsDir); } catch { return aggregate; }
+
+  const allModels = new Set<string>();
+  for (const dir of dirs) {
+    const dirPath = path.join(projectsDir, dir);
+    try {
+      const stat = await fs.stat(dirPath);
+      if (!stat.isDirectory()) continue;
+      const entries = await fs.readdir(dirPath);
+      const jsonlFiles = entries.filter((e) => e.endsWith(".jsonl"));
+      for (const file of jsonlFiles) {
+        const result = await scanConversationFile(path.join(dirPath, file));
+        aggregate.inputTokens += result.inputTokens;
+        aggregate.outputTokens += result.outputTokens;
+        aggregate.cacheCreateTokens += result.cacheCreateTokens;
+        aggregate.cacheReadTokens += result.cacheReadTokens;
+        aggregate.totalTurns += result.turns;
+        aggregate.errorCount += result.errors;
+        aggregate.conversationCount++;
+        for (const model of result.models) allModels.add(model);
+        for (const [tool, count] of Object.entries(result.tools)) {
+          aggregate.toolUsage[tool] = (aggregate.toolUsage[tool] || 0) + count;
+        }
+      }
+    } catch { /* skip */ }
+  }
+
+  aggregate.totalTokens = aggregate.inputTokens + aggregate.outputTokens;
+  aggregate.modelsUsed = Array.from(allModels);
+  aggregate.costEstimate = computeCost(aggregate.inputTokens, aggregate.outputTokens, aggregate.cacheCreateTokens, aggregate.cacheReadTokens);
+  return aggregate;
+}

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -248,10 +248,10 @@ export async function scanAllSessions(): Promise<SessionSummary[]> {
     }
   }
 
-  // Sort by most recent first
+  // Sort by most recent activity (endTime) so active sessions appear first
   sessions.sort((a, b) => {
-    const ta = a.startTime ? new Date(a.startTime).getTime() : 0;
-    const tb = b.startTime ? new Date(b.startTime).getTime() : 0;
+    const ta = a.endTime ? new Date(a.endTime).getTime() : 0;
+    const tb = b.endTime ? new Date(b.endTime).getTime() : 0;
     return tb - ta;
   });
 
@@ -328,6 +328,24 @@ export async function scanSessionDetail(
               content: text,
             });
           }
+        }
+
+        // Process sidechain assistant entries for subagent stats
+        if (entry.type === "assistant" && entry.message && entry.isSidechain) {
+          const msg = entry.message;
+          const parentId = (entry as any).parentToolUseID;
+          if (parentId && subagentMap.has(parentId)) {
+            const agent = subagentMap.get(parentId)!;
+            agent.messageCount++;
+            if (Array.isArray(msg.content)) {
+              for (const block of msg.content) {
+                if (block.type === "tool_use" && block.name) {
+                  agent.toolUsage[block.name] = (agent.toolUsage[block.name] || 0) + 1;
+                }
+              }
+            }
+          }
+          continue;
         }
 
         if (entry.type === "assistant" && entry.message && !entry.isSidechain) {
@@ -545,6 +563,25 @@ export async function scanClaudeConversations(
 
 export async function scanAllClaudeConversations(): Promise<ClaudeUsageStats> {
   const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  return scanConversationDirs(projectsDir);
+}
+
+/**
+ * Scan Claude conversations scoped to specific project paths only.
+ * Prevents inflating stats with unrelated repos outside devRoot.
+ */
+export async function scanClaudeConversationsForProjects(
+  projectPaths: string[]
+): Promise<ClaudeUsageStats> {
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const allowedDirs = new Set(projectPaths.map((p) => encodePath(p)));
+  return scanConversationDirs(projectsDir, allowedDirs);
+}
+
+async function scanConversationDirs(
+  projectsDir: string,
+  allowedDirs?: Set<string>
+): Promise<ClaudeUsageStats> {
   const aggregate: ClaudeUsageStats = {
     totalTokens: 0, inputTokens: 0, outputTokens: 0,
     cacheCreateTokens: 0, cacheReadTokens: 0,
@@ -557,6 +594,9 @@ export async function scanAllClaudeConversations(): Promise<ClaudeUsageStats> {
 
   const allModels = new Set<string>();
   for (const dir of dirs) {
+    // If scoped, only process directories matching scanned projects
+    if (allowedDirs && !allowedDirs.has(dir)) continue;
+
     const dirPath = path.join(projectsDir, dir);
     try {
       const stat = await fs.stat(dirPath);

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,101 @@
+import { ProjectData, StatsData, ClaudeUsageStats } from "./types";
+
+function countField(
+  projects: ProjectData[],
+  getter: (p: ProjectData) => string | undefined
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const p of projects) {
+    const val = getter(p);
+    if (val) counts[val] = (counts[val] || 0) + 1;
+  }
+  return counts;
+}
+
+function computeActivity(projects: ProjectData[]) {
+  const now = Date.now();
+  const DAY = 86400_000;
+  const result = { today: 0, thisWeek: 0, thisMonth: 0, older: 0, none: 0 };
+
+  for (const p of projects) {
+    if (!p.lastActivity) {
+      result.none++;
+      continue;
+    }
+    const age = now - new Date(p.lastActivity).getTime();
+    if (age < DAY) result.today++;
+    else if (age < 7 * DAY) result.thisWeek++;
+    else if (age < 30 * DAY) result.thisMonth++;
+    else result.older++;
+  }
+
+  return result;
+}
+
+export function computeStats(
+  projects: ProjectData[],
+  hiddenCount: number,
+  claudeUsage?: ClaudeUsageStats
+): StatsData {
+  // Service counts — flatten across all projects
+  const services: Record<string, number> = {};
+  for (const p of projects) {
+    for (const s of p.externalServices) {
+      services[s] = (services[s] || 0) + 1;
+    }
+  }
+
+  // Database types from database info
+  const databases: Record<string, number> = {};
+  for (const p of projects) {
+    if (p.database?.type) {
+      databases[p.database.type] = (databases[p.database.type] || 0) + 1;
+    }
+  }
+
+  // TODO health
+  let todoTotal = 0, todoCompleted = 0, todoPending = 0;
+  for (const p of projects) {
+    if (p.todos) {
+      todoTotal += p.todos.total;
+      todoCompleted += p.todos.completed;
+      todoPending += p.todos.pending;
+    }
+  }
+
+  // Manual steps health
+  let msTotal = 0, msCompleted = 0, msPending = 0;
+  for (const p of projects) {
+    if (p.manualSteps) {
+      msTotal += p.manualSteps.totalSteps;
+      msCompleted += p.manualSteps.completedSteps;
+      msPending += p.manualSteps.pendingSteps;
+    }
+  }
+
+  // Claude sessions
+  let totalSessions = 0;
+  let projectsWithSessions = 0;
+  for (const p of projects) {
+    if (p.claude && p.claude.sessionCount > 0) {
+      totalSessions += p.claude.sessionCount;
+      projectsWithSessions++;
+    }
+  }
+
+  return {
+    projectCount: projects.length,
+    hiddenCount,
+    frameworks: countField(projects, (p) => p.framework),
+    orms: countField(projects, (p) => p.orm),
+    styling: countField(projects, (p) => p.styling),
+    services,
+    databases,
+    statuses: countField(projects, (p) => p.status),
+    activity: computeActivity(projects),
+    todoHealth: { total: todoTotal, completed: todoCompleted, pending: todoPending },
+    manualStepsHealth: { total: msTotal, completed: msCompleted, pending: msPending },
+    claudeSessions: { total: totalSessions, projectsWithSessions },
+    claudeUsage,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -116,6 +116,90 @@ export interface MinderConfig {
   devRoot: string; // root directory to scan for projects
 }
 
+export interface ClaudeUsageStats {
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreateTokens: number;
+  cacheReadTokens: number;
+  totalTurns: number;
+  toolUsage: Record<string, number>;
+  errorCount: number;
+  modelsUsed: string[];
+  costEstimate: number; // rough USD estimate
+  conversationCount: number;
+}
+
+export interface StatsData {
+  projectCount: number;
+  hiddenCount: number;
+  frameworks: Record<string, number>;
+  orms: Record<string, number>;
+  styling: Record<string, number>;
+  services: Record<string, number>;
+  databases: Record<string, number>;
+  statuses: Record<string, number>;
+  activity: { today: number; thisWeek: number; thisMonth: number; older: number; none: number };
+  todoHealth: { total: number; completed: number; pending: number };
+  manualStepsHealth: { total: number; completed: number; pending: number };
+  claudeSessions: { total: number; projectsWithSessions: number };
+  claudeUsage?: ClaudeUsageStats;
+}
+
+export interface SessionSummary {
+  sessionId: string;
+  projectPath: string;
+  projectSlug: string;
+  projectName: string;
+  startTime?: string;
+  endTime?: string;
+  durationMs?: number;
+  initialPrompt?: string;
+  messageCount: number;
+  userMessageCount: number;
+  assistantMessageCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  costEstimate: number;
+  toolUsage: Record<string, number>;
+  modelsUsed: string[];
+  gitBranch?: string;
+  subagentCount: number;
+  errorCount: number;
+  isActive: boolean;
+}
+
+export interface TimelineEvent {
+  type: "user" | "assistant" | "tool_use" | "thinking" | "error";
+  timestamp?: string;
+  content: string;
+  toolName?: string;
+  tokenCount?: number;
+}
+
+export interface FileOperation {
+  path: string;
+  operation: string;
+  timestamp?: string;
+  toolName: string;
+}
+
+export interface SubagentInfo {
+  agentId: string;
+  type: string;
+  description: string;
+  messageCount: number;
+  toolUsage: Record<string, number>;
+}
+
+export interface SessionDetail extends SessionSummary {
+  timeline: TimelineEvent[];
+  fileOperations: FileOperation[];
+  subagents: SubagentInfo[];
+}
+
 export interface ScanResult {
   projects: ProjectData[];
   portConflicts: PortConflict[];


### PR DESCRIPTION
## Summary

- **Stats Dashboard** (`/stats`) — portfolio-wide analytics: overview cards (projects, sessions, TODOs, costs), tech stack distribution (frameworks, ORMs, styling, services), project health (status, activity recency, TODO completion), Claude Code usage (tokens, tools, models, errors). Inspired by [Sniffly](https://github.com/chiphuyen/sniffly).
- **Sessions Browser** (`/sessions`) — browse all Claude Code sessions across projects. Search by prompt, project, or branch. Sort by recency, duration, or tokens. Active session indicators (green pulse). Click into detail view with timeline, tool usage chart, file operations table, and subagent tracking. Inspired by [claude-code-karma](https://github.com/JayantDevkar/claude-code-karma).
- Enhanced JSONL conversation parser with two-tier loading: lightweight summaries for the list, full detail (timeline, file ops, subagents) on demand.

## Test plan

- [ ] Visit `/stats` — overview cards show real counts, tech stack charts render
- [ ] Visit `/sessions` — session list loads with search/sort working
- [ ] Click a session — detail view shows timeline, tools, files tabs
- [ ] Verify active session detection (green pulse on recent sessions)
- [ ] `npm run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)