### PR TITLE
feat: add TODOs from UI (per-project form + Quick Add modal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Add TODOs from the UI** — Append new items to any project's `TODO.md` without opening an editor. Per-project: inline "Add a new TODO..." form on the TODOs tab of the detail page. Cross-project: **Quick Add** button in the dashboard header (shortcut **Shift+T**) opens a modal with a multi-select project picker and one-idea-per-line textarea that fires parallel appends to every selected project. Creates `TODO.md` with a `# TODO` header if the file doesn't exist. Uses per-file mutex + atomic write to prevent clobbering on concurrent submissions. New `POST /api/todos/[slug]` route accepts `{text}` or `{items[]}`.
 - **Hide projects UI** — Three-dot menu on project cards with "Hide project" action. Confirmation dialog before hiding. "(N hidden)" link in dashboard footer opens a manage modal to view and unhide projects. Uses `@radix-ui/react-dropdown-menu`.
 - **Manual Steps Tracker** — Surfaces `MANUAL_STEPS.md` entries across all projects. Interactive checkboxes toggle steps on disk. Cross-project dashboard at `/manual-steps`. File watcher with real-time toast + OS notifications when Claude adds new steps.
 - **Help system** — Contextual help panel (`?` shortcut) with docs for each page/tab. Help mapping for all routes.

--- a/docs/help/project-details.md
+++ b/docs/help/project-details.md
@@ -55,6 +55,15 @@ Shows TODO items parsed from the project's `TODO.md` file:
 - Each item listed with a checkmark (done) or open circle (pending)
 - A total count of completed vs. remaining items
 
+### Adding TODOs
+
+Use the **Add a new TODO...** field at the bottom of the tab to append a new
+item to `TODO.md`. The item is written as `- [ ] your text` on a new line at
+the end of the file (the file is created automatically if it doesn't exist).
+
+For dumping ideas into many projects at once, use the **Quick Add** button in
+the dashboard header (shortcut: **Shift+T**). See [Quick Add TODOs](quick-actions.md#quick-add-todos).
+
 ## Claude Tab
 
 Shows your Claude session history for this project:

--- a/docs/help/quick-actions.md
+++ b/docs/help/quick-actions.md
@@ -13,3 +13,15 @@ Click **Terminal** to open Windows Terminal with the working directory set to th
 ## Opening the Dev Server
 
 When a dev server is running, click the **localhost:PORT** button to open it in your default browser. See [Dev Servers](dev-servers.md) for more.
+
+## Quick Add TODOs
+
+The **Quick Add** button in the dashboard header (keyboard shortcut: **Shift+T**) opens a modal for dumping ideas into one or many projects at once.
+
+- **Pick projects** — check one or more projects from the searchable list. Archived projects are hidden by default. Use **All visible** or **Clear** to bulk-toggle the current filtered list.
+- **Enter ideas** — type one TODO per line in the textarea. Each non-empty line is appended to the selected projects as `- [ ] your idea`.
+- **Submit** — the button shows the total write count (projects × ideas). Each project is updated in parallel; a per-project success/failure list appears below the textarea.
+
+If a project has no `TODO.md` yet, one is created with a `# TODO` header. Existing file contents are always preserved — items are appended to the end, never inserted in the middle.
+
+You can also add TODOs one-project-at-a-time from the **TODOs** tab on the project detail page.

--- a/public/help/project-details.md
+++ b/public/help/project-details.md
@@ -55,6 +55,15 @@ Shows TODO items parsed from the project's `TODO.md` file:
 - Each item listed with a checkmark (done) or open circle (pending)
 - A total count of completed vs. remaining items
 
+### Adding TODOs
+
+Use the **Add a new TODO...** field at the bottom of the tab to append a new
+item to `TODO.md`. The item is written as `- [ ] your text` on a new line at
+the end of the file (the file is created automatically if it doesn't exist).
+
+For dumping ideas into many projects at once, use the **Quick Add** button in
+the dashboard header (shortcut: **Shift+T**). See [Quick Add TODOs](quick-actions.md#quick-add-todos).
+
 ## Claude Tab
 
 Shows your Claude session history for this project:

--- a/public/help/quick-actions.md
+++ b/public/help/quick-actions.md
@@ -13,3 +13,15 @@ Click **Terminal** to open Windows Terminal with the working directory set to th
 ## Opening the Dev Server
 
 When a dev server is running, click the **localhost:PORT** button to open it in your default browser. See [Dev Servers](dev-servers.md) for more.
+
+## Quick Add TODOs
+
+The **Quick Add** button in the dashboard header (keyboard shortcut: **Shift+T**) opens a modal for dumping ideas into one or many projects at once.
+
+- **Pick projects** — check one or more projects from the searchable list. Archived projects are hidden by default. Use **All visible** or **Clear** to bulk-toggle the current filtered list.
+- **Enter ideas** — type one TODO per line in the textarea. Each non-empty line is appended to the selected projects as `- [ ] your idea`.
+- **Submit** — the button shows the total write count (projects × ideas). Each project is updated in parallel; a per-project success/failure list appears below the textarea.
+
+If a project has no `TODO.md` yet, one is created with a `# TODO` header. Existing file contents are always preserved — items are appended to the end, never inserted in the middle.
+
+You can also add TODOs one-project-at-a-time from the **TODOs** tab on the project detail page.

--- a/src/app/api/todos/[slug]/route.ts
+++ b/src/app/api/todos/[slug]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { scanAllProjects } from "@/lib/scanner";
+import { getCachedScan, setCachedScan, invalidateCache } from "@/lib/cache";
+import { appendTodosToFile, TodoWriteError } from "@/lib/todoWriter";
+
+async function findProjectPath(slug: string): Promise<string | null> {
+  let result = getCachedScan();
+  if (!result) {
+    result = await scanAllProjects();
+    setCachedScan(result);
+  }
+  const project = result.projects.find((p) => p.slug === slug);
+  return project?.path ?? null;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const projectPath = await findProjectPath(slug);
+  if (!projectPath) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { text, items } = (body ?? {}) as { text?: unknown; items?: unknown };
+
+  let texts: string[];
+  if (Array.isArray(items)) {
+    if (!items.every((i) => typeof i === "string")) {
+      return NextResponse.json(
+        { error: "items must be an array of strings" },
+        { status: 400 }
+      );
+    }
+    texts = (items as string[]).filter((s) => s.trim().length > 0);
+  } else if (typeof text === "string") {
+    texts = [text];
+  } else {
+    return NextResponse.json(
+      { error: "text or items required" },
+      { status: 400 }
+    );
+  }
+
+  if (texts.length === 0) {
+    return NextResponse.json(
+      { error: "No non-empty items supplied" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const updated = await appendTodosToFile(projectPath, texts);
+    invalidateCache();
+    return NextResponse.json({ todos: updated, added: texts.length });
+  } catch (err) {
+    if (err instanceof TodoWriteError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    return NextResponse.json(
+      { error: "Failed to append TODOs" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -8,8 +8,9 @@ import { ManageHiddenProjects } from "./ManageHiddenProjects";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
-import { Search, RefreshCw, SortAsc, EyeOff } from "lucide-react";
+import { Search, RefreshCw, SortAsc, Lightbulb } from "lucide-react";
 import { Skeleton } from "./ui/skeleton";
+import { QuickAddTodosModal } from "./QuickAddTodosModal";
 
 type SortOption = "activity" | "name" | "claude";
 
@@ -41,6 +42,7 @@ export function DashboardGrid({
   const [statusFilter, setStatusFilter] = useState<ProjectStatus | "all">("all");
   const [sortBy, setSortBy] = useState<SortOption>("activity");
   const [showHidden, setShowHidden] = useState(false);
+  const [quickAddOpen, setQuickAddOpen] = useState(false);
 
   const filtered = useMemo(() => {
     // Apply git dirty status overrides from background cache
@@ -97,12 +99,27 @@ export function DashboardGrid({
   // Keyboard shortcuts
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      const active = document.activeElement;
+      const inField =
+        active?.tagName === "INPUT" || active?.tagName === "TEXTAREA";
+
       if (e.key === "/" && !e.ctrlKey && !e.metaKey) {
-        const active = document.activeElement;
-        if (active?.tagName !== "INPUT") {
+        if (!inField) {
           e.preventDefault();
           document.getElementById("search-input")?.focus();
         }
+      }
+      // Shift+T → Quick Add TODOs (don't trigger while typing in a field)
+      if (
+        e.key === "T" &&
+        e.shiftKey &&
+        !e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        !inField
+      ) {
+        e.preventDefault();
+        setQuickAddOpen(true);
       }
     },
     []
@@ -164,6 +181,16 @@ export function DashboardGrid({
             ))}
           </div>
 
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setQuickAddOpen(true)}
+            title="Quick Add TODOs (Shift+T)"
+          >
+            <Lightbulb className="h-4 w-4 mr-1" />
+            Quick Add
+          </Button>
+
           <Button variant="outline" size="sm" onClick={onRescan} disabled={loading}>
             <RefreshCw className={`h-4 w-4 mr-1 ${loading ? "animate-spin" : ""}`} />
             Rescan
@@ -206,6 +233,12 @@ export function DashboardGrid({
           )}
         </div>
       )}
+
+      <QuickAddTodosModal
+        projects={projects}
+        open={quickAddOpen}
+        onClose={() => setQuickAddOpen(false)}
+      />
 
       {showHidden && (
         <ManageHiddenProjects

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ProjectData, ProjectStatus } from "@/lib/types";
+import { ProjectData, ProjectStatus, TodoInfo } from "@/lib/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
@@ -9,7 +9,7 @@ import { StatusSelector } from "./StatusBadge";
 import { TechStackBadges } from "./TechStackBadges";
 import { GitStatus } from "./GitStatus";
 import { ClaudeSessionList } from "./ClaudeSessionList";
-import { TodoList } from "./TodoList";
+import { TodoList, AddTodoForm } from "./TodoList";
 import { DevServerControl } from "./DevServerControl";
 import { PortEditor } from "./PortEditor";
 import { ManualStepsList } from "./ManualStepsList";
@@ -33,6 +33,7 @@ interface ProjectDetailProps {
 
 export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
   const [devPort, setDevPort] = useState(project.devPort);
+  const [todos, setTodos] = useState<TodoInfo | undefined>(project.todos);
 
   const openInVSCode = () => {
     window.open(`vscode://file/${project.path.replace(/\\/g, "/")}`, "_blank");
@@ -227,15 +228,18 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
         </TabsContent>
 
         <TabsContent value="todos">
-          {project.todos ? (
-            <div className="rounded-lg border p-6">
-              <TodoList todos={project.todos} />
-            </div>
-          ) : (
-            <p className="text-[var(--muted-foreground)] py-8 text-center">
-              No TODO.md found for this project.
-            </p>
-          )}
+          <div className="rounded-lg border p-6">
+            {todos ? (
+              <TodoList todos={todos} slug={project.slug} onChange={setTodos} />
+            ) : (
+              <div className="space-y-4">
+                <p className="text-[var(--muted-foreground)] text-sm">
+                  No TODO.md found for this project. Add an item below to create one.
+                </p>
+                <AddTodoForm slug={project.slug} onAdded={setTodos} />
+              </div>
+            )}
+          </div>
         </TabsContent>
 
         <TabsContent value="claude">

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ProjectData, ProjectStatus, TodoInfo } from "@/lib/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import { Button } from "./ui/button";
@@ -34,6 +34,12 @@ interface ProjectDetailProps {
 export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
   const [devPort, setDevPort] = useState(project.devPort);
   const [todos, setTodos] = useState<TodoInfo | undefined>(project.todos);
+
+  // Resync local TODO state when the component receives a different project
+  // (e.g. client-side route transitions between /project/[slug] pages).
+  useEffect(() => {
+    setTodos(project.todos);
+  }, [project.slug, project.todos]);
 
   const openInVSCode = () => {
     window.open(`vscode://file/${project.path.replace(/\\/g, "/")}`, "_blank");
@@ -234,7 +240,7 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
             ) : (
               <div className="space-y-4">
                 <p className="text-[var(--muted-foreground)] text-sm">
-                  No TODO.md found for this project. Add an item below to create one.
+                  No TODO items found for this project. Add an item below to create or seed <code>TODO.md</code>.
                 </p>
                 <AddTodoForm slug={project.slug} onAdded={setTodos} />
               </div>

--- a/src/components/QuickAddTodosModal.tsx
+++ b/src/components/QuickAddTodosModal.tsx
@@ -33,15 +33,15 @@ export function QuickAddTodosModal({
   const [results, setResults] = useState<ProjectResult[] | null>(null);
   const { showToast } = useToast();
 
-  // Close on Escape
+  // Close on Escape, except while a batch write is in flight
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !submitting) onClose();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  }, [open, onClose, submitting]);
 
   // Reset state each time the modal reopens
   useEffect(() => {
@@ -145,7 +145,9 @@ export function QuickAddTodosModal({
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 backdrop-blur-sm p-4 overflow-y-auto"
-      onClick={onClose}
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
     >
       <div
         className="w-full max-w-3xl mt-12 rounded-lg border bg-[var(--card)] shadow-xl"
@@ -177,7 +179,7 @@ export function QuickAddTodosModal({
                   variant="ghost"
                   size="sm"
                   onClick={selectAllVisible}
-                  disabled={visibleProjects.length === 0}
+                  disabled={submitting || visibleProjects.length === 0}
                 >
                   All visible
                 </Button>
@@ -185,7 +187,7 @@ export function QuickAddTodosModal({
                   variant="ghost"
                   size="sm"
                   onClick={clearSelection}
-                  disabled={selectedSlugs.size === 0}
+                  disabled={submitting || selectedSlugs.size === 0}
                 >
                   Clear
                 </Button>
@@ -195,6 +197,7 @@ export function QuickAddTodosModal({
               placeholder="Filter projects..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              disabled={submitting}
             />
             <div className="h-80 overflow-y-auto rounded-md border">
               {visibleProjects.length === 0 ? (
@@ -212,6 +215,7 @@ export function QuickAddTodosModal({
                             type="checkbox"
                             checked={checked}
                             onChange={() => toggleProject(p.slug)}
+                            disabled={submitting}
                             className="shrink-0"
                           />
                           <span className="truncate">{p.name}</span>
@@ -242,7 +246,8 @@ export function QuickAddTodosModal({
               onChange={(e) => setText(e.target.value)}
               placeholder={"Refactor the scanner batching\nAdd keyboard shortcuts to detail page\nInvestigate flaky git subprocess pool"}
               rows={12}
-              className="w-full rounded-md border border-[var(--input)] bg-[var(--background)] px-3 py-2 text-sm font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+              disabled={submitting}
+              className="w-full rounded-md border border-[var(--input)] bg-[var(--background)] px-3 py-2 text-sm font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-50"
             />
 
             {results && (

--- a/src/components/QuickAddTodosModal.tsx
+++ b/src/components/QuickAddTodosModal.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ProjectData } from "@/lib/types";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { X, Loader2, CheckCircle2, XCircle, Lightbulb } from "lucide-react";
+import { useToast } from "./ToastProvider";
+
+interface QuickAddTodosModalProps {
+  projects: ProjectData[];
+  open: boolean;
+  onClose: () => void;
+}
+
+interface ProjectResult {
+  slug: string;
+  name: string;
+  ok: boolean;
+  error?: string;
+  added?: number;
+}
+
+export function QuickAddTodosModal({
+  projects,
+  open,
+  onClose,
+}: QuickAddTodosModalProps) {
+  const [search, setSearch] = useState("");
+  const [selectedSlugs, setSelectedSlugs] = useState<Set<string>>(new Set());
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [results, setResults] = useState<ProjectResult[] | null>(null);
+  const { showToast } = useToast();
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Reset state each time the modal reopens
+  useEffect(() => {
+    if (open) {
+      setSearch("");
+      setSelectedSlugs(new Set());
+      setText("");
+      setResults(null);
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  const visibleProjects = useMemo(() => {
+    const active = projects.filter((p) => p.status !== "archived");
+    if (!search) return active;
+    const q = search.toLowerCase();
+    return active.filter(
+      (p) => p.name.toLowerCase().includes(q) || p.slug.includes(q)
+    );
+  }, [projects, search]);
+
+  const items = useMemo(
+    () =>
+      text
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0),
+    [text]
+  );
+
+  if (!open) return null;
+
+  const toggleProject = (slug: string) => {
+    setSelectedSlugs((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  };
+
+  const selectAllVisible = () => {
+    setSelectedSlugs(new Set(visibleProjects.map((p) => p.slug)));
+  };
+
+  const clearSelection = () => setSelectedSlugs(new Set());
+
+  const submit = async () => {
+    if (selectedSlugs.size === 0 || items.length === 0 || submitting) return;
+    setSubmitting(true);
+    setResults(null);
+
+    const selected = projects.filter((p) => selectedSlugs.has(p.slug));
+    const settled = await Promise.all(
+      selected.map(async (p): Promise<ProjectResult> => {
+        try {
+          const res = await fetch(`/api/todos/${p.slug}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ items }),
+          });
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            return {
+              slug: p.slug,
+              name: p.name,
+              ok: false,
+              error: body.error ?? `HTTP ${res.status}`,
+            };
+          }
+          const body = await res.json();
+          return {
+            slug: p.slug,
+            name: p.name,
+            ok: true,
+            added: body.added ?? items.length,
+          };
+        } catch (err) {
+          return {
+            slug: p.slug,
+            name: p.name,
+            ok: false,
+            error: err instanceof Error ? err.message : "Network error",
+          };
+        }
+      })
+    );
+
+    setResults(settled);
+    setSubmitting(false);
+
+    const successCount = settled.filter((r) => r.ok).length;
+    const failCount = settled.length - successCount;
+    showToast(
+      failCount === 0
+        ? `Added ${items.length} TODO${items.length !== 1 ? "s" : ""} to ${successCount} project${successCount !== 1 ? "s" : ""}`
+        : `Added to ${successCount}, failed for ${failCount}`
+    );
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 backdrop-blur-sm p-4 overflow-y-auto"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-3xl mt-12 rounded-lg border bg-[var(--card)] shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b p-4">
+          <div className="flex items-center gap-2">
+            <Lightbulb className="h-5 w-5 text-amber-400" />
+            <h2 className="text-lg font-semibold">Quick Add TODOs</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4">
+          {/* Project picker */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">
+                Projects ({selectedSlugs.size} selected)
+              </label>
+              <div className="flex gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={selectAllVisible}
+                  disabled={visibleProjects.length === 0}
+                >
+                  All visible
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={clearSelection}
+                  disabled={selectedSlugs.size === 0}
+                >
+                  Clear
+                </Button>
+              </div>
+            </div>
+            <Input
+              placeholder="Filter projects..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <div className="h-80 overflow-y-auto rounded-md border">
+              {visibleProjects.length === 0 ? (
+                <p className="p-3 text-sm text-[var(--muted-foreground)]">
+                  No projects match.
+                </p>
+              ) : (
+                <ul>
+                  {visibleProjects.map((p) => {
+                    const checked = selectedSlugs.has(p.slug);
+                    return (
+                      <li key={p.slug}>
+                        <label className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-[var(--muted)] cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => toggleProject(p.slug)}
+                            className="shrink-0"
+                          />
+                          <span className="truncate">{p.name}</span>
+                          {p.framework && (
+                            <span className="ml-auto text-xs text-[var(--muted-foreground)] shrink-0">
+                              {p.framework}
+                            </span>
+                          )}
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          {/* Idea input */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium">
+              Ideas ({items.length} {items.length === 1 ? "item" : "items"})
+            </label>
+            <p className="text-xs text-[var(--muted-foreground)]">
+              One TODO per line. Each line is appended as <code>- [ ] …</code>.
+            </p>
+            <textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder={"Refactor the scanner batching\nAdd keyboard shortcuts to detail page\nInvestigate flaky git subprocess pool"}
+              rows={12}
+              className="w-full rounded-md border border-[var(--input)] bg-[var(--background)] px-3 py-2 text-sm font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+            />
+
+            {results && (
+              <div className="max-h-40 overflow-y-auto rounded-md border text-xs">
+                <ul>
+                  {results.map((r) => (
+                    <li
+                      key={r.slug}
+                      className="flex items-center gap-2 px-3 py-1.5 border-b last:border-b-0"
+                    >
+                      {r.ok ? (
+                        <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+                      ) : (
+                        <XCircle className="h-3.5 w-3.5 text-red-500 shrink-0" />
+                      )}
+                      <span className="truncate">{r.name}</span>
+                      <span className="ml-auto text-[var(--muted-foreground)]">
+                        {r.ok ? `+${r.added}` : r.error}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between border-t p-4">
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Will write to {selectedSlugs.size} × {items.length} ={" "}
+            {selectedSlugs.size * items.length} TODO
+            {selectedSlugs.size * items.length !== 1 ? "s" : ""}
+          </p>
+          <div className="flex gap-2">
+            <Button variant="ghost" onClick={onClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={submit}
+              disabled={
+                submitting || selectedSlugs.size === 0 || items.length === 0
+              }
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                  Adding...
+                </>
+              ) : (
+                <>
+                  <Lightbulb className="h-4 w-4 mr-1" />
+                  Add to {selectedSlugs.size || 0} project
+                  {selectedSlugs.size !== 1 ? "s" : ""}
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,7 +1,19 @@
-import { TodoInfo } from "@/lib/types";
-import { CheckCircle2, Circle } from "lucide-react";
+"use client";
 
-export function TodoList({ todos }: { todos: TodoInfo }) {
+import { useState } from "react";
+import { TodoInfo } from "@/lib/types";
+import { CheckCircle2, Circle, Plus, Loader2 } from "lucide-react";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
+import { useToast } from "./ToastProvider";
+
+interface TodoListProps {
+  todos: TodoInfo;
+  slug?: string;
+  onChange?: (updated: TodoInfo) => void;
+}
+
+export function TodoList({ todos, slug, onChange }: TodoListProps) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -32,7 +44,70 @@ export function TodoList({ todos }: { todos: TodoInfo }) {
           </li>
         ))}
       </ul>
+
+      {slug && <AddTodoForm slug={slug} onAdded={onChange} />}
     </div>
+  );
+}
+
+export function AddTodoForm({
+  slug,
+  onAdded,
+}: {
+  slug: string;
+  onAdded?: (updated: TodoInfo) => void;
+}) {
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const { showToast } = useToast();
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed || submitting) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/todos/${slug}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: trimmed }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const body = await res.json();
+      setText("");
+      onAdded?.(body.todos as TodoInfo);
+      showToast("TODO added", trimmed);
+    } catch (err) {
+      showToast(
+        "Failed to add TODO",
+        err instanceof Error ? err.message : "Unknown error"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="flex gap-2 pt-2">
+      <Input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Add a new TODO..."
+        maxLength={500}
+        disabled={submitting}
+      />
+      <Button type="submit" size="sm" disabled={submitting || !text.trim()}>
+        {submitting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Plus className="h-4 w-4" />
+        )}
+      </Button>
+    </form>
   );
 }
 

--- a/src/lib/todoWriter.ts
+++ b/src/lib/todoWriter.ts
@@ -1,0 +1,101 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { scanTodoMd } from "./scanner/todoMd";
+import { TodoInfo } from "./types";
+
+/**
+ * Per-file mutex to serialize read-modify-write cycles.
+ * Prevents concurrent appends from clobbering each other.
+ */
+const fileLocks = new Map<string, Promise<unknown>>();
+
+function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const normalized = path.resolve(filePath);
+  const prev = fileLocks.get(normalized) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  fileLocks.set(normalized, next);
+  next.finally(() => {
+    if (fileLocks.get(normalized) === next) {
+      fileLocks.delete(normalized);
+    }
+  });
+  return next;
+}
+
+async function atomicWriteFile(
+  filePath: string,
+  content: string
+): Promise<void> {
+  const tmpPath = filePath + ".tmp." + process.pid;
+  await fs.writeFile(tmpPath, content, "utf-8");
+  await fs.rename(tmpPath, filePath);
+}
+
+const MAX_TODO_LENGTH = 500;
+
+export class TodoWriteError extends Error {
+  constructor(message: string, public code: "EMPTY" | "TOO_LONG") {
+    super(message);
+    this.name = "TodoWriteError";
+  }
+}
+
+function sanitize(text: string): string {
+  // Collapse any newlines/tabs to single spaces so one line = one item.
+  const cleaned = text.replace(/[\r\n\t]+/g, " ").trim();
+  if (cleaned.length === 0) {
+    throw new TodoWriteError("TODO text is empty", "EMPTY");
+  }
+  if (cleaned.length > MAX_TODO_LENGTH) {
+    throw new TodoWriteError(
+      `TODO text exceeds ${MAX_TODO_LENGTH} characters`,
+      "TOO_LONG"
+    );
+  }
+  return cleaned;
+}
+
+/**
+ * Append one or more TODO items to a project's TODO.md.
+ * Creates the file with a default header if it does not exist.
+ * Returns the refreshed TodoInfo after the write.
+ */
+export async function appendTodosToFile(
+  projectPath: string,
+  texts: string[]
+): Promise<TodoInfo> {
+  const sanitized = texts.map(sanitize);
+  const filePath = path.join(projectPath, "TODO.md");
+
+  return withFileLock(filePath, async () => {
+    let existing: string;
+    try {
+      existing = await fs.readFile(filePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        existing = "# TODO\n\n";
+      } else {
+        throw err;
+      }
+    }
+
+    // Ensure the file ends with exactly one newline before we append.
+    const base = existing.replace(/\s*$/, "") + (existing.length > 0 ? "\n" : "");
+    const appended =
+      base + sanitized.map((t) => `- [ ] ${t}`).join("\n") + "\n";
+
+    await atomicWriteFile(filePath, appended);
+
+    const info = await scanTodoMd(projectPath);
+    // scanTodoMd returns undefined only if zero items — after an append this
+    // should never happen, but fall back to a safe empty shape just in case.
+    return (
+      info ?? {
+        total: sanitized.length,
+        completed: 0,
+        pending: sanitized.length,
+        items: sanitized.map((t) => ({ text: t, completed: false })),
+      }
+    );
+  });
+}

--- a/src/lib/todoWriter.ts
+++ b/src/lib/todoWriter.ts
@@ -79,8 +79,16 @@ export async function appendTodosToFile(
       }
     }
 
-    // Ensure the file ends with exactly one newline before we append.
-    const base = existing.replace(/\s*$/, "") + (existing.length > 0 ? "\n" : "");
+    // Normalize trailing whitespace before appending.
+    // Preserve the conventional blank line after a standalone "# TODO" header
+    // so newly-seeded files read as "# TODO\n\n- [ ] ...".
+    const normalized = existing.replace(/[\r\n]*$/, "");
+    const base =
+      normalized.length === 0
+        ? ""
+        : normalized === "# TODO"
+          ? normalized + "\n\n"
+          : normalized + "\n";
     const appended =
       base + sanitized.map((t) => `- [ ] ${t}`).join("\n") + "\n";
 


### PR DESCRIPTION
## Summary
- Inline **Add a new TODO...** form on the project detail page's TODOs tab — appends to `TODO.md` via new `POST /api/todos/[slug]`.
- **Quick Add** modal (dashboard header button + **Shift+T** shortcut) with searchable multi-select project picker and one-idea-per-line textarea; fires parallel appends and shows a per-project success/failure list.
- New `src/lib/todoWriter.ts` mirrors the `manualStepsWriter` safety pattern — per-file mutex + atomic temp-rename write, ENOENT → seeds `# TODO\n\n`, 500-char and empty-input validation.

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Open a project with an existing `TODO.md`, add an item from the TODOs tab → new `- [ ] ...` line appears in the file on disk and in the UI without refresh
- [ ] Open a project with **no** `TODO.md` → empty-state form creates the file with `# TODO` header + the new item
- [ ] Open Quick Add (Shift+T), select 3 projects, enter 2 lines → all 3 files gain 2 items each, success toast + per-project summary
- [ ] Concurrency smoke: fire two Quick Add submissions targeting the same project back-to-back → both items land (proves file lock works)
- [ ] Shift+T does not fire while typing in the search box or any input

🤖 Generated with [Claude Code](https://claude.com/claude-code)