### PR TITLE
feat: worktree support — dev servers, sync, staleness detection

### DIFF
--- a/docs/superpowers/plans/2026-04-15-worktree-support.md
+++ b/docs/superpowers/plans/2026-04-15-worktree-support.md
@@ -1,0 +1,1000 @@
+# Worktree Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add worktree-aware dev server control, markdown sync, and stale-worktree cleanup to Project Minder's project detail page.
+
+**Architecture:** A new `/api/worktrees/[slug]` route runs on-demand git checks per worktree (merged status, remote branch existence, dirty status) and handles start-server and remove actions. A new `WorktreePanel` component on the project detail Overview tab renders these controls lazily on first expand. Pure logic (port finding, sync diffing, git status parsing) is unit-tested; UI and routes are validated via `npm run build` and manual browser testing.
+
+**Tech Stack:** Next.js App Router API routes, TypeScript, child_process.execFile, existing `processManager` singleton, vitest for unit tests.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/lib/types.ts` | Modify | Add `WorktreeStatus` interface |
+| `src/lib/processManager.ts` | Modify | Export `findFreePort(startPort, maxAttempts?, checker?)` |
+| `src/lib/worktreeChecker.ts` | Create | `checkWorktreeStatus()` — runs 4 git commands per worktree |
+| `src/lib/worktreeSync.ts` | Create | `diffTodos`, `diffManualSteps`, `diffInsights` — pure diff functions |
+| `src/app/api/worktrees/[slug]/route.ts` | Create | GET (status list) + POST (start-server, remove) |
+| `src/app/api/worktrees/[slug]/sync/route.ts` | Create | POST (append worktree-only entries to parent file) |
+| `src/components/WorktreePanel.tsx` | Create | Lazy status panel: dev server, sync badges, stale/remove |
+| `src/components/ProjectDetail.tsx` | Modify | Render WorktreePanel in Overview tab when worktrees exist |
+| `src/components/ProjectCard.tsx` | Modify | Show `wt N` count badge when project has worktrees |
+| `tests/findFreePort.test.ts` | Create | Unit tests for port auto-finding |
+| `tests/worktreeChecker.test.ts` | Create | Unit tests for git status parsing |
+| `tests/worktreeSync.test.ts` | Create | Unit tests for diff functions |
+
+---
+
+## Task 1: Add WorktreeStatus to types
+
+**Files:** Modify `src/lib/types.ts`
+
+- [ ] **Step 1: Add interface after WorktreeOverlay (~line 127)**
+
+```ts
+export interface WorktreeStatus {
+  worktreePath: string;
+  branch: string;
+  isDirty: boolean;
+  uncommittedCount: number;
+  isMergedLocally: boolean;       // git branch --merged main
+  isRemoteBranchDeleted: boolean; // git ls-remote --heads origin <branch> returned empty
+  isStale: boolean;               // isMergedLocally && isRemoteBranchDeleted
+  lastCommitDate?: string;        // from git log -1 --format=%aI
+}
+```
+
+- [ ] **Step 2: Verify build** — `npm run build 2>&1 | tail -5` — expect no errors.
+
+- [ ] **Step 3: Commit** — `git add src/lib/types.ts && git commit -m "feat: add WorktreeStatus type"`
+
+---
+
+## Task 2: Add findFreePort to processManager — TDD
+
+**Files:** Modify `src/lib/processManager.ts`, Create `tests/findFreePort.test.ts`
+
+- [ ] **Step 1: Create `tests/findFreePort.test.ts`**
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { findFreePort } from "@/lib/processManager";
+
+describe("findFreePort", () => {
+  it("returns startPort when it is free", async () => {
+    const checker = vi.fn().mockResolvedValue(false);
+    expect(await findFreePort(4101, 10, checker)).toBe(4101);
+    expect(checker).toHaveBeenCalledWith(4101);
+  });
+
+  it("skips in-use ports and returns next free one", async () => {
+    const checker = vi.fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    expect(await findFreePort(4101, 10, checker)).toBe(4103);
+  });
+
+  it("returns null when all attempts exhausted", async () => {
+    const checker = vi.fn().mockResolvedValue(true);
+    expect(await findFreePort(4101, 3, checker)).toBeNull();
+    expect(checker).toHaveBeenCalledTimes(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `npm test -- --reporter=verbose 2>&1 | grep -A3 "findFreePort"`
+
+- [ ] **Step 3: Add to `src/lib/processManager.ts` after the `isPortInUse` function (~line 252)**
+
+```ts
+/**
+ * Find the next free port starting at startPort.
+ * The checker parameter is injectable for testability.
+ */
+export async function findFreePort(
+  startPort: number,
+  maxAttempts = 10,
+  checker: (port: number) => Promise<boolean> = isPortInUse
+): Promise<number | null> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = startPort + i;
+    if (!(await checker(port))) return port;
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run** — `npm test -- --reporter=verbose 2>&1 | grep -A3 "findFreePort"` — expect 3 passing.
+
+- [ ] **Step 5: Commit** — `git add src/lib/processManager.ts tests/findFreePort.test.ts && git commit -m "feat: add findFreePort"`
+
+---
+
+## Task 3: Create worktreeChecker.ts — TDD
+
+**Files:** Create `src/lib/worktreeChecker.ts`, Create `tests/worktreeChecker.test.ts`
+
+Note: uses `execFile` from node:child_process (NOT exec — no shell injection risk).
+
+- [ ] **Step 1: Create `tests/worktreeChecker.test.ts`**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+vi.mock("@/lib/processManager", () => ({ processManager: { get: vi.fn().mockReturnValue(undefined) } }));
+
+import { execFile } from "child_process";
+import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+
+const execFileMock = vi.mocked(execFile);
+
+function stubOutputs(outputs: string[]) {
+  let call = 0;
+  execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+    const cb = callback as (err: null, stdout: string, stderr: string) => void;
+    cb(null, (outputs[call++] ?? "") + "\n", "");
+    return {} as ReturnType<typeof execFile>;
+  });
+}
+
+describe("checkWorktreeStatus", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("marks stale when merged locally and remote deleted", async () => {
+    stubOutputs(["  main\n  feature/foo", "", "", "2026-04-01T10:00:00Z"]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isMergedLocally).toBe(true);
+    expect(s.isRemoteBranchDeleted).toBe(true);
+    expect(s.isStale).toBe(true);
+    expect(s.isDirty).toBe(false);
+  });
+
+  it("not stale when remote branch still exists", async () => {
+    stubOutputs(["  main", "abc123\trefs/heads/feature/foo", "", ""]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isStale).toBe(false);
+  });
+
+  it("reports dirty worktree", async () => {
+    stubOutputs(["  main", "", " M src/foo.ts\nA  src/bar.ts", ""]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isDirty).toBe(true);
+    expect(s.uncommittedCount).toBe(2);
+  });
+
+  it("returns isStale false when git fails (offline safety)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as (err: Error) => void)(new Error("network unreachable"));
+      return {} as ReturnType<typeof execFile>;
+    });
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isStale).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Verify FAIL** — `npm test -- --reporter=verbose 2>&1 | grep -A3 "worktreeChecker"`
+
+- [ ] **Step 3: Create `src/lib/worktreeChecker.ts`**
+
+```ts
+import { execFile } from "child_process";
+import { WorktreeStatus } from "./types";
+
+function runGit(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("git", args, { cwd, timeout: 5000 }, (err, stdout) => {
+      resolve(err ? "" : stdout.trim());
+    });
+  });
+}
+
+export async function checkWorktreeStatus(
+  parentPath: string,
+  worktreePath: string,
+  branch: string,
+  _worktreeSlug: string
+): Promise<WorktreeStatus> {
+  const [mergedOutput, remoteOutput, porcelain, lastCommit] = await Promise.all([
+    runGit(["branch", "--merged", "main"], parentPath),
+    runGit(["ls-remote", "--heads", "origin", branch], parentPath),
+    runGit(["status", "--porcelain"], worktreePath),
+    runGit(["log", "-1", "--format=%aI"], worktreePath),
+  ]);
+
+  const mergedBranches = mergedOutput.split("\n").map((l) => l.trim().replace(/^\*\s*/, "")).filter(Boolean);
+  const isMergedLocally = mergedBranches.includes(branch);
+  const isRemoteBranchDeleted = remoteOutput.trim() === "";
+  const porcelainLines = porcelain ? porcelain.split("\n").filter((l) => l.trim()) : [];
+
+  return {
+    worktreePath,
+    branch,
+    isDirty: porcelainLines.length > 0,
+    uncommittedCount: porcelainLines.length,
+    isMergedLocally,
+    isRemoteBranchDeleted,
+    isStale: isMergedLocally && isRemoteBranchDeleted,
+    lastCommitDate: lastCommit || undefined,
+  };
+}
+```
+
+- [ ] **Step 4: Run** — `npm test -- --reporter=verbose 2>&1 | grep -A3 "worktreeChecker"` — expect 4 passing.
+
+- [ ] **Step 5: Commit** — `git add src/lib/worktreeChecker.ts tests/worktreeChecker.test.ts && git commit -m "feat: add worktreeChecker"`
+
+---
+
+## Task 4: Create worktreeSync.ts — TDD
+
+**Files:** Create `src/lib/worktreeSync.ts`, Create `tests/worktreeSync.test.ts`
+
+- [ ] **Step 1: Create `tests/worktreeSync.test.ts`**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { diffTodos, diffManualSteps, diffInsights } from "@/lib/worktreeSync";
+
+describe("diffTodos", () => {
+  it("returns items in worktree not in parent", () => {
+    const parent = [{ text: "fix bug", completed: false }];
+    const worktree = [{ text: "fix bug", completed: true }, { text: "add feature", completed: false }];
+    expect(diffTodos(parent, worktree)).toEqual(["add feature"]);
+  });
+  it("returns empty when nothing new", () => {
+    expect(diffTodos([{ text: "x", completed: false }], [{ text: "x", completed: false }])).toEqual([]);
+  });
+  it("returns all when parent empty", () => {
+    expect(diffTodos([], [{ text: "a", completed: false }, { text: "b", completed: false }])).toEqual(["a", "b"]);
+  });
+});
+
+describe("diffManualSteps", () => {
+  const e = (date: string, slug: string, title: string) => ({ date, featureSlug: slug, title, steps: [] });
+  it("returns entries in worktree not in parent", () => {
+    const result = diffManualSteps(
+      [e("2026-04-01 10:00", "auth", "Setup auth")],
+      [e("2026-04-01 10:00", "auth", "Setup auth"), e("2026-04-10 12:00", "feat-x", "Setup X")]
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].featureSlug).toBe("feat-x");
+  });
+  it("returns empty when nothing new", () => {
+    const entry = e("2026-04-01", "a", "T");
+    expect(diffManualSteps([entry], [entry])).toHaveLength(0);
+  });
+});
+
+describe("diffInsights", () => {
+  const ins = (id: string) => ({ id, content: "x", sessionId: "s1", date: "2026-04-01", project: "p", projectPath: "/p" });
+  it("returns insights not in parent ids", () => {
+    const result = diffInsights(new Set(["abc123"]), [ins("abc123"), ins("def456")]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("def456");
+  });
+  it("returns all when parent empty", () => {
+    expect(diffInsights(new Set(), [ins("a"), ins("b")])).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Verify FAIL** — `npm test -- --reporter=verbose 2>&1 | grep -A3 "worktreeSync"`
+
+- [ ] **Step 3: Create `src/lib/worktreeSync.ts`**
+
+```ts
+import { TodoItem, ManualStepEntry, InsightEntry } from "./types";
+
+export function diffTodos(parentItems: TodoItem[], worktreeItems: TodoItem[]): string[] {
+  const parentTexts = new Set(parentItems.map((i) => i.text));
+  return worktreeItems.filter((i) => !parentTexts.has(i.text)).map((i) => i.text);
+}
+
+export function diffManualSteps(parentEntries: ManualStepEntry[], worktreeEntries: ManualStepEntry[]): ManualStepEntry[] {
+  const key = (e: ManualStepEntry) => `${e.date}|${e.featureSlug}|${e.title}`;
+  const parentKeys = new Set(parentEntries.map(key));
+  return worktreeEntries.filter((e) => !parentKeys.has(key(e)));
+}
+
+export function diffInsights(parentIds: Set<string>, worktreeEntries: InsightEntry[]): InsightEntry[] {
+  return worktreeEntries.filter((e) => !parentIds.has(e.id));
+}
+```
+
+- [ ] **Step 4: Run all tests** — `npm test 2>&1 | tail -6` — expect 13 files passing.
+
+- [ ] **Step 5: Commit** — `git add src/lib/worktreeSync.ts tests/worktreeSync.test.ts && git commit -m "feat: add worktreeSync diff utilities"`
+
+---
+
+## Task 5: Create GET /api/worktrees/[slug]
+
+**Files:** Create `src/app/api/worktrees/[slug]/route.ts`
+
+- [ ] **Step 1: Create directory** — `mkdir -p "src/app/api/worktrees/[slug]"`
+
+- [ ] **Step 2: Create route.ts**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { getCachedScan } from "@/lib/cache";
+import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const scan = getCachedScan();
+  if (!scan) return NextResponse.json({ error: "Scan cache not ready" }, { status: 503 });
+  const project = scan.projects.find((p) => p.slug === slug);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  if (!project.worktrees || project.worktrees.length === 0) return NextResponse.json([]);
+
+  const worktreeSlugFor = (branch: string) => `${slug}:wt:${branch.replace(/\//g, "-")}`;
+  const statuses = await Promise.all(
+    project.worktrees.map((wt) =>
+      checkWorktreeStatus(project.path, wt.worktreePath, wt.branch, worktreeSlugFor(wt.branch))
+    )
+  );
+  return NextResponse.json(statuses);
+}
+```
+
+- [ ] **Step 3: Verify build** — `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit** — `git add "src/app/api/worktrees/" && git commit -m "feat: add GET /api/worktrees/[slug]"`
+
+---
+
+## Task 6: Add POST to /api/worktrees/[slug] (start-server + remove)
+
+**Files:** Modify `src/app/api/worktrees/[slug]/route.ts`
+
+- [ ] **Step 1: Replace the import block with**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { getCachedScan } from "@/lib/cache";
+import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+import { processManager, findFreePort } from "@/lib/processManager";
+
+const execFileAsync = promisify(execFile);
+```
+
+- [ ] **Step 2: Add POST handler after the GET export**
+
+```ts
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const body = (await req.json()) as {
+    action: "start-server" | "remove";
+    worktreePath: string;
+    parentDevPort?: number;
+  };
+
+  const scan = getCachedScan();
+  if (!scan) return NextResponse.json({ error: "Scan cache not ready" }, { status: 503 });
+  const project = scan.projects.find((p) => p.slug === slug);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  const wt = project.worktrees?.find((w) => w.worktreePath === body.worktreePath);
+  if (!wt) return NextResponse.json({ error: "Worktree not found" }, { status: 404 });
+
+  const worktreeSlug = `${slug}:wt:${wt.branch.replace(/\//g, "-")}`;
+
+  if (body.action === "start-server") {
+    const startPort = (body.parentDevPort ?? project.devPort ?? 3000) + 1;
+    const port = await findFreePort(startPort);
+    if (!port) return NextResponse.json({ error: `No free port from ${startPort}` }, { status: 409 });
+    const info = await processManager.start(worktreeSlug, body.worktreePath, port);
+    return NextResponse.json({ ...info, resolvedPort: port });
+  }
+
+  if (body.action === "remove") {
+    const status = await checkWorktreeStatus(project.path, body.worktreePath, wt.branch, worktreeSlug);
+    if (!status.isStale) {
+      return NextResponse.json({ error: "Worktree is not stale — cannot remove automatically" }, { status: 400 });
+    }
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        "git", ["worktree", "remove", body.worktreePath],
+        { cwd: project.path, timeout: 10000 }
+      );
+      return NextResponse.json({ removed: true, output: stdout || stderr });
+    } catch (err: unknown) {
+      return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 409 });
+    }
+  }
+
+  return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+}
+```
+
+- [ ] **Step 3: Verify build** — `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit** — `git add "src/app/api/worktrees/[slug]/route.ts" && git commit -m "feat: add POST /api/worktrees/[slug]"`
+
+---
+
+## Task 7: Create POST /api/worktrees/[slug]/sync
+
+**Files:** Create `src/app/api/worktrees/[slug]/sync/route.ts`
+
+- [ ] **Step 1: Create directory** — `mkdir -p "src/app/api/worktrees/[slug]/sync"`
+
+- [ ] **Step 2: Create sync/route.ts**
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { getCachedScan } from "@/lib/cache";
+import { scanTodoMd } from "@/lib/scanner/todoMd";
+import { scanManualStepsMd } from "@/lib/scanner/manualStepsMd";
+import { scanInsightsMd, parseInsightsMd, appendInsights } from "@/lib/scanner/insightsMd";
+import { appendTodosToFile } from "@/lib/todoWriter";
+import { diffTodos, diffManualSteps, diffInsights } from "@/lib/worktreeSync";
+import { ManualStepEntry } from "@/lib/types";
+
+function entryToMarkdown(entry: ManualStepEntry): string {
+  const steps = entry.steps.map((step) => {
+    const checkbox = step.completed ? "- [x]" : "- [ ]";
+    const details = step.details.map((d) => `  ${d}`).join("\n");
+    return details ? `${checkbox} ${step.text}\n${details}` : `${checkbox} ${step.text}`;
+  }).join("\n");
+  return `## ${entry.date} | ${entry.featureSlug} | ${entry.title}\n\n${steps}\n\n---\n`;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const body = (await req.json()) as { worktreePath: string; file: "todos" | "manual-steps" | "insights" };
+  const scan = getCachedScan();
+  if (!scan) return NextResponse.json({ error: "Scan cache not ready" }, { status: 503 });
+  const project = scan.projects.find((p) => p.slug === slug);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+
+  if (body.file === "todos") {
+    const [parentInfo, worktreeInfo] = await Promise.all([scanTodoMd(project.path), scanTodoMd(body.worktreePath)]);
+    const newTexts = diffTodos(parentInfo?.items ?? [], worktreeInfo?.items ?? []);
+    if (newTexts.length === 0) return NextResponse.json({ synced: 0 });
+    await appendTodosToFile(project.path, newTexts);
+    return NextResponse.json({ synced: newTexts.length });
+  }
+
+  if (body.file === "manual-steps") {
+    const [parentInfo, worktreeInfo] = await Promise.all([scanManualStepsMd(project.path), scanManualStepsMd(body.worktreePath)]);
+    const newEntries = diffManualSteps(parentInfo?.entries ?? [], worktreeInfo?.entries ?? []);
+    if (newEntries.length === 0) return NextResponse.json({ synced: 0 });
+    const filePath = path.join(project.path, "MANUAL_STEPS.md");
+    let existing = "";
+    try { existing = await fs.readFile(filePath, "utf-8"); } catch { /* new file */ }
+    const sep = existing.trimEnd() ? "\n\n" : "";
+    await fs.writeFile(filePath, existing.trimEnd() + sep + newEntries.map(entryToMarkdown).join("\n"), "utf-8");
+    return NextResponse.json({ synced: newEntries.length });
+  }
+
+  if (body.file === "insights") {
+    const worktreeInfo = await scanInsightsMd(body.worktreePath);
+    if (!worktreeInfo || worktreeInfo.entries.length === 0) return NextResponse.json({ synced: 0 });
+    let parentContent = "";
+    try { parentContent = await fs.readFile(path.join(project.path, "INSIGHTS.md"), "utf-8"); } catch { /* new */ }
+    const { knownIds } = parseInsightsMd(parentContent);
+    const newEntries = diffInsights(knownIds, worktreeInfo.entries);
+    if (newEntries.length === 0) return NextResponse.json({ synced: 0 });
+    await appendInsights(project.path, newEntries);
+    return NextResponse.json({ synced: newEntries.length });
+  }
+
+  return NextResponse.json({ error: "Unknown file type" }, { status: 400 });
+}
+```
+
+- [ ] **Step 3: Verify build** — `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit** — `git add "src/app/api/worktrees/[slug]/sync/" && git commit -m "feat: add POST /api/worktrees/[slug]/sync"`
+
+
+---
+
+## Task 8: Create WorktreePanel.tsx
+
+**Files:** Create `src/components/WorktreePanel.tsx`
+
+- [ ] **Step 1: Create `src/components/WorktreePanel.tsx`**
+
+```tsx
+"use client";
+import { useState, useCallback, useEffect } from "react";
+import { WorktreeOverlay, WorktreeStatus } from "@/lib/types";
+
+interface WorktreePanelProps {
+  slug: string;
+  devPort?: number;
+  worktrees: WorktreeOverlay[];
+}
+
+type SyncFile = "todos" | "manual-steps" | "insights";
+
+interface DevServerState { running: boolean; port?: number; loading: boolean; }
+interface SyncState { loading: boolean; result?: number; error?: string; }
+
+interface WorktreeRowProps {
+  wt: WorktreeOverlay;
+  status: WorktreeStatus;
+  parentSlug: string;
+  parentDevPort?: number;
+  onRemoved: () => void;
+}
+
+function worktreeSlugFor(parentSlug: string, branch: string) {
+  return `${parentSlug}:wt:${branch.replace(/\//g, "-")}`;
+}
+
+function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: WorktreeRowProps) {
+  const wtSlug = worktreeSlugFor(parentSlug, wt.branch);
+  const [devServer, setDevServer] = useState<DevServerState>({ running: false, loading: false });
+  const [serverAction, setServerAction] = useState<"starting" | "stopping" | null>(null);
+  const [syncState, setSyncState] = useState<Record<SyncFile, SyncState>>({
+    todos: { loading: false },
+    "manual-steps": { loading: false },
+    insights: { loading: false },
+  });
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  const refreshDevServer = useCallback(async () => {
+    setDevServer((s) => ({ ...s, loading: true }));
+    try {
+      const res = await fetch(`/api/dev-server/${encodeURIComponent(wtSlug)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setDevServer({ running: data.running === true, port: data.port, loading: false });
+      } else {
+        setDevServer({ running: false, loading: false });
+      }
+    } catch {
+      setDevServer({ running: false, loading: false });
+    }
+  }, [wtSlug]);
+
+  useEffect(() => { refreshDevServer(); }, [refreshDevServer]);
+
+  const handleStart = async () => {
+    setServerAction("starting");
+    try {
+      const res = await fetch(`/api/worktrees/${parentSlug}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "start-server", worktreePath: wt.worktreePath, parentDevPort }),
+      });
+      if (res.ok) await refreshDevServer();
+    } finally {
+      setServerAction(null);
+    }
+  };
+
+  const handleStop = async () => {
+    setServerAction("stopping");
+    try {
+      await fetch(`/api/dev-server/${encodeURIComponent(wtSlug)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "stop" }),
+      });
+      await refreshDevServer();
+    } finally {
+      setServerAction(null);
+    }
+  };
+
+  const handleSync = async (file: SyncFile) => {
+    setSyncState((s) => ({ ...s, [file]: { loading: true } }));
+    try {
+      const res = await fetch(`/api/worktrees/${parentSlug}/sync`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ worktreePath: wt.worktreePath, file }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSyncState((s) => ({ ...s, [file]: { loading: false, result: data.synced } }));
+      } else {
+        setSyncState((s) => ({ ...s, [file]: { loading: false, error: "Sync failed" } }));
+      }
+    } catch {
+      setSyncState((s) => ({ ...s, [file]: { loading: false, error: "Network error" } }));
+    }
+  };
+
+  const handleRemove = async () => {
+    setRemoving(true);
+    setRemoveError(null);
+    try {
+      const res = await fetch(`/api/worktrees/${parentSlug}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "remove", worktreePath: wt.worktreePath }),
+      });
+      if (res.ok) {
+        onRemoved();
+      } else {
+        const data = await res.json();
+        setRemoveError(data.error ?? "Remove failed");
+        setRemoving(false);
+      }
+    } catch {
+      setRemoveError("Network error");
+      setRemoving(false);
+    }
+  };
+
+  const lastCommit = status.lastCommitDate
+    ? new Date(status.lastCommitDate).toLocaleDateString()
+    : null;
+
+  const syncItems: { file: SyncFile; label: string; has: boolean }[] = [
+    { file: "todos", label: "TODOs", has: (wt.todos?.total ?? 0) > 0 },
+    { file: "manual-steps", label: "Manual Steps", has: (wt.manualSteps?.totalSteps ?? 0) > 0 },
+    { file: "insights", label: "Insights", has: (wt.insights?.total ?? 0) > 0 },
+  ];
+
+  return (
+    <div style={{ border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)", padding: "12px 14px" }}>
+      {/* Branch header */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "10px" }}>
+        <code style={{ fontSize: "0.78rem", color: "var(--text-primary)", background: "var(--bg-muted)", padding: "1px 6px", borderRadius: "3px" }}>
+          {wt.branch}
+        </code>
+        {lastCommit && <span style={{ fontSize: "0.7rem", color: "var(--text-muted)" }}>{lastCommit}</span>}
+        {status.isStale && (
+          <span style={{ fontSize: "0.68rem", color: "var(--accent)", fontWeight: 500, marginLeft: "auto" }}>Stale</span>
+        )}
+      </div>
+
+      {/* Dev server */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px" }}>
+        <span style={{ fontSize: "0.72rem", color: "var(--text-muted)", width: "80px" }}>Dev server</span>
+        {devServer.loading ? (
+          <span style={{ fontSize: "0.72rem", color: "var(--text-muted)" }}>…</span>
+        ) : devServer.running ? (
+          <>
+            <span style={{ fontSize: "0.72rem", color: "var(--success, #4ade80)", fontFamily: "var(--font-mono)" }}>
+              ● :{devServer.port}
+            </span>
+            <a
+              href={`http://localhost:${devServer.port}`}
+              target="_blank"
+              rel="noreferrer"
+              style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              localhost:{devServer.port}
+            </a>
+            <button
+              onClick={handleStop}
+              disabled={serverAction !== null}
+              style={{ fontSize: "0.7rem", padding: "1px 8px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}
+            >
+              {serverAction === "stopping" ? "…" : "Stop"}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={handleStart}
+            disabled={serverAction !== null}
+            style={{ fontSize: "0.7rem", padding: "1px 8px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
+          >
+            {serverAction === "starting" ? "Starting…" : "Start"}
+          </button>
+        )}
+      </div>
+
+      {/* Sync badges */}
+      {syncItems.some((s) => s.has) && (
+        <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginBottom: "8px" }}>
+          {syncItems.map(({ file, label, has }) => {
+            if (!has) return null;
+            const s = syncState[file];
+            const done = s.result !== undefined;
+            return (
+              <div key={file} style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                <span style={{
+                  fontSize: "0.68rem", padding: "1px 5px", borderRadius: "3px",
+                  background: done ? "color-mix(in srgb, var(--success, #4ade80) 15%, transparent)" : "var(--accent-muted, rgba(245,158,11,0.12))",
+                  color: done ? "var(--success, #4ade80)" : "var(--accent)",
+                }}>
+                  {done ? (s.result === 0 ? `${label} in sync` : `${label} +${s.result}`) : `${label} out of sync`}
+                </span>
+                {!done && (
+                  <button
+                    onClick={() => handleSync(file)}
+                    disabled={s.loading}
+                    style={{ fontSize: "0.68rem", padding: "1px 6px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
+                  >
+                    {s.loading ? "…" : "Sync to parent"}
+                  </button>
+                )}
+                {s.error && <span style={{ fontSize: "0.68rem", color: "var(--destructive)" }}>{s.error}</span>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Remove (stale only) */}
+      {status.isStale && !confirmRemove && (
+        <button
+          onClick={() => setConfirmRemove(true)}
+          style={{ fontSize: "0.7rem", padding: "2px 10px", borderRadius: "3px", border: "1px solid var(--destructive)", background: "transparent", color: "var(--destructive)", cursor: "pointer" }}
+        >
+          Remove worktree
+        </button>
+      )}
+      {confirmRemove && (
+        <div style={{ marginTop: "6px", padding: "10px", background: "var(--bg-muted)", borderRadius: "var(--radius)", fontSize: "0.75rem" }}>
+          <p style={{ margin: "0 0 6px", color: "var(--text-primary)" }}>
+            Remove <code>{wt.branch}</code>?
+            {status.uncommittedCount > 0 && (
+              <span style={{ color: "var(--accent)" }}> Has {status.uncommittedCount} uncommitted changes.</span>
+            )}
+            {lastCommit && <span> Last commit {lastCommit}.</span>}
+          </p>
+          {removeError && <p style={{ margin: "0 0 6px", color: "var(--destructive)" }}>{removeError}</p>}
+          <div style={{ display: "flex", gap: "6px" }}>
+            <button
+              onClick={handleRemove}
+              disabled={removing}
+              style={{ fontSize: "0.7rem", padding: "2px 10px", borderRadius: "3px", border: "none", background: "var(--destructive)", color: "white", cursor: "pointer" }}
+            >
+              {removing ? "Removing…" : "Confirm Remove"}
+            </button>
+            <button
+              onClick={() => { setConfirmRemove(false); setRemoveError(null); }}
+              disabled={removing}
+              style={{ fontSize: "0.7rem", padding: "2px 10px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WorktreePanel({ slug, devPort, worktrees }: WorktreePanelProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [statuses, setStatuses] = useState<WorktreeStatus[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatuses = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/worktrees/${slug}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setStatuses(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [slug]);
+
+  const handleExpand = () => {
+    if (!expanded && !statuses && !loading) fetchStatuses();
+    setExpanded((x) => !x);
+  };
+
+  if (!worktrees || worktrees.length === 0) return null;
+
+  return (
+    <div>
+      <button
+        onClick={handleExpand}
+        style={{ display: "flex", alignItems: "center", gap: "6px", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+      >
+        <span style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>{expanded ? "▾" : "▸"}</span>
+        <span style={{ fontSize: "0.85rem", fontWeight: 600, color: "var(--text-primary)" }}>
+          Worktrees ({worktrees.length})
+        </span>
+      </button>
+
+      {expanded && (
+        <div style={{ marginTop: "12px", display: "flex", flexDirection: "column", gap: "10px" }}>
+          {loading && <span style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>Loading…</span>}
+          {error && (
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <span style={{ fontSize: "0.8rem", color: "var(--destructive)" }}>{error}</span>
+              <button
+                onClick={fetchStatuses}
+                style={{ fontSize: "0.72rem", padding: "2px 8px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+          {statuses && worktrees.map((wt, i) => (
+            <WorktreeRow
+              key={wt.worktreePath}
+              wt={wt}
+              status={statuses[i]}
+              parentSlug={slug}
+              parentDevPort={devPort}
+              onRemoved={fetchStatuses}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build** — `npm run build 2>&1 | tail -5` — expect no type errors.
+
+- [ ] **Step 3: Commit** — `git add src/components/WorktreePanel.tsx && git commit -m "feat: add WorktreePanel component"`
+
+
+---
+
+## Task 9: Wire WorktreePanel into ProjectDetail.tsx
+
+**Files:** Modify `src/components/ProjectDetail.tsx`
+
+- [ ] **Step 1: Add import at the top of ProjectDetail.tsx** (after the existing imports, before the first component definition)
+
+Find the existing import block that includes `DevServerControl` (around line 7):
+```ts
+import { DevServerControl } from "./DevServerControl";
+```
+Add immediately after it:
+```ts
+import { WorktreePanel } from "./WorktreePanel";
+```
+
+- [ ] **Step 2: Add WorktreePanel in the Overview tab after DevServerControl**
+
+Find the `<DevServerControl` block in the overview tab (around line 548):
+```tsx
+              <DevServerControl
+                slug={project.slug}
+                projectPath={project.path}
+                devPort={devPort}
+              />
+```
+Add immediately after the closing `/>`:
+```tsx
+
+              {project.worktrees && project.worktrees.length > 0 && (
+                <WorktreePanel
+                  slug={project.slug}
+                  devPort={devPort}
+                  worktrees={project.worktrees}
+                />
+              )}
+```
+
+- [ ] **Step 3: Verify build** — `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit** — `git add src/components/ProjectDetail.tsx && git commit -m "feat: wire WorktreePanel into project overview"`
+
+
+---
+
+## Task 10: Add worktree count badge to ProjectCard.tsx
+
+**Files:** Modify `src/components/ProjectCard.tsx`
+
+The card already aggregates worktree counts for todos/steps/insights. Add a simple `wt N` badge near the dev server footer so users can see at a glance which cards have active worktrees.
+
+- [ ] **Step 1: Add worktreeCount variable after the existing `insightsTotal` block (around line 52)**
+
+Find this block:
+```ts
+  const hasAttention = pendingTodos > 0 || pendingSteps > 0;
+```
+Add before it:
+```ts
+  const worktreeCount = (project.worktrees ?? []).length;
+```
+
+- [ ] **Step 2: Add badge in the port/dev-server footer row**
+
+In the footer section, find the port info `<div>` containing `<PortEditor` (around line 228):
+```tsx
+            {/* Port info */}
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-secondary)" }}>
+                <PortEditor
+```
+Directly after the closing `</span>` of that PortEditor span (after the `{project.dbPort && ...}` block), before the closing `</div>` of the port info div, add:
+```tsx
+              {worktreeCount > 0 && (
+                <span
+                  style={{
+                    fontSize: "0.68rem",
+                    fontFamily: "var(--font-mono)",
+                    color: "#60a5fa",
+                    background: "rgba(96,165,250,0.12)",
+                    padding: "1px 5px",
+                    borderRadius: "3px",
+                  }}
+                >
+                  wt {worktreeCount}
+                </span>
+              )}
+```
+
+- [ ] **Step 3: Verify build** — `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit** — `git add src/components/ProjectCard.tsx && git commit -m "feat: add worktree count badge to project card"`
+
+
+---
+
+## Task 11: Final verification
+
+**Files:** None — run tests and manual browser validation.
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+npm test 2>&1 | tail -10
+```
+
+Expected: all tests pass, including the 3 new test files (`findFreePort`, `worktreeChecker`, `worktreeSync`). Total should be 13 test files.
+
+- [ ] **Step 2: Production build**
+
+```bash
+npm run build 2>&1 | tail -10
+```
+
+Expected: no TypeScript errors, no missing exports.
+
+- [ ] **Step 3: Start dev server and verify WorktreePanel**
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:4100` and navigate to a project that has worktrees (look for cards showing `wt N` blue badge).
+
+Verify on the project detail page:
+- [ ] Overview tab shows a "Worktrees (N)" collapsible section below DevServerControl
+- [ ] Clicking expands and shows a skeleton/loading state, then per-worktree rows
+- [ ] Each row shows branch name in monospace badge + last commit date
+- [ ] Dev server row shows Start button; clicking it starts a server on the next free port
+- [ ] When server running: shows green `● :PORT`, localhost link, Stop button
+- [ ] Sync badges appear for file types that have content in the worktree
+- [ ] "Sync to parent" button calls sync and shows `+N` or "in sync" result
+- [ ] Stale worktrees show amber "Stale" badge and "Remove worktree" button
+- [ ] Remove opens confirmation with branch name, last commit date, uncommitted count
+- [ ] Confirming remove calls git and refreshes the panel
+- [ ] Dashboard cards for projects with worktrees show blue `wt N` badge
+
+- [ ] **Step 4: Commit final state if any loose changes**
+
+```bash
+git status
+git add -A && git commit -m "feat: worktree support — dev server, sync, stale cleanup"
+```
+

--- a/docs/superpowers/specs/2026-04-15-worktree-support-design.md
+++ b/docs/superpowers/specs/2026-04-15-worktree-support-design.md
@@ -1,0 +1,146 @@
+# Worktree Support Design
+
+**Date:** 2026-04-15  
+**Branch:** feature/worktree-support  
+**Status:** Approved
+
+## Problem
+
+Project Minder already discovers Claude Code worktrees (`--claude-worktrees-` naming convention) and surfaces their markdown files as read-only overlays. Three gaps remain:
+
+1. **Dev server**: Running the dev server from a worktree requires the user to manually `cd` there and start it. Project Minder has no awareness of worktree dev servers.
+2. **Markdown file conflicts**: TODO.md, INSIGHTS.md, and MANUAL_STEPS.md are written independently in worktrees and can conflict on merge. No tooling exists to pre-sync these before merging.
+3. **Stale worktrees**: After a branch is merged and the PR closed, the local worktree directory persists. Users have no visibility into stale worktrees and no in-app cleanup path.
+
+## Approach
+
+**Option B — Separate worktree status API (chosen)**
+
+Keep `WorktreeOverlay` lean. Add a new on-demand `/api/worktrees/[slug]` route that runs git checks lazily when the user expands a worktree section. Dev server control reuses the existing `processManager` with a worktree-specific slug convention. This mirrors the existing `gitStatusCache` pattern and keeps the main scan fast.
+
+Rejected alternatives:
+- **Option A** (fat `WorktreeOverlay`): Couples slow git network ops to the main scan path.
+- **Option C** (background polling cache): More complexity before knowing usage patterns; can be added later as an optimization.
+
+## Data Model
+
+### New type: `WorktreeStatus` (add to `src/lib/types.ts`)
+
+```ts
+interface WorktreeStatus {
+  worktreePath: string;
+  branch: string;
+  isDirty: boolean;
+  uncommittedCount: number;
+  isMergedLocally: boolean;       // git branch --merged main
+  isRemoteBranchDeleted: boolean; // git ls-remote --heads origin <branch> returns empty
+  isStale: boolean;               // true when isMergedLocally && isRemoteBranchDeleted
+  lastCommitDate?: string;
+  devServer?: DevServerInfo;      // injected from processManager if a server is running
+}
+```
+
+### `WorktreeOverlay` — no changes
+
+The existing type (`branch`, `worktreePath`, `todos`, `manualSteps`, `insights`) stays as-is. `WorktreeStatus` is fetched separately on demand.
+
+## API Routes
+
+### `GET /api/worktrees/[slug]`
+
+Returns `WorktreeStatus[]` for all worktrees attached to the given project slug.
+
+Per worktree, runs in parallel:
+- `git branch --merged main` (from parent project path) → `isMergedLocally`
+- `git ls-remote --heads origin <branch>` → `isRemoteBranchDeleted` (empty output = deleted)
+- `git status --porcelain` (in worktree path) → `isDirty`, `uncommittedCount`
+- `git log -1 --format=%aI` (in worktree path) → `lastCommitDate`
+
+Injects live `processManager.get(worktreeSlug)` as `devServer` if present.
+
+**Offline/timeout handling:** If `git ls-remote` times out or fails, `isRemoteBranchDeleted` defaults to `false` and `isStale` stays `false` — no false positives when offline.
+
+### `POST /api/worktrees/[slug]`
+
+Body actions:
+
+**`start-server`**
+```json
+{ "action": "start-server", "worktreePath": "/abs/path", "port": null }
+```
+- Slug convention: `{parentSlug}:wt:{branchHint}` (e.g. `project-minder:wt:feature-worktree-support`)
+- Port auto-find: start at `parentDevPort + 1`, increment via existing `isPortInUse()`, cap at 10 attempts
+- Delegates to `processManager.start(worktreeSlug, worktreePath, resolvedPort)`
+
+**`remove`**
+```json
+{ "action": "remove", "worktreePath": "/abs/path" }
+```
+- Only permitted when `isStale: true` (enforced server-side)
+- Runs `git worktree remove <worktreePath>` from parent project path
+- If git refuses (uncommitted changes), returns 409 with git's error message — never force-removes
+
+### `POST /api/worktrees/[slug]/sync`
+
+```json
+{ "worktreePath": "/abs/path", "file": "todos" | "manual-steps" | "insights" }
+```
+
+Reads both the parent file and worktree file. Diffs entries:
+- **Insights**: by `InsightEntry.id` (content hash, already used)
+- **TODOs**: by item text
+- **Manual steps**: by entry header (`## date | slug | title`)
+
+Appends worktree-only entries to the parent file using existing writers (`todoWriter`, `manualStepsWriter`, `insightsWriter`). Append-only — never overwrites or reorders existing parent content.
+
+## UI
+
+### `WorktreePanel` component (replaces `WorktreeSection`)
+
+Location: project detail page, shown per-worktree when the project has `worktrees`.
+
+**Loading**: Fetches `/api/worktrees/[slug]` on first expand (lazy). Shows skeleton while loading.
+
+**Per worktree row:**
+
+- Branch name badge (monospace) + last commit date
+- **Dev server**: compact `DevServerControl` reused with worktree slug and `projectPath = worktreePath`. Shows `● :4101` when running, Start button when stopped, `localhost:4101` link when running.
+- **Sync indicators**: per-file badges for TODO, Manual Steps, Insights. Each shows "out of sync" (amber) when worktree has entries not in parent, "in sync" (green) after sync. Each has a "Sync to parent" button.
+- **Staleness**: amber "Stale" badge when `isStale: true`. "Remove worktree" button opens confirmation modal showing branch, last commit date, and uncommitted count (safety check even though stale implies 0). Confirmed action calls `POST /api/worktrees/[slug]` `remove`.
+
+**Error states:**
+- Status fetch failure → inline retry button
+- Sync error → inline error next to badge
+- Remove error → shown in confirmation modal (e.g. git refused due to uncommitted changes)
+
+### Project card additions (minimal)
+
+- Blue `wt` dot alongside dev server badge if any worktree server is running
+- Amber `N stale` badge if any worktrees are stale (count)
+
+These are additive — no changes to existing card layout.
+
+### No new page
+
+All worktree management lives in the existing project detail view. The worktree section is already rendered in `ProjectDetail.tsx`.
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `src/lib/types.ts` | Add `WorktreeStatus` interface |
+| `src/app/api/worktrees/[slug]/route.ts` | New: GET + POST handlers |
+| `src/app/api/worktrees/[slug]/sync/route.ts` | New: POST sync handler |
+| `src/components/WorktreePanel.tsx` | New: management UI (dev server, sync, staleness) for Overview tab |
+| `src/components/WorktreeSection.tsx` | No changes — stays as collapsible content display in TODO/Manual Steps/Insights tabs |
+| `src/components/ProjectDetail.tsx` | Wire `WorktreePanel` into Overview tab |
+| `src/components/ProjectCard.tsx` | Add `wt` dot + stale badge |
+| `src/lib/scanner/worktrees.ts` | No changes needed |
+| `src/lib/processManager.ts` | No changes needed (worktree slug is transparent to it) |
+
+## Out of Scope
+
+- Automatic merge/rebase of worktree branches (git operations beyond `worktree remove`)
+- Worktree creation from within Project Minder
+- Background polling of worktree status (can be added later as Option C optimization)
+- Support for non-Claude-Code worktrees (`.worktrees/` internal dev worktrees)

--- a/src/app/api/worktrees/[slug]/route.ts
+++ b/src/app/api/worktrees/[slug]/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import { getCachedScan } from "@/lib/cache";
 import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+import { processManager, findFreePort } from "@/lib/processManager";
+
+const execFileAsync = promisify(execFile);
 
 export async function GET(
   _req: NextRequest,
@@ -20,4 +25,51 @@ export async function GET(
     )
   );
   return NextResponse.json(statuses);
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const body = (await req.json()) as {
+    action: "start-server" | "remove";
+    worktreePath: string;
+    parentDevPort?: number;
+  };
+
+  const scan = getCachedScan();
+  if (!scan) return NextResponse.json({ error: "Scan cache not ready" }, { status: 503 });
+  const project = scan.projects.find((p) => p.slug === slug);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  const wt = project.worktrees?.find((w) => w.worktreePath === body.worktreePath);
+  if (!wt) return NextResponse.json({ error: "Worktree not found" }, { status: 404 });
+
+  const worktreeSlug = `${slug}:wt:${wt.branch.replace(/\//g, "-")}`;
+
+  if (body.action === "start-server") {
+    const startPort = (body.parentDevPort ?? project.devPort ?? 3000) + 1;
+    const port = await findFreePort(startPort);
+    if (!port) return NextResponse.json({ error: `No free port from ${startPort}` }, { status: 409 });
+    const info = await processManager.start(worktreeSlug, body.worktreePath, port);
+    return NextResponse.json({ ...info, resolvedPort: port });
+  }
+
+  if (body.action === "remove") {
+    const status = await checkWorktreeStatus(project.path, body.worktreePath, wt.branch, worktreeSlug);
+    if (!status.isStale) {
+      return NextResponse.json({ error: "Worktree is not stale — cannot remove automatically" }, { status: 400 });
+    }
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        "git", ["worktree", "remove", body.worktreePath],
+        { cwd: project.path, timeout: 10000 }
+      );
+      return NextResponse.json({ removed: true, output: stdout || stderr });
+    } catch (err: unknown) {
+      return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 409 });
+    }
+  }
+
+  return NextResponse.json({ error: "Unknown action" }, { status: 400 });
 }

--- a/src/app/api/worktrees/[slug]/route.ts
+++ b/src/app/api/worktrees/[slug]/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCachedScan } from "@/lib/cache";
+import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const scan = getCachedScan();
+  if (!scan) return NextResponse.json({ error: "Scan cache not ready" }, { status: 503 });
+  const project = scan.projects.find((p) => p.slug === slug);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  if (!project.worktrees || project.worktrees.length === 0) return NextResponse.json([]);
+
+  const worktreeSlugFor = (branch: string) => `${slug}:wt:${branch.replace(/\//g, "-")}`;
+  const statuses = await Promise.all(
+    project.worktrees.map((wt) =>
+      checkWorktreeStatus(project.path, wt.worktreePath, wt.branch, worktreeSlugFor(wt.branch))
+    )
+  );
+  return NextResponse.json(statuses);
+}

--- a/src/app/api/worktrees/[slug]/route.ts
+++ b/src/app/api/worktrees/[slug]/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { getCachedScan } from "@/lib/cache";
-import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+import { checkWorktreeStatus, checkAllWorktreeStatuses } from "@/lib/worktreeChecker";
+import { worktreeSlug } from "@/lib/worktreeUtils";
 import { processManager, findFreePort } from "@/lib/processManager";
 
 const execFileAsync = promisify(execFile);
@@ -18,12 +19,7 @@ export async function GET(
   if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
   if (!project.worktrees || project.worktrees.length === 0) return NextResponse.json([]);
 
-  const worktreeSlugFor = (branch: string) => `${slug}:wt:${branch.replace(/\//g, "-")}`;
-  const statuses = await Promise.all(
-    project.worktrees.map((wt) =>
-      checkWorktreeStatus(project.path, wt.worktreePath, wt.branch, worktreeSlugFor(wt.branch))
-    )
-  );
+  const statuses = await checkAllWorktreeStatuses(project.path, project.worktrees);
   return NextResponse.json(statuses);
 }
 
@@ -45,18 +41,18 @@ export async function POST(
   const wt = project.worktrees?.find((w) => w.worktreePath === body.worktreePath);
   if (!wt) return NextResponse.json({ error: "Worktree not found" }, { status: 404 });
 
-  const worktreeSlug = `${slug}:wt:${wt.branch.replace(/\//g, "-")}`;
+  const wtSlug = worktreeSlug(slug, wt.branch);
 
   if (body.action === "start-server") {
     const startPort = (body.parentDevPort ?? project.devPort ?? 3000) + 1;
     const port = await findFreePort(startPort);
     if (!port) return NextResponse.json({ error: `No free port from ${startPort}` }, { status: 409 });
-    const info = await processManager.start(worktreeSlug, body.worktreePath, port);
+    const info = await processManager.start(wtSlug, body.worktreePath, port);
     return NextResponse.json({ ...info, resolvedPort: port });
   }
 
   if (body.action === "remove") {
-    const status = await checkWorktreeStatus(project.path, body.worktreePath, wt.branch, worktreeSlug);
+    const status = await checkWorktreeStatus(project.path, body.worktreePath, wt.branch);
     if (!status.isStale) {
       return NextResponse.json({ error: "Worktree is not stale — cannot remove automatically" }, { status: 400 });
     }

--- a/src/app/api/worktrees/[slug]/route.ts
+++ b/src/app/api/worktrees/[slug]/route.ts
@@ -44,7 +44,11 @@ export async function POST(
   const wtSlug = worktreeSlug(slug, wt.branch);
 
   if (body.action === "start-server") {
-    const startPort = (body.parentDevPort ?? project.devPort ?? 3000) + 1;
+    const rawPort = body.parentDevPort ?? project.devPort ?? 3000;
+    if (!Number.isInteger(rawPort) || rawPort < 1 || rawPort > 65534) {
+      return NextResponse.json({ error: "Invalid parentDevPort" }, { status: 400 });
+    }
+    const startPort = rawPort + 1;
     const port = await findFreePort(startPort);
     if (!port) return NextResponse.json({ error: `No free port from ${startPort}` }, { status: 409 });
     const info = await processManager.start(wtSlug, body.worktreePath, port);
@@ -63,7 +67,13 @@ export async function POST(
       );
       return NextResponse.json({ removed: true, output: stdout || stderr });
     } catch (err: unknown) {
-      return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 409 });
+      // execFileAsync error objects carry stdout/stderr — prefer that for actionable git messages
+      const gitMsg =
+        err && typeof err === "object" && "stderr" in err
+          ? String((err as { stderr: string }).stderr).trim()
+          : "";
+      const fallback = err instanceof Error ? err.message : String(err);
+      return NextResponse.json({ error: gitMsg || fallback }, { status: 409 });
     }
   }
 

--- a/src/app/api/worktrees/[slug]/sync/route.ts
+++ b/src/app/api/worktrees/[slug]/sync/route.ts
@@ -31,6 +31,9 @@ export async function POST(
   const project = scan.projects.find((p) => p.slug === slug);
   if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
 
+  const wt = project.worktrees?.find((w) => w.worktreePath === body.worktreePath);
+  if (!wt) return NextResponse.json({ error: "Worktree not found" }, { status: 404 });
+
   if (body.file === "todos") {
     const [parentInfo, worktreeInfo] = await Promise.all([
       scanTodoMd(project.path),

--- a/src/app/api/worktrees/[slug]/sync/route.ts
+++ b/src/app/api/worktrees/[slug]/sync/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { getCachedScan } from "@/lib/cache";
+import { scanTodoMd } from "@/lib/scanner/todoMd";
+import { scanManualStepsMd } from "@/lib/scanner/manualStepsMd";
+import { scanInsightsMd, parseInsightsMd, appendInsights } from "@/lib/scanner/insightsMd";
+import { appendTodosToFile } from "@/lib/todoWriter";
+import { diffTodos, diffManualSteps, diffInsights } from "@/lib/worktreeSync";
+import { ManualStepEntry } from "@/lib/types";
+
+function entryToMarkdown(entry: ManualStepEntry): string {
+  const steps = entry.steps
+    .map((step) => {
+      const checkbox = step.completed ? "- [x]" : "- [ ]";
+      const details = step.details.map((d) => `  ${d}`).join("\n");
+      return details ? `${checkbox} ${step.text}\n${details}` : `${checkbox} ${step.text}`;
+    })
+    .join("\n");
+  return `## ${entry.date} | ${entry.featureSlug} | ${entry.title}\n\n${steps}\n\n---\n`;
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const body = (await req.json()) as { worktreePath: string; file: "todos" | "manual-steps" | "insights" };
+  const scan = getCachedScan();
+  if (!scan) return NextResponse.json({ error: "Scan cache not ready" }, { status: 503 });
+  const project = scan.projects.find((p) => p.slug === slug);
+  if (!project) return NextResponse.json({ error: "Project not found" }, { status: 404 });
+
+  if (body.file === "todos") {
+    const [parentInfo, worktreeInfo] = await Promise.all([
+      scanTodoMd(project.path),
+      scanTodoMd(body.worktreePath),
+    ]);
+    const newTexts = diffTodos(parentInfo?.items ?? [], worktreeInfo?.items ?? []);
+    if (newTexts.length === 0) return NextResponse.json({ synced: 0 });
+    await appendTodosToFile(project.path, newTexts);
+    return NextResponse.json({ synced: newTexts.length });
+  }
+
+  if (body.file === "manual-steps") {
+    const [parentInfo, worktreeInfo] = await Promise.all([
+      scanManualStepsMd(project.path),
+      scanManualStepsMd(body.worktreePath),
+    ]);
+    const newEntries = diffManualSteps(parentInfo?.entries ?? [], worktreeInfo?.entries ?? []);
+    if (newEntries.length === 0) return NextResponse.json({ synced: 0 });
+    const filePath = path.join(project.path, "MANUAL_STEPS.md");
+    let existing = "";
+    try {
+      existing = await fs.readFile(filePath, "utf-8");
+    } catch {
+      /* new file */
+    }
+    const sep = existing.trimEnd() ? "\n\n" : "";
+    await fs.writeFile(
+      filePath,
+      existing.trimEnd() + sep + newEntries.map(entryToMarkdown).join("\n"),
+      "utf-8"
+    );
+    return NextResponse.json({ synced: newEntries.length });
+  }
+
+  if (body.file === "insights") {
+    const worktreeInfo = await scanInsightsMd(body.worktreePath);
+    if (!worktreeInfo || worktreeInfo.entries.length === 0) return NextResponse.json({ synced: 0 });
+    let parentContent = "";
+    try {
+      parentContent = await fs.readFile(path.join(project.path, "INSIGHTS.md"), "utf-8");
+    } catch {
+      /* new file */
+    }
+    const { knownIds } = parseInsightsMd(parentContent);
+    const newEntries = diffInsights(knownIds, worktreeInfo.entries);
+    if (newEntries.length === 0) return NextResponse.json({ synced: 0 });
+    await appendInsights(project.path, newEntries);
+    return NextResponse.json({ synced: newEntries.length });
+  }
+
+  return NextResponse.json({ error: "Unknown file type" }, { status: 400 });
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -51,6 +51,7 @@ export function ProjectCard({ project, onHide }: ProjectCardProps) {
     return main + wt;
   })();
 
+  const worktreeCount = (project.worktrees ?? []).length;
   const hasAttention = pendingTodos > 0 || pendingSteps > 0;
   const isArchived   = project.status === "archived";
 
@@ -244,6 +245,20 @@ export function ProjectCard({ project, onHide }: ProjectCardProps) {
                 >
                   <Database style={{ width: "10px", height: "10px" }} />
                   {project.dbPort}
+                </span>
+              )}
+              {worktreeCount > 0 && (
+                <span
+                  style={{
+                    fontSize: "0.68rem",
+                    fontFamily: "var(--font-mono)",
+                    color: "#60a5fa",
+                    background: "rgba(96,165,250,0.12)",
+                    padding: "1px 5px",
+                    borderRadius: "3px",
+                  }}
+                >
+                  wt {worktreeCount}
                 </span>
               )}
             </div>

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -5,6 +5,7 @@ import { ProjectData, ProjectStatus, TodoInfo } from "@/lib/types";
 import { StatusSelector } from "./StatusBadge";
 import { TodoList, AddTodoForm } from "./TodoList";
 import { DevServerControl } from "./DevServerControl";
+import { WorktreePanel } from "./WorktreePanel";
 import { PortEditor } from "./PortEditor";
 import { ManualStepsList } from "./ManualStepsList";
 import { InsightsTab } from "./InsightsTab";
@@ -550,6 +551,14 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
                 projectPath={project.path}
                 devPort={devPort}
               />
+
+              {project.worktrees && project.worktrees.length > 0 && (
+                <WorktreePanel
+                  slug={project.slug}
+                  devPort={devPort}
+                  worktrees={project.worktrees}
+                />
+              )}
 
               {/* Git */}
               {project.git && (

--- a/src/components/WorktreePanel.tsx
+++ b/src/components/WorktreePanel.tsx
@@ -58,7 +58,7 @@ function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: Workt
   const handleStart = async () => {
     setServerAction("starting");
     try {
-      const res = await fetch(`/api/worktrees/${parentSlug}`, {
+      const res = await fetch(`/api/worktrees/${encodeURIComponent(parentSlug)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action: "start-server", worktreePath: wt.worktreePath, parentDevPort }),
@@ -86,7 +86,7 @@ function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: Workt
   const handleSync = async (file: SyncFile) => {
     setSyncState((s) => ({ ...s, [file]: { loading: true } }));
     try {
-      const res = await fetch(`/api/worktrees/${parentSlug}/sync`, {
+      const res = await fetch(`/api/worktrees/${encodeURIComponent(parentSlug)}/sync`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ worktreePath: wt.worktreePath, file }),
@@ -106,7 +106,7 @@ function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: Workt
     setRemoving(true);
     setRemoveError(null);
     try {
-      const res = await fetch(`/api/worktrees/${parentSlug}`, {
+      const res = await fetch(`/api/worktrees/${encodeURIComponent(parentSlug)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action: "remove", worktreePath: wt.worktreePath }),
@@ -268,7 +268,7 @@ export function WorktreePanel({ slug, devPort, worktrees }: WorktreePanelProps) 
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/worktrees/${slug}`);
+      const res = await fetch(`/api/worktrees/${encodeURIComponent(slug)}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setStatuses(await res.json());
     } catch (e) {
@@ -311,16 +311,20 @@ export function WorktreePanel({ slug, devPort, worktrees }: WorktreePanelProps) 
               </button>
             </div>
           )}
-          {statuses && worktrees.map((wt, i) => (
-            <WorktreeRow
-              key={wt.worktreePath}
-              wt={wt}
-              status={statuses[i]}
-              parentSlug={slug}
-              parentDevPort={devPort}
-              onRemoved={fetchStatuses}
-            />
-          ))}
+          {statuses && worktrees.map((wt) => {
+            const status = statuses.find((s) => s.worktreePath === wt.worktreePath);
+            if (!status) return null;
+            return (
+              <WorktreeRow
+                key={wt.worktreePath}
+                wt={wt}
+                status={status}
+                parentSlug={slug}
+                parentDevPort={devPort}
+                onRemoved={fetchStatuses}
+              />
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/WorktreePanel.tsx
+++ b/src/components/WorktreePanel.tsx
@@ -19,7 +19,7 @@ interface WorktreeRowProps {
   status: WorktreeStatus;
   parentSlug: string;
   parentDevPort?: number;
-  onRemoved: () => void;
+  onRemoved: (worktreePath: string) => void;
 }
 
 function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: WorktreeRowProps) {
@@ -109,7 +109,7 @@ function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: Workt
         body: JSON.stringify({ action: "remove", worktreePath: wt.worktreePath }),
       });
       if (res.ok) {
-        onRemoved();
+        onRemoved(wt.worktreePath);
       } else {
         const data = await res.json();
         setRemoveError(data.error ?? "Remove failed");
@@ -125,6 +125,8 @@ function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: Workt
     ? new Date(status.lastCommitDate).toLocaleDateString()
     : null;
 
+  // Show sync controls for any file type the worktree has content for.
+  // We don't assert "out of sync" before syncing — the sync result tells us how many were new.
   const syncItems: { file: SyncFile; label: string; has: boolean }[] = [
     { file: "todos", label: "TODOs", has: (wt.todos?.total ?? 0) > 0 },
     { file: "manual-steps", label: "Manual Steps", has: (wt.manualSteps?.totalSteps ?? 0) > 0 },
@@ -182,7 +184,7 @@ function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: Workt
         )}
       </div>
 
-      {/* Sync badges */}
+      {/* Sync controls — button always shown for worktrees with content; result shown after sync */}
       {syncItems.some((s) => s.has) && (
         <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginBottom: "8px" }}>
           {syncItems.map(({ file, label, has }) => {
@@ -191,20 +193,20 @@ function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: Workt
             const done = s.result !== undefined;
             return (
               <div key={file} style={{ display: "flex", alignItems: "center", gap: "4px" }}>
-                <span style={{
-                  fontSize: "0.68rem", padding: "1px 5px", borderRadius: "3px",
-                  background: done ? "rgba(74,222,128,0.12)" : "rgba(245,158,11,0.12)",
-                  color: done ? "#4ade80" : "var(--accent)",
-                }}>
-                  {done ? (s.result === 0 ? `${label} in sync` : `${label} +${s.result}`) : `${label} out of sync`}
-                </span>
-                {!done && (
+                {done ? (
+                  <span style={{
+                    fontSize: "0.68rem", padding: "1px 5px", borderRadius: "3px",
+                    background: "rgba(74,222,128,0.12)", color: "#4ade80",
+                  }}>
+                    {s.result === 0 ? `${label} in sync` : `${label} +${s.result} synced`}
+                  </span>
+                ) : (
                   <button
                     onClick={() => handleSync(file)}
                     disabled={s.loading}
                     style={{ fontSize: "0.68rem", padding: "1px 6px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
                   >
-                    {s.loading ? "…" : "Sync to parent"}
+                    {s.loading ? "…" : `Sync ${label}`}
                   </button>
                 )}
                 {s.error && <span style={{ fontSize: "0.68rem", color: "var(--destructive)" }}>{s.error}</span>}
@@ -260,6 +262,7 @@ export function WorktreePanel({ slug, devPort, worktrees }: WorktreePanelProps) 
   const [statuses, setStatuses] = useState<WorktreeStatus[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [removedPaths, setRemovedPaths] = useState<Set<string>>(new Set());
 
   const fetchStatuses = useCallback(async () => {
     setLoading(true);
@@ -308,20 +311,22 @@ export function WorktreePanel({ slug, devPort, worktrees }: WorktreePanelProps) 
               </button>
             </div>
           )}
-          {statuses && worktrees.map((wt) => {
-            const status = statuses.find((s) => s.worktreePath === wt.worktreePath);
-            if (!status) return null;
-            return (
-              <WorktreeRow
-                key={wt.worktreePath}
-                wt={wt}
-                status={status}
-                parentSlug={slug}
-                parentDevPort={devPort}
-                onRemoved={fetchStatuses}
-              />
-            );
-          })}
+          {statuses && worktrees
+            .filter((wt) => !removedPaths.has(wt.worktreePath))
+            .map((wt) => {
+              const status = statuses.find((s) => s.worktreePath === wt.worktreePath);
+              if (!status) return null;
+              return (
+                <WorktreeRow
+                  key={wt.worktreePath}
+                  wt={wt}
+                  status={status}
+                  parentSlug={slug}
+                  parentDevPort={devPort}
+                  onRemoved={(path) => setRemovedPaths((prev) => new Set([...prev, path]))}
+                />
+              );
+            })}
         </div>
       )}
     </div>

--- a/src/components/WorktreePanel.tsx
+++ b/src/components/WorktreePanel.tsx
@@ -1,0 +1,328 @@
+"use client";
+import { useState, useCallback, useEffect } from "react";
+import { WorktreeOverlay, WorktreeStatus } from "@/lib/types";
+
+interface WorktreePanelProps {
+  slug: string;
+  devPort?: number;
+  worktrees: WorktreeOverlay[];
+}
+
+type SyncFile = "todos" | "manual-steps" | "insights";
+
+interface DevServerState { running: boolean; port?: number; loading: boolean; }
+interface SyncState { loading: boolean; result?: number; error?: string; }
+
+interface WorktreeRowProps {
+  wt: WorktreeOverlay;
+  status: WorktreeStatus;
+  parentSlug: string;
+  parentDevPort?: number;
+  onRemoved: () => void;
+}
+
+function worktreeSlugFor(parentSlug: string, branch: string) {
+  return `${parentSlug}:wt:${branch.replace(/\//g, "-")}`;
+}
+
+function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: WorktreeRowProps) {
+  const wtSlug = worktreeSlugFor(parentSlug, wt.branch);
+  const [devServer, setDevServer] = useState<DevServerState>({ running: false, loading: false });
+  const [serverAction, setServerAction] = useState<"starting" | "stopping" | null>(null);
+  const [syncState, setSyncState] = useState<Record<SyncFile, SyncState>>({
+    todos: { loading: false },
+    "manual-steps": { loading: false },
+    insights: { loading: false },
+  });
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const [removeError, setRemoveError] = useState<string | null>(null);
+
+  const refreshDevServer = useCallback(async () => {
+    setDevServer((s) => ({ ...s, loading: true }));
+    try {
+      const res = await fetch(`/api/dev-server/${encodeURIComponent(wtSlug)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setDevServer({ running: data.running === true, port: data.port, loading: false });
+      } else {
+        setDevServer({ running: false, loading: false });
+      }
+    } catch {
+      setDevServer({ running: false, loading: false });
+    }
+  }, [wtSlug]);
+
+  useEffect(() => { refreshDevServer(); }, [refreshDevServer]);
+
+  const handleStart = async () => {
+    setServerAction("starting");
+    try {
+      const res = await fetch(`/api/worktrees/${parentSlug}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "start-server", worktreePath: wt.worktreePath, parentDevPort }),
+      });
+      if (res.ok) await refreshDevServer();
+    } finally {
+      setServerAction(null);
+    }
+  };
+
+  const handleStop = async () => {
+    setServerAction("stopping");
+    try {
+      await fetch(`/api/dev-server/${encodeURIComponent(wtSlug)}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "stop" }),
+      });
+      await refreshDevServer();
+    } finally {
+      setServerAction(null);
+    }
+  };
+
+  const handleSync = async (file: SyncFile) => {
+    setSyncState((s) => ({ ...s, [file]: { loading: true } }));
+    try {
+      const res = await fetch(`/api/worktrees/${parentSlug}/sync`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ worktreePath: wt.worktreePath, file }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSyncState((s) => ({ ...s, [file]: { loading: false, result: data.synced } }));
+      } else {
+        setSyncState((s) => ({ ...s, [file]: { loading: false, error: "Sync failed" } }));
+      }
+    } catch {
+      setSyncState((s) => ({ ...s, [file]: { loading: false, error: "Network error" } }));
+    }
+  };
+
+  const handleRemove = async () => {
+    setRemoving(true);
+    setRemoveError(null);
+    try {
+      const res = await fetch(`/api/worktrees/${parentSlug}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "remove", worktreePath: wt.worktreePath }),
+      });
+      if (res.ok) {
+        onRemoved();
+      } else {
+        const data = await res.json();
+        setRemoveError(data.error ?? "Remove failed");
+        setRemoving(false);
+      }
+    } catch {
+      setRemoveError("Network error");
+      setRemoving(false);
+    }
+  };
+
+  const lastCommit = status.lastCommitDate
+    ? new Date(status.lastCommitDate).toLocaleDateString()
+    : null;
+
+  const syncItems: { file: SyncFile; label: string; has: boolean }[] = [
+    { file: "todos", label: "TODOs", has: (wt.todos?.total ?? 0) > 0 },
+    { file: "manual-steps", label: "Manual Steps", has: (wt.manualSteps?.totalSteps ?? 0) > 0 },
+    { file: "insights", label: "Insights", has: (wt.insights?.total ?? 0) > 0 },
+  ];
+
+  return (
+    <div style={{ border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)", padding: "12px 14px" }}>
+      {/* Branch header */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "10px" }}>
+        <code style={{ fontSize: "0.78rem", color: "var(--text-primary)", background: "var(--bg-muted)", padding: "1px 6px", borderRadius: "3px" }}>
+          {wt.branch}
+        </code>
+        {lastCommit && <span style={{ fontSize: "0.7rem", color: "var(--text-muted)" }}>{lastCommit}</span>}
+        {status.isStale && (
+          <span style={{ fontSize: "0.68rem", color: "var(--accent)", fontWeight: 500, marginLeft: "auto" }}>Stale</span>
+        )}
+      </div>
+
+      {/* Dev server */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "8px" }}>
+        <span style={{ fontSize: "0.72rem", color: "var(--text-muted)", width: "80px" }}>Dev server</span>
+        {devServer.loading ? (
+          <span style={{ fontSize: "0.72rem", color: "var(--text-muted)" }}>…</span>
+        ) : devServer.running ? (
+          <>
+            <span style={{ fontSize: "0.72rem", color: "#4ade80", fontFamily: "var(--font-mono)" }}>
+              ● :{devServer.port}
+            </span>
+            <a
+              href={`http://localhost:${devServer.port}`}
+              target="_blank"
+              rel="noreferrer"
+              style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              localhost:{devServer.port}
+            </a>
+            <button
+              onClick={handleStop}
+              disabled={serverAction !== null}
+              style={{ fontSize: "0.7rem", padding: "1px 8px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}
+            >
+              {serverAction === "stopping" ? "…" : "Stop"}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={handleStart}
+            disabled={serverAction !== null}
+            style={{ fontSize: "0.7rem", padding: "1px 8px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
+          >
+            {serverAction === "starting" ? "Starting…" : "Start"}
+          </button>
+        )}
+      </div>
+
+      {/* Sync badges */}
+      {syncItems.some((s) => s.has) && (
+        <div style={{ display: "flex", gap: "6px", flexWrap: "wrap", marginBottom: "8px" }}>
+          {syncItems.map(({ file, label, has }) => {
+            if (!has) return null;
+            const s = syncState[file];
+            const done = s.result !== undefined;
+            return (
+              <div key={file} style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                <span style={{
+                  fontSize: "0.68rem", padding: "1px 5px", borderRadius: "3px",
+                  background: done ? "rgba(74,222,128,0.12)" : "rgba(245,158,11,0.12)",
+                  color: done ? "#4ade80" : "var(--accent)",
+                }}>
+                  {done ? (s.result === 0 ? `${label} in sync` : `${label} +${s.result}`) : `${label} out of sync`}
+                </span>
+                {!done && (
+                  <button
+                    onClick={() => handleSync(file)}
+                    disabled={s.loading}
+                    style={{ fontSize: "0.68rem", padding: "1px 6px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
+                  >
+                    {s.loading ? "…" : "Sync to parent"}
+                  </button>
+                )}
+                {s.error && <span style={{ fontSize: "0.68rem", color: "var(--destructive)" }}>{s.error}</span>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Remove (stale only) */}
+      {status.isStale && !confirmRemove && (
+        <button
+          onClick={() => setConfirmRemove(true)}
+          style={{ fontSize: "0.7rem", padding: "2px 10px", borderRadius: "3px", border: "1px solid var(--destructive)", background: "transparent", color: "var(--destructive)", cursor: "pointer" }}
+        >
+          Remove worktree
+        </button>
+      )}
+      {confirmRemove && (
+        <div style={{ marginTop: "6px", padding: "10px", background: "var(--bg-muted)", borderRadius: "var(--radius)", fontSize: "0.75rem" }}>
+          <p style={{ margin: "0 0 6px", color: "var(--text-primary)" }}>
+            Remove <code>{wt.branch}</code>?
+            {status.uncommittedCount > 0 && (
+              <span style={{ color: "var(--accent)" }}> Has {status.uncommittedCount} uncommitted changes.</span>
+            )}
+            {lastCommit && <span> Last commit {lastCommit}.</span>}
+          </p>
+          {removeError && <p style={{ margin: "0 0 6px", color: "var(--destructive)" }}>{removeError}</p>}
+          <div style={{ display: "flex", gap: "6px" }}>
+            <button
+              onClick={handleRemove}
+              disabled={removing}
+              style={{ fontSize: "0.7rem", padding: "2px 10px", borderRadius: "3px", border: "none", background: "var(--destructive)", color: "white", cursor: "pointer" }}
+            >
+              {removing ? "Removing…" : "Confirm Remove"}
+            </button>
+            <button
+              onClick={() => { setConfirmRemove(false); setRemoveError(null); }}
+              disabled={removing}
+              style={{ fontSize: "0.7rem", padding: "2px 10px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-muted)", cursor: "pointer" }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WorktreePanel({ slug, devPort, worktrees }: WorktreePanelProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [statuses, setStatuses] = useState<WorktreeStatus[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatuses = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/worktrees/${slug}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setStatuses(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [slug]);
+
+  const handleExpand = () => {
+    if (!expanded && !statuses && !loading) fetchStatuses();
+    setExpanded((x) => !x);
+  };
+
+  if (!worktrees || worktrees.length === 0) return null;
+
+  return (
+    <div>
+      <button
+        onClick={handleExpand}
+        style={{ display: "flex", alignItems: "center", gap: "6px", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+      >
+        <span style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>{expanded ? "▾" : "▸"}</span>
+        <span style={{ fontSize: "0.85rem", fontWeight: 600, color: "var(--text-primary)" }}>
+          Worktrees ({worktrees.length})
+        </span>
+      </button>
+
+      {expanded && (
+        <div style={{ marginTop: "12px", display: "flex", flexDirection: "column", gap: "10px" }}>
+          {loading && <span style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>Loading…</span>}
+          {error && (
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <span style={{ fontSize: "0.8rem", color: "var(--destructive)" }}>{error}</span>
+              <button
+                onClick={fetchStatuses}
+                style={{ fontSize: "0.72rem", padding: "2px 8px", borderRadius: "3px", border: "1px solid var(--border-subtle)", background: "transparent", color: "var(--text-secondary)", cursor: "pointer" }}
+              >
+                Retry
+              </button>
+            </div>
+          )}
+          {statuses && worktrees.map((wt, i) => (
+            <WorktreeRow
+              key={wt.worktreePath}
+              wt={wt}
+              status={statuses[i]}
+              parentSlug={slug}
+              parentDevPort={devPort}
+              onRemoved={fetchStatuses}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/WorktreePanel.tsx
+++ b/src/components/WorktreePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useCallback, useEffect } from "react";
 import { WorktreeOverlay, WorktreeStatus } from "@/lib/types";
+import { worktreeSlug } from "@/lib/worktreeUtils";
 
 interface WorktreePanelProps {
   slug: string;
@@ -21,12 +22,8 @@ interface WorktreeRowProps {
   onRemoved: () => void;
 }
 
-function worktreeSlugFor(parentSlug: string, branch: string) {
-  return `${parentSlug}:wt:${branch.replace(/\//g, "-")}`;
-}
-
 function WorktreeRow({ wt, status, parentSlug, parentDevPort, onRemoved }: WorktreeRowProps) {
-  const wtSlug = worktreeSlugFor(parentSlug, wt.branch);
+  const wtSlug = worktreeSlug(parentSlug, wt.branch);
   const [devServer, setDevServer] = useState<DevServerState>({ running: false, loading: false });
   const [serverAction, setServerAction] = useState<"starting" | "stopping" | null>(null);
   const [syncState, setSyncState] = useState<Record<SyncFile, SyncState>>({

--- a/src/lib/processManager.ts
+++ b/src/lib/processManager.ts
@@ -251,6 +251,22 @@ function isPortInUse(port: number): Promise<boolean> {
   });
 }
 
+/**
+ * Find the next free port starting at startPort.
+ * The checker parameter is injectable for testability.
+ */
+export async function findFreePort(
+  startPort: number,
+  maxAttempts = 10,
+  checker: (port: number) => Promise<boolean> = isPortInUse
+): Promise<number | null> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = startPort + i;
+    if (!(await checker(port))) return port;
+  }
+  return null;
+}
+
 // Singleton — persist across hot reloads in dev
 const globalForPM = globalThis as unknown as { __processManager?: ProcessManager };
 export const processManager =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -132,6 +132,17 @@ export interface WorktreeOverlay {
   insights?: InsightsInfo;
 }
 
+export interface WorktreeStatus {
+  worktreePath: string;
+  branch: string;
+  isDirty: boolean;
+  uncommittedCount: number;
+  isMergedLocally: boolean;       // git branch --merged main
+  isRemoteBranchDeleted: boolean; // git ls-remote --heads origin <branch> returned empty
+  isStale: boolean;               // isMergedLocally && isRemoteBranchDeleted
+  lastCommitDate?: string;        // from git log -1 --format=%aI
+}
+
 export interface PortConflict {
   port: number;
   projects: string[];

--- a/src/lib/worktreeChecker.ts
+++ b/src/lib/worktreeChecker.ts
@@ -19,10 +19,18 @@ function runGitNullable(args: string[], cwd: string): Promise<string | null> {
   });
 }
 
+/** Resolves the repo's default branch via origin/HEAD; falls back to "main". */
+async function getDefaultBranch(cwd: string): Promise<string> {
+  const ref = await runGit(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd);
+  const match = ref.match(/^refs\/remotes\/origin\/(.+)$/);
+  return match ? match[1] : "main";
+}
+
 function parseMergedBranches(mergedOutput: string): string[] {
   return mergedOutput
     .split("\n")
-    .map((l) => l.trim().replace(/^\*\s*/, ""))
+    // Strip both "* " (current branch) and "+ " (checked-out-in-worktree) markers
+    .map((l) => l.trim().replace(/^[*+]\s*/, ""))
     .filter(Boolean);
 }
 
@@ -55,8 +63,9 @@ export async function checkWorktreeStatus(
   worktreePath: string,
   branch: string
 ): Promise<WorktreeStatus> {
+  const defaultBranch = await getDefaultBranch(parentPath);
   const [mergedOutput, remoteOutput, porcelain, lastCommit] = await Promise.all([
-    runGit(["branch", "--merged", "main"], parentPath),
+    runGit(["branch", "--merged", defaultBranch], parentPath),
     runGitNullable(["ls-remote", "--heads", "origin", branch], parentPath),
     runGit(["status", "--porcelain"], worktreePath),
     runGit(["log", "-1", "--format=%aI"], worktreePath),
@@ -71,12 +80,13 @@ export async function checkWorktreeStatus(
   );
 }
 
-/** Efficient multi-worktree variant: runs `git branch --merged main` once for all worktrees. */
+/** Efficient multi-worktree variant: resolves default branch and runs git branch --merged once for all worktrees. */
 export async function checkAllWorktreeStatuses(
   parentPath: string,
   worktrees: Array<{ worktreePath: string; branch: string }>
 ): Promise<WorktreeStatus[]> {
-  const mergedOutput = await runGit(["branch", "--merged", "main"], parentPath);
+  const defaultBranch = await getDefaultBranch(parentPath);
+  const mergedOutput = await runGit(["branch", "--merged", defaultBranch], parentPath);
   const mergedBranches = parseMergedBranches(mergedOutput);
 
   return Promise.all(

--- a/src/lib/worktreeChecker.ts
+++ b/src/lib/worktreeChecker.ts
@@ -1,5 +1,6 @@
 import { execFile } from "child_process";
 import { WorktreeStatus } from "./types";
+export { worktreeSlug } from "./worktreeUtils";
 
 function runGit(args: string[], cwd: string): Promise<string> {
   return new Promise((resolve) => {
@@ -18,28 +19,25 @@ function runGitNullable(args: string[], cwd: string): Promise<string | null> {
   });
 }
 
-export async function checkWorktreeStatus(
-  parentPath: string,
-  worktreePath: string,
-  branch: string,
-  _worktreeSlug: string
-): Promise<WorktreeStatus> {
-  const [mergedOutput, remoteOutput, porcelain, lastCommit] = await Promise.all([
-    runGit(["branch", "--merged", "main"], parentPath),
-    runGitNullable(["ls-remote", "--heads", "origin", branch], parentPath),
-    runGit(["status", "--porcelain"], worktreePath),
-    runGit(["log", "-1", "--format=%aI"], worktreePath),
-  ]);
-
-  const mergedBranches = mergedOutput
+function parseMergedBranches(mergedOutput: string): string[] {
+  return mergedOutput
     .split("\n")
     .map((l) => l.trim().replace(/^\*\s*/, ""))
     .filter(Boolean);
+}
+
+function parseStatus(
+  mergedBranches: string[],
+  remoteOutput: string | null,
+  porcelain: string,
+  lastCommit: string,
+  worktreePath: string,
+  branch: string
+): WorktreeStatus {
   const isMergedLocally = mergedBranches.includes(branch);
-  // null = network/remote error (unknown), treat as NOT deleted to avoid false staleness
+  // null = network/remote error (unknown) — treat as NOT deleted to avoid false staleness
   const isRemoteBranchDeleted = remoteOutput !== null && remoteOutput.trim() === "";
   const porcelainLines = porcelain ? porcelain.split("\n").filter((l) => l.trim()) : [];
-
   return {
     worktreePath,
     branch,
@@ -50,4 +48,45 @@ export async function checkWorktreeStatus(
     isStale: isMergedLocally && isRemoteBranchDeleted,
     lastCommitDate: lastCommit || undefined,
   };
+}
+
+export async function checkWorktreeStatus(
+  parentPath: string,
+  worktreePath: string,
+  branch: string
+): Promise<WorktreeStatus> {
+  const [mergedOutput, remoteOutput, porcelain, lastCommit] = await Promise.all([
+    runGit(["branch", "--merged", "main"], parentPath),
+    runGitNullable(["ls-remote", "--heads", "origin", branch], parentPath),
+    runGit(["status", "--porcelain"], worktreePath),
+    runGit(["log", "-1", "--format=%aI"], worktreePath),
+  ]);
+  return parseStatus(
+    parseMergedBranches(mergedOutput),
+    remoteOutput,
+    porcelain,
+    lastCommit,
+    worktreePath,
+    branch
+  );
+}
+
+/** Efficient multi-worktree variant: runs `git branch --merged main` once for all worktrees. */
+export async function checkAllWorktreeStatuses(
+  parentPath: string,
+  worktrees: Array<{ worktreePath: string; branch: string }>
+): Promise<WorktreeStatus[]> {
+  const mergedOutput = await runGit(["branch", "--merged", "main"], parentPath);
+  const mergedBranches = parseMergedBranches(mergedOutput);
+
+  return Promise.all(
+    worktrees.map(async ({ worktreePath, branch }) => {
+      const [remoteOutput, porcelain, lastCommit] = await Promise.all([
+        runGitNullable(["ls-remote", "--heads", "origin", branch], parentPath),
+        runGit(["status", "--porcelain"], worktreePath),
+        runGit(["log", "-1", "--format=%aI"], worktreePath),
+      ]);
+      return parseStatus(mergedBranches, remoteOutput, porcelain, lastCommit, worktreePath, branch);
+    })
+  );
 }

--- a/src/lib/worktreeChecker.ts
+++ b/src/lib/worktreeChecker.ts
@@ -1,0 +1,43 @@
+import { execFile } from "child_process";
+import { WorktreeStatus } from "./types";
+
+function runGit(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("git", args, { cwd, timeout: 5000 }, (err, stdout) => {
+      resolve(err ? "" : stdout.trim());
+    });
+  });
+}
+
+export async function checkWorktreeStatus(
+  parentPath: string,
+  worktreePath: string,
+  branch: string,
+  _worktreeSlug: string
+): Promise<WorktreeStatus> {
+  const [mergedOutput, remoteOutput, porcelain, lastCommit] = await Promise.all([
+    runGit(["branch", "--merged", "main"], parentPath),
+    runGit(["ls-remote", "--heads", "origin", branch], parentPath),
+    runGit(["status", "--porcelain"], worktreePath),
+    runGit(["log", "-1", "--format=%aI"], worktreePath),
+  ]);
+
+  const mergedBranches = mergedOutput
+    .split("\n")
+    .map((l) => l.trim().replace(/^\*\s*/, ""))
+    .filter(Boolean);
+  const isMergedLocally = mergedBranches.includes(branch);
+  const isRemoteBranchDeleted = remoteOutput.trim() === "";
+  const porcelainLines = porcelain ? porcelain.split("\n").filter((l) => l.trim()) : [];
+
+  return {
+    worktreePath,
+    branch,
+    isDirty: porcelainLines.length > 0,
+    uncommittedCount: porcelainLines.length,
+    isMergedLocally,
+    isRemoteBranchDeleted,
+    isStale: isMergedLocally && isRemoteBranchDeleted,
+    lastCommitDate: lastCommit || undefined,
+  };
+}

--- a/src/lib/worktreeChecker.ts
+++ b/src/lib/worktreeChecker.ts
@@ -9,6 +9,15 @@ function runGit(args: string[], cwd: string): Promise<string> {
   });
 }
 
+/** Returns null if the command failed (e.g., network error), empty string if command succeeded with no output. */
+function runGitNullable(args: string[], cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("git", args, { cwd, timeout: 5000 }, (err, stdout) => {
+      resolve(err ? null : stdout.trim());
+    });
+  });
+}
+
 export async function checkWorktreeStatus(
   parentPath: string,
   worktreePath: string,
@@ -17,7 +26,7 @@ export async function checkWorktreeStatus(
 ): Promise<WorktreeStatus> {
   const [mergedOutput, remoteOutput, porcelain, lastCommit] = await Promise.all([
     runGit(["branch", "--merged", "main"], parentPath),
-    runGit(["ls-remote", "--heads", "origin", branch], parentPath),
+    runGitNullable(["ls-remote", "--heads", "origin", branch], parentPath),
     runGit(["status", "--porcelain"], worktreePath),
     runGit(["log", "-1", "--format=%aI"], worktreePath),
   ]);
@@ -27,7 +36,8 @@ export async function checkWorktreeStatus(
     .map((l) => l.trim().replace(/^\*\s*/, ""))
     .filter(Boolean);
   const isMergedLocally = mergedBranches.includes(branch);
-  const isRemoteBranchDeleted = remoteOutput.trim() === "";
+  // null = network/remote error (unknown), treat as NOT deleted to avoid false staleness
+  const isRemoteBranchDeleted = remoteOutput !== null && remoteOutput.trim() === "";
   const porcelainLines = porcelain ? porcelain.split("\n").filter((l) => l.trim()) : [];
 
   return {

--- a/src/lib/worktreeSync.ts
+++ b/src/lib/worktreeSync.ts
@@ -1,0 +1,16 @@
+import { TodoItem, ManualStepEntry, InsightEntry } from "./types";
+
+export function diffTodos(parentItems: TodoItem[], worktreeItems: TodoItem[]): string[] {
+  const parentTexts = new Set(parentItems.map((i) => i.text));
+  return worktreeItems.filter((i) => !parentTexts.has(i.text)).map((i) => i.text);
+}
+
+export function diffManualSteps(parentEntries: ManualStepEntry[], worktreeEntries: ManualStepEntry[]): ManualStepEntry[] {
+  const key = (e: ManualStepEntry) => `${e.date}|${e.featureSlug}|${e.title}`;
+  const parentKeys = new Set(parentEntries.map(key));
+  return worktreeEntries.filter((e) => !parentKeys.has(key(e)));
+}
+
+export function diffInsights(parentIds: Set<string>, worktreeEntries: InsightEntry[]): InsightEntry[] {
+  return worktreeEntries.filter((e) => !parentIds.has(e.id));
+}

--- a/src/lib/worktreeUtils.ts
+++ b/src/lib/worktreeUtils.ts
@@ -1,0 +1,5 @@
+/** Pure, browser-safe worktree utilities (no Node.js imports). */
+
+export function worktreeSlug(parentSlug: string, branch: string): string {
+  return `${parentSlug}:wt:${branch.replace(/\//g, "-")}`;
+}

--- a/src/lib/worktreeUtils.ts
+++ b/src/lib/worktreeUtils.ts
@@ -1,5 +1,6 @@
 /** Pure, browser-safe worktree utilities (no Node.js imports). */
 
+/** Generates a collision-free process-manager slug for a worktree. */
 export function worktreeSlug(parentSlug: string, branch: string): string {
-  return `${parentSlug}:wt:${branch.replace(/\//g, "-")}`;
+  return `${parentSlug}:wt:${encodeURIComponent(branch)}`;
 }

--- a/tests/findFreePort.test.ts
+++ b/tests/findFreePort.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { findFreePort } from "@/lib/processManager";
+
+describe("findFreePort", () => {
+  it("returns startPort when it is free", async () => {
+    const checker = vi.fn().mockResolvedValue(false);
+    expect(await findFreePort(4101, 10, checker)).toBe(4101);
+    expect(checker).toHaveBeenCalledWith(4101);
+  });
+
+  it("skips in-use ports and returns next free one", async () => {
+    const checker = vi.fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    expect(await findFreePort(4101, 10, checker)).toBe(4103);
+  });
+
+  it("returns null when all attempts exhausted", async () => {
+    const checker = vi.fn().mockResolvedValue(true);
+    expect(await findFreePort(4101, 3, checker)).toBeNull();
+    expect(checker).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/worktreeChecker.test.ts
+++ b/tests/worktreeChecker.test.ts
@@ -9,6 +9,13 @@ import { worktreeSlug } from "@/lib/worktreeUtils";
 
 const execFileMock = vi.mocked(execFile);
 
+/** Stub sequential execFile calls. Call order in checkWorktreeStatus:
+ *  0: git symbolic-ref refs/remotes/origin/HEAD  → default branch ref
+ *  1: git branch --merged <defaultBranch>         → merged branches
+ *  2: git ls-remote --heads origin <branch>       → remote ref (empty = deleted)
+ *  3: git status --porcelain                      → dirty files
+ *  4: git log -1 --format=%aI                     → last commit date
+ */
 function stubOutputs(outputs: string[]) {
   let call = 0;
   execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
@@ -19,12 +26,18 @@ function stubOutputs(outputs: string[]) {
 }
 
 describe("worktreeSlug", () => {
-  it("replaces slashes with dashes in branch name", () => {
-    expect(worktreeSlug("my-app", "feature/foo-bar")).toBe("my-app:wt:feature-foo-bar");
+  it("URL-encodes slashes in branch name (collision-safe)", () => {
+    expect(worktreeSlug("my-app", "feature/foo-bar")).toBe("my-app:wt:feature%2Ffoo-bar");
   });
 
   it("handles branch with no slashes", () => {
     expect(worktreeSlug("my-app", "main")).toBe("my-app:wt:main");
+  });
+
+  it("distinguishes branches that differ only by slash position", () => {
+    const a = worktreeSlug("app", "feature/foo-bar");
+    const b = worktreeSlug("app", "feature-foo/bar");
+    expect(a).not.toBe(b);
   });
 });
 
@@ -32,7 +45,7 @@ describe("checkWorktreeStatus", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("marks stale when merged locally and remote deleted", async () => {
-    stubOutputs(["  main\n  feature/foo", "", "", "2026-04-01T10:00:00Z"]);
+    stubOutputs(["refs/remotes/origin/main", "  main\n  feature/foo", "", "", "2026-04-01T10:00:00Z"]);
     const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isMergedLocally).toBe(true);
     expect(s.isRemoteBranchDeleted).toBe(true);
@@ -40,14 +53,21 @@ describe("checkWorktreeStatus", () => {
     expect(s.isDirty).toBe(false);
   });
 
+  it("strips worktree '+' prefix from git branch --merged output", async () => {
+    // git branch --merged prefixes linked worktrees with "+ " not "* "
+    stubOutputs(["refs/remotes/origin/main", "  main\n+ feature/wt-branch", "", "", ""]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/wt-branch");
+    expect(s.isMergedLocally).toBe(true);
+  });
+
   it("not stale when remote branch still exists", async () => {
-    stubOutputs(["  main", "abc123\trefs/heads/feature/foo", "", ""]);
+    stubOutputs(["refs/remotes/origin/main", "  main", "abc123\trefs/heads/feature/foo", "", ""]);
     const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isStale).toBe(false);
   });
 
   it("reports dirty worktree", async () => {
-    stubOutputs(["  main", "", " M src/foo.ts\nA  src/bar.ts", ""]);
+    stubOutputs(["refs/remotes/origin/main", "  main", "", " M src/foo.ts\nA  src/bar.ts", ""]);
     const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isDirty).toBe(true);
     expect(s.uncommittedCount).toBe(2);
@@ -60,5 +80,12 @@ describe("checkWorktreeStatus", () => {
     });
     const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isStale).toBe(false);
+  });
+
+  it("falls back to 'main' when symbolic-ref unavailable", async () => {
+    // First call (symbolic-ref) returns empty → falls back to "main"
+    stubOutputs(["", "  main\n  feature/foo", "", "", ""]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
+    expect(s.isMergedLocally).toBe(true);
   });
 });

--- a/tests/worktreeChecker.test.ts
+++ b/tests/worktreeChecker.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+vi.mock("@/lib/processManager", () => ({ processManager: { get: vi.fn().mockReturnValue(undefined) } }));
+
+import { execFile } from "child_process";
+import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+
+const execFileMock = vi.mocked(execFile);
+
+function stubOutputs(outputs: string[]) {
+  let call = 0;
+  execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+    const cb = callback as (err: null, stdout: string, stderr: string) => void;
+    cb(null, (outputs[call++] ?? "") + "\n", "");
+    return {} as ReturnType<typeof execFile>;
+  });
+}
+
+describe("checkWorktreeStatus", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("marks stale when merged locally and remote deleted", async () => {
+    stubOutputs(["  main\n  feature/foo", "", "", "2026-04-01T10:00:00Z"]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isMergedLocally).toBe(true);
+    expect(s.isRemoteBranchDeleted).toBe(true);
+    expect(s.isStale).toBe(true);
+    expect(s.isDirty).toBe(false);
+  });
+
+  it("not stale when remote branch still exists", async () => {
+    stubOutputs(["  main", "abc123\trefs/heads/feature/foo", "", ""]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isStale).toBe(false);
+  });
+
+  it("reports dirty worktree", async () => {
+    stubOutputs(["  main", "", " M src/foo.ts\nA  src/bar.ts", ""]);
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isDirty).toBe(true);
+    expect(s.uncommittedCount).toBe(2);
+  });
+
+  it("returns isStale false when git fails (offline safety)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, callback) => {
+      (callback as (err: Error) => void)(new Error("network unreachable"));
+      return {} as ReturnType<typeof execFile>;
+    });
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    expect(s.isStale).toBe(false);
+  });
+});

--- a/tests/worktreeChecker.test.ts
+++ b/tests/worktreeChecker.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/processManager", () => ({ processManager: { get: vi.fn().mockRetu
 
 import { execFile } from "child_process";
 import { checkWorktreeStatus } from "@/lib/worktreeChecker";
+import { worktreeSlug } from "@/lib/worktreeUtils";
 
 const execFileMock = vi.mocked(execFile);
 
@@ -17,12 +18,22 @@ function stubOutputs(outputs: string[]) {
   });
 }
 
+describe("worktreeSlug", () => {
+  it("replaces slashes with dashes in branch name", () => {
+    expect(worktreeSlug("my-app", "feature/foo-bar")).toBe("my-app:wt:feature-foo-bar");
+  });
+
+  it("handles branch with no slashes", () => {
+    expect(worktreeSlug("my-app", "main")).toBe("my-app:wt:main");
+  });
+});
+
 describe("checkWorktreeStatus", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("marks stale when merged locally and remote deleted", async () => {
     stubOutputs(["  main\n  feature/foo", "", "", "2026-04-01T10:00:00Z"]);
-    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isMergedLocally).toBe(true);
     expect(s.isRemoteBranchDeleted).toBe(true);
     expect(s.isStale).toBe(true);
@@ -31,13 +42,13 @@ describe("checkWorktreeStatus", () => {
 
   it("not stale when remote branch still exists", async () => {
     stubOutputs(["  main", "abc123\trefs/heads/feature/foo", "", ""]);
-    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isStale).toBe(false);
   });
 
   it("reports dirty worktree", async () => {
     stubOutputs(["  main", "", " M src/foo.ts\nA  src/bar.ts", ""]);
-    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isDirty).toBe(true);
     expect(s.uncommittedCount).toBe(2);
   });
@@ -47,7 +58,7 @@ describe("checkWorktreeStatus", () => {
       (callback as (err: Error) => void)(new Error("network unreachable"));
       return {} as ReturnType<typeof execFile>;
     });
-    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo", "p:wt:feature-foo");
+    const s = await checkWorktreeStatus("C:/dev/p", "C:/dev/p--wt", "feature/foo");
     expect(s.isStale).toBe(false);
   });
 });

--- a/tests/worktreeSync.test.ts
+++ b/tests/worktreeSync.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { diffTodos, diffManualSteps, diffInsights } from "@/lib/worktreeSync";
+
+describe("diffTodos", () => {
+  it("returns items in worktree not in parent", () => {
+    const parent = [{ text: "fix bug", completed: false }];
+    const worktree = [{ text: "fix bug", completed: true }, { text: "add feature", completed: false }];
+    expect(diffTodos(parent, worktree)).toEqual(["add feature"]);
+  });
+  it("returns empty when nothing new", () => {
+    expect(diffTodos([{ text: "x", completed: false }], [{ text: "x", completed: false }])).toEqual([]);
+  });
+  it("returns all when parent empty", () => {
+    expect(diffTodos([], [{ text: "a", completed: false }, { text: "b", completed: false }])).toEqual(["a", "b"]);
+  });
+});
+
+describe("diffManualSteps", () => {
+  const e = (date: string, slug: string, title: string) => ({ date, featureSlug: slug, title, steps: [] });
+  it("returns entries in worktree not in parent", () => {
+    const result = diffManualSteps(
+      [e("2026-04-01 10:00", "auth", "Setup auth")],
+      [e("2026-04-01 10:00", "auth", "Setup auth"), e("2026-04-10 12:00", "feat-x", "Setup X")]
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].featureSlug).toBe("feat-x");
+  });
+  it("returns empty when nothing new", () => {
+    const entry = e("2026-04-01", "a", "T");
+    expect(diffManualSteps([entry], [entry])).toHaveLength(0);
+  });
+});
+
+describe("diffInsights", () => {
+  const ins = (id: string) => ({ id, content: "x", sessionId: "s1", date: "2026-04-01", project: "p", projectPath: "/p" });
+  it("returns insights not in parent ids", () => {
+    const result = diffInsights(new Set(["abc123"]), [ins("abc123"), ins("def456")]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("def456");
+  });
+  it("returns all when parent empty", () => {
+    expect(diffInsights(new Set(), [ins("a"), ins("b")])).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- **On-demand worktree status API** (`GET /api/worktrees/[slug]`) — lazy-fetched on panel expand; runs `git branch --merged main` once per project then checks each worktree's remote ref, dirty state, and last commit in parallel
- **Worktree dev servers** (`POST /api/worktrees/[slug]` `start-server`) — auto-finds free port starting at parent port+1, delegates to existing `processManager` with slug convention `parentSlug:wt:branchHint`
- **Append-only file sync** (`POST /api/worktrees/[slug]/sync`) — diffs TODO items by text, manual steps by date|slug|title key, insights by content hash; appends worktree-only entries to parent file using existing writers
- **Stale worktree detection + removal** — marks worktree stale when merged locally AND remote branch deleted; `remove` action calls `git worktree remove` (never force), returns 409 if git refuses
- **`WorktreePanel` component** — collapsible panel in project Overview tab; lazy-loads status on first expand; per-worktree dev server control, sync badges, and stale/remove confirmation
- **Project card badge** — blue `wt N` badge when project has worktrees

## Security

- Sync route validates `worktreePath` against the project's known worktrees list (path traversal guard)
- Remove action enforces `isStale: true` server-side before running `git worktree remove`
- `ls-remote` failure treated as `isRemoteBranchDeleted = false` — no false-positive stale detection when offline

## Test plan

- [ ] Expand worktree panel on a project with worktrees — status loads, branch + last commit date visible
- [ ] Start dev server for a worktree — port auto-assigned, `● :NNNN` indicator appears
- [ ] Stop worktree dev server
- [ ] Sync TODOs/Manual Steps/Insights from a worktree that has entries not in parent
- [ ] Confirm sync badge turns green after syncing
- [ ] Stale badge appears on a worktree with merged + remote-deleted branch
- [ ] Remove worktree via confirmation modal — verify directory is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)