### PR TITLE
feat(todos): make TODO items toggleable from project detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Minimal GitHub Actions CI workflow (`.github/workflows/ci.yml`) running lint, tests, and build on every PR and push to `main`.
+- TODO items in the project detail TODO tab are now interactive: click any item to toggle it done/undone. Changes are written back to `TODO.md` immediately.
 
 ### Changed
 - Branch protection: `main` now requires PRs, linear history, force-pushes and deletions blocked. Squash is the only merge style. The `verify` CI status check will be added as a required check once the initial workflow run completes on `main`.

--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -1,5 +1,23 @@
 # Insights
 
+<!-- insight:30ab4fef8e43 | session:661056b7-befa-4f76-81c0-03159b90270a | 2026-04-16T19:52:15.694Z -->
+## ★ Insight
+The toggle uses **optimistic opacity** (`opacity: 0.5` while in-flight) rather than optimistic state because the server returns the authoritative post-write `TodoInfo` — simpler and avoids a stale-state bug if the write fails.
+
+---
+
+<!-- insight:89dca674735f | session:661056b7-befa-4f76-81c0-03159b90270a | 2026-04-16T19:49:44.171Z -->
+## ★ Insight
+The ManualSteps toggle works because `parseManualStepsMd` stores line numbers per item. `scanTodoMd` discards line numbers entirely — so even if we had a toggle API, we'd have no way to know which line to mutate. The fix threads line numbers through all 5 layers: type → scanner → writer → API route → UI.
+
+---
+
+<!-- insight:bcab28f3eca7 | session:661056b7-befa-4f76-81c0-03159b90270a | 2026-04-16T19:49:12.063Z -->
+## ★ Insight
+The `Circle` and `CheckCircle2` icons in `TodoList.tsx` have no `onClick` handler — they're purely decorative. The `ManualStepsList` component (for Manual Steps) has toggle support, but that pattern was never wired up for TODOs.
+
+---
+
 <!-- insight:edcacf1e497f | session:177aee6d-5c58-4038-9422-d242d4bf0a9c | 2026-04-16T16:50:09.861Z -->
 ## ★ Insight
 The `vi.mock("child_process")` call must be at the **top of the file** because Vitest hoists it before any imports during transformation — if you put it inside a `describe` block or `beforeEach`, the mock won't be in place when the real module is first imported. The `vi.mocked()` wrapper then lets you configure return values inside individual tests after the mock factory has already run.

--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -5,7 +5,6 @@
 The toggle uses **optimistic opacity** (`opacity: 0.5` while in-flight) rather than optimistic state because the server returns the authoritative post-write `TodoInfo` — simpler and avoids a stale-state bug if the write fails.
 
 ---
-
 <!-- insight:89dca674735f | session:661056b7-befa-4f76-81c0-03159b90270a | 2026-04-16T19:49:44.171Z -->
 ## ★ Insight
 The ManualSteps toggle works because `parseManualStepsMd` stores line numbers per item. `scanTodoMd` discards line numbers entirely — so even if we had a toggle API, we'd have no way to know which line to mutate. The fix threads line numbers through all 5 layers: type → scanner → writer → API route → UI.
@@ -15,6 +14,61 @@ The ManualSteps toggle works because `parseManualStepsMd` stores line numbers pe
 <!-- insight:bcab28f3eca7 | session:661056b7-befa-4f76-81c0-03159b90270a | 2026-04-16T19:49:12.063Z -->
 ## ★ Insight
 The `Circle` and `CheckCircle2` icons in `TodoList.tsx` have no `onClick` handler — they're purely decorative. The `ManualStepsList` component (for Manual Steps) has toggle support, but that pattern was never wired up for TODOs.
+
+---
+
+
+<!-- insight:e8c2db7d4c57 | session:7ed31474-191f-4cc4-a499-f22c78d4fea8 | 2026-04-16T19:33:09.855Z -->
+## ★ Insight
+This is the classic Windows-to-Linux CI failure pattern: `path.basename` on Linux only splits on `/`, not `\`. The project already has a `platform.ts` module for cross-platform concerns, but path manipulation using Node's built-in `path` module silently breaks when Windows-style paths are fed into Linux's POSIX `path.basename`. The regex split `/[/\\]/` is the idiomatic cross-platform fix for last-segment extraction.
+
+---
+
+<!-- insight:57d77ed13551 | session:7ed31474-191f-4cc4-a499-f22c78d4fea8 | 2026-04-16T19:26:02.429Z -->
+## ★ Insight
+ESLint 9 switched from `.eslintrc.*` (legacy config) to `eslint.config.js` (flat config) as the default. Next.js 16 ships `eslint-config-next` but doesn't auto-generate the config file for existing projects — you have to add it. The `FlatCompat` wrapper is the bridge that lets old-style `extends: ["next/core-web-vitals"]` rules work inside the new flat config format, without having to rewrite every rule in native flat-config syntax.
+
+---
+
+<!-- insight:7d70318c27d9 | session:7ed31474-191f-4cc4-a499-f22c78d4fea8 | 2026-04-16T19:17:20.240Z -->
+## ★ Insight
+The `ci.yml` uses `npm ci` (not `npm install`) intentionally — `npm ci` uses `package-lock.json` exactly, fails if it's out of date, and never modifies it. This gives CI a deterministic, reproducible install that catches "works on my machine because my node_modules is different" problems. The `cache: 'npm'` in `setup-node` caches the npm cache folder between runs, so `npm ci` is fast after the first run.
+
+---
+
+<!-- insight:c772b44a6809 | session:7ed31474-191f-4cc4-a499-f22c78d4fea8 | 2026-04-16T19:03:32.929Z -->
+## ★ Insight
+Two things worth knowing about this plan's structure: (1) Phase A is intentionally "no dependencies" — you can apply it today even if CI never lands, because force-push/deletion/linear-history rules don't depend on any status check. (2) The maintainer bypass set to "Always" is the solo-dev escape hatch — without it, a rule like "require PR" would mean you can't hotfix `main` from your laptop at 2am. GitHub's bypass model is the right place to encode "I trust myself, but I want the guardrails to catch accidents."
+
+---
+
+<!-- insight:cb7bf19c791b | session:7ed31474-191f-4cc4-a499-f22c78d4fea8 | 2026-04-16T19:02:11.046Z -->
+## ★ Insight
+One subtle benefit of squash + linear history + PR-required on a solo repo: it converts your ad-hoc `Merge branch 'main' of ...` commits (caused by `git pull` without rebase) into a clean one-PR-per-feature log. Your recent history already shows both styles mixed — enforcing squash now means new readers of the public repo see a tidy story, not "what was this local merge for?"
+
+---
+
+<!-- insight:fc11572a090f | session:7ed31474-191f-4cc4-a499-f22c78d4fea8 | 2026-04-16T18:37:39.335Z -->
+## ★ Insight
+Branch protection rules on a solo-maintainer public repo are a different design problem than on a team repo. Team repos use them to enforce review between people; solo repos use them as a safety net against your own mistakes (accidental force-push, deleting main, bypassing your own tests). The rule set should match that threat model — not copy-paste from enterprise playbooks.
+
+---
+
+<!-- insight:953fe4cd64c3 | session:03581b67-1dea-4628-8be9-0134803f87b0 | 2026-04-16T18:06:33.616Z -->
+## ★ Insight
+The temp-dir approach (`mkdtemp` + `afterEach rm`) is preferable to `vi.mock("fs")` here because `setupApply.ts`'s value proposition *is* the file layout it produces — idempotency, backup creation, partial merges. Mocking `fs` would test that `writeFile` was called; the real filesystem tests that the resulting files are correct. The `afterEach` cleanup ensures tests are hermetic even if one throws mid-way.
+
+---
+
+<!-- insight:2c17cdd32cb8 | session:03581b67-1dea-4628-8be9-0134803f87b0 | 2026-04-16T18:04:25.964Z -->
+## ★ Insight
+`setupApply.ts` uses real `fs.promises` rather than injected deps, so tests need **real temp directories** instead of `vi.mock("fs")`. `os.tmpdir()` + `fs.mkdtemp` gives each test an isolated scratch dir, and `afterEach` cleans up. This is better than mocking for filesystem-heavy logic because the test exercises the actual file layout — a mock would only prove the code called write functions, not that the resulting files are correct.
+
+---
+
+<!-- insight:20b5f762ac12 | session:03581b67-1dea-4628-8be9-0134803f87b0 | 2026-04-16T18:03:27.577Z -->
+## ★ Insight
+`setupApply.ts` uses **real `fs` calls** (not injected), which means tests need to use `tmp` directories rather than `vi.mock("fs")`. This is a different testing pattern from the rest of the codebase — but it's actually better for these tests because the logic we care about is the *file layout* after apply, not just the parsing logic. Temp-dir fixtures let the real filesystem validate the idempotency contract.
 
 ---
 

--- a/src/app/api/todos/[slug]/route.ts
+++ b/src/app/api/todos/[slug]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { scanAllProjects } from "@/lib/scanner";
 import { getCachedScan, setCachedScan, invalidateCache } from "@/lib/cache";
-import { appendTodosToFile, TodoWriteError } from "@/lib/todoWriter";
+import { appendTodosToFile, toggleTodoInFile, TodoWriteError } from "@/lib/todoWriter";
 
 async function findProjectPath(slug: string): Promise<string | null> {
   let result = getCachedScan();
@@ -69,5 +69,36 @@ export async function POST(
       { error: "Failed to append TODOs" },
       { status: 500 }
     );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const projectPath = await findProjectPath(slug);
+  if (!projectPath) {
+    return NextResponse.json({ error: "Project not found" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { lineNumber } = (body ?? {}) as { lineNumber?: unknown };
+  if (typeof lineNumber !== "number" || lineNumber < 1) {
+    return NextResponse.json({ error: "lineNumber required" }, { status: 400 });
+  }
+
+  try {
+    const updated = await toggleTodoInFile(projectPath, lineNumber);
+    invalidateCache();
+    return NextResponse.json({ todos: updated });
+  } catch {
+    return NextResponse.json({ error: "Failed to toggle TODO" }, { status: 500 });
   }
 }

--- a/src/app/api/todos/[slug]/route.ts
+++ b/src/app/api/todos/[slug]/route.ts
@@ -90,12 +90,13 @@ export async function PATCH(
   }
 
   const { lineNumber } = (body ?? {}) as { lineNumber?: unknown };
-  if (typeof lineNumber !== "number" || lineNumber < 1) {
+  if (!Number.isFinite(lineNumber) || !Number.isInteger(lineNumber) || (lineNumber as number) < 1) {
     return NextResponse.json({ error: "lineNumber required" }, { status: 400 });
   }
+  const safeLineNumber = lineNumber as number;
 
   try {
-    const updated = await toggleTodoInFile(projectPath, lineNumber);
+    const updated = await toggleTodoInFile(projectPath, safeLineNumber);
     invalidateCache();
     return NextResponse.json({ todos: updated });
   } catch {

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -99,31 +99,36 @@ export function TodoList({ todos, slug, onChange, worktrees }: TodoListProps) {
 
       {/* Items */}
       <ul style={{ display: "flex", flexDirection: "column", gap: "2px", padding: 0, margin: 0, listStyle: "none" }}>
-        {filtered.map((item, i) => {
+        {filtered.map((item) => {
           const isToggling = toggling === item.lineNumber;
           const canToggle = slug != null && item.lineNumber != null;
+          const itemKey = item.lineNumber != null ? `line-${item.lineNumber}` : `todo-${item.text}`;
           return (
-            <li
-              key={i}
-              onClick={() => canToggle && toggleItem(item.lineNumber)}
-              style={{
-                display: "flex", alignItems: "flex-start", gap: "8px", padding: "4px 0",
-                cursor: canToggle ? "pointer" : "default",
-                opacity: isToggling ? 0.5 : 1,
-              }}
-            >
-              {item.completed ? (
-                <CheckCircle2 style={{ width: "14px", height: "14px", color: "var(--status-active-text)", flexShrink: 0, marginTop: "1px" }} />
-              ) : (
-                <Circle style={{ width: "14px", height: "14px", color: "var(--text-muted)", flexShrink: 0, marginTop: "1px" }} />
-              )}
-              <span style={{
-                fontSize: "0.82rem", color: item.completed ? "var(--text-muted)" : "var(--text-secondary)",
-                textDecoration: item.completed ? "line-through" : "none",
-                lineHeight: 1.55,
-              }}>
-                {item.text}
-              </span>
+            <li key={itemKey}>
+              <button
+                type="button"
+                onClick={() => canToggle && toggleItem(item.lineNumber)}
+                disabled={!canToggle || isToggling}
+                style={{
+                  display: "flex", alignItems: "flex-start", gap: "8px", padding: "4px 0",
+                  width: "100%", border: "none", background: "none", textAlign: "left",
+                  cursor: canToggle && !isToggling ? "pointer" : "default",
+                  opacity: isToggling ? 0.5 : 1,
+                }}
+              >
+                {item.completed ? (
+                  <CheckCircle2 style={{ width: "14px", height: "14px", color: "var(--status-active-text)", flexShrink: 0, marginTop: "1px" }} />
+                ) : (
+                  <Circle style={{ width: "14px", height: "14px", color: "var(--text-muted)", flexShrink: 0, marginTop: "1px" }} />
+                )}
+                <span style={{
+                  fontSize: "0.82rem", color: item.completed ? "var(--text-muted)" : "var(--text-secondary)",
+                  textDecoration: item.completed ? "line-through" : "none",
+                  lineHeight: 1.55,
+                }}>
+                  {item.text}
+                </span>
+              </button>
             </li>
           );
         })}

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -19,6 +19,27 @@ type FilterMode = "all" | "open" | "done";
 
 export function TodoList({ todos, slug, onChange, worktrees }: TodoListProps) {
   const [filter, setFilter] = useState<FilterMode>("open");
+  const [toggling, setToggling] = useState<number | null>(null);
+  const { showToast } = useToast();
+
+  const toggleItem = async (lineNumber: number | undefined) => {
+    if (!slug || lineNumber == null || toggling != null) return;
+    setToggling(lineNumber);
+    try {
+      const res = await fetch(`/api/todos/${slug}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ lineNumber }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = await res.json();
+      onChange?.(body.todos as TodoInfo);
+    } catch {
+      showToast("Failed to update TODO", "Please try again");
+    } finally {
+      setToggling(null);
+    }
+  };
 
   const filtered = todos.items.filter((item) => {
     if (filter === "open") return !item.completed;
@@ -78,22 +99,34 @@ export function TodoList({ todos, slug, onChange, worktrees }: TodoListProps) {
 
       {/* Items */}
       <ul style={{ display: "flex", flexDirection: "column", gap: "2px", padding: 0, margin: 0, listStyle: "none" }}>
-        {filtered.map((item, i) => (
-          <li key={i} style={{ display: "flex", alignItems: "flex-start", gap: "8px", padding: "4px 0" }}>
-            {item.completed ? (
-              <CheckCircle2 style={{ width: "14px", height: "14px", color: "var(--status-active-text)", flexShrink: 0, marginTop: "1px" }} />
-            ) : (
-              <Circle style={{ width: "14px", height: "14px", color: "var(--text-muted)", flexShrink: 0, marginTop: "1px" }} />
-            )}
-            <span style={{
-              fontSize: "0.82rem", color: item.completed ? "var(--text-muted)" : "var(--text-secondary)",
-              textDecoration: item.completed ? "line-through" : "none",
-              lineHeight: 1.55,
-            }}>
-              {item.text}
-            </span>
-          </li>
-        ))}
+        {filtered.map((item, i) => {
+          const isToggling = toggling === item.lineNumber;
+          const canToggle = slug != null && item.lineNumber != null;
+          return (
+            <li
+              key={i}
+              onClick={() => canToggle && toggleItem(item.lineNumber)}
+              style={{
+                display: "flex", alignItems: "flex-start", gap: "8px", padding: "4px 0",
+                cursor: canToggle ? "pointer" : "default",
+                opacity: isToggling ? 0.5 : 1,
+              }}
+            >
+              {item.completed ? (
+                <CheckCircle2 style={{ width: "14px", height: "14px", color: "var(--status-active-text)", flexShrink: 0, marginTop: "1px" }} />
+              ) : (
+                <Circle style={{ width: "14px", height: "14px", color: "var(--text-muted)", flexShrink: 0, marginTop: "1px" }} />
+              )}
+              <span style={{
+                fontSize: "0.82rem", color: item.completed ? "var(--text-muted)" : "var(--text-secondary)",
+                textDecoration: item.completed ? "line-through" : "none",
+                lineHeight: 1.55,
+              }}>
+                {item.text}
+              </span>
+            </li>
+          );
+        })}
         {filtered.length === 0 && (
           <li style={{ fontSize: "0.78rem", color: "var(--text-muted)", padding: "8px 0" }}>
             {filter === "all" ? "No TODOs yet." : filter === "open" ? "No open items." : "No completed items."}

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -20,7 +20,6 @@ import {
   type CachedFileStats,
 } from "../claudeStatsCache";
 
- 
 export interface ConversationEntry {
   type?: string;
   subtype?: string;

--- a/src/lib/scanner/todoMd.ts
+++ b/src/lib/scanner/todoMd.ts
@@ -14,14 +14,15 @@ export async function scanTodoMd(
     const items: TodoItem[] = [];
     const lines = content.split("\n");
 
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
       const completedMatch = line.match(/^\s*-\s*\[x\]\s+(.*)/i);
       const pendingMatch = line.match(/^\s*-\s*\[\s\]\s+(.*)/);
 
       if (completedMatch) {
-        items.push({ text: completedMatch[1].trim(), completed: true });
+        items.push({ text: completedMatch[1].trim(), completed: true, lineNumber: i + 1 });
       } else if (pendingMatch) {
-        items.push({ text: pendingMatch[1].trim(), completed: false });
+        items.push({ text: pendingMatch[1].trim(), completed: false, lineNumber: i + 1 });
       }
     }
 

--- a/src/lib/todoWriter.ts
+++ b/src/lib/todoWriter.ts
@@ -118,16 +118,22 @@ export async function toggleTodoInFile(
     const lines = content.split("\n");
     const idx = lineNumber - 1;
 
+    let changed = false;
+
     if (idx >= 0 && idx < lines.length) {
       const line = lines[idx];
       if (line.match(/^\s*-\s*\[\s\]/)) {
-        lines[idx] = line.replace("- [ ]", "- [x]");
+        lines[idx] = line.replace(/^(\s*-\s*)\[\s\]/, "$1[x]");
+        changed = true;
       } else if (line.match(/^\s*-\s*\[x\]/i)) {
-        lines[idx] = line.replace(/- \[x\]/i, "- [ ]");
+        lines[idx] = line.replace(/^(\s*-\s*)\[x\]/i, "$1[ ]");
+        changed = true;
       }
     }
 
-    await atomicWriteFile(filePath, lines.join("\n"));
+    if (changed) {
+      await atomicWriteFile(filePath, lines.join("\n"));
+    }
     const info = await scanTodoMd(projectPath);
     return info ?? { total: 0, completed: 0, pending: 0, items: [] };
   });

--- a/src/lib/todoWriter.ts
+++ b/src/lib/todoWriter.ts
@@ -107,3 +107,28 @@ export async function appendTodosToFile(
     );
   });
 }
+
+export async function toggleTodoInFile(
+  projectPath: string,
+  lineNumber: number
+): Promise<TodoInfo> {
+  const filePath = path.join(projectPath, "TODO.md");
+  return withFileLock(filePath, async () => {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    const idx = lineNumber - 1;
+
+    if (idx >= 0 && idx < lines.length) {
+      const line = lines[idx];
+      if (line.match(/^\s*-\s*\[\s\]/)) {
+        lines[idx] = line.replace("- [ ]", "- [x]");
+      } else if (line.match(/^\s*-\s*\[x\]/i)) {
+        lines[idx] = line.replace(/- \[x\]/i, "- [ ]");
+      }
+    }
+
+    await atomicWriteFile(filePath, lines.join("\n"));
+    const info = await scanTodoMd(projectPath);
+    return info ?? { total: 0, completed: 0, pending: 0, items: [] };
+  });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,6 +87,7 @@ export interface TodoInfo {
 export interface TodoItem {
   text: string;
   completed: boolean;
+  lineNumber?: number;
 }
 
 export interface ManualStepEntry {

--- a/src/lib/usage/parser.ts
+++ b/src/lib/usage/parser.ts
@@ -7,8 +7,6 @@ import {
 } from "@/lib/scanner/claudeConversations";
 import type { UsageTurn } from "./types";
 
- 
-
 const MAX_SESSION_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
 

--- a/src/lib/usage/types.ts
+++ b/src/lib/usage/types.ts
@@ -1,5 +1,3 @@
- 
-
 export interface ToolCall {
   name: string;
   arguments?: Record<string, any>;

--- a/tests/todoMd.test.ts
+++ b/tests/todoMd.test.ts
@@ -36,9 +36,9 @@ describe("scanTodoMd", () => {
       completed: 1,
       pending: 2,
       items: [
-        { text: "Fix bug", completed: false },
-        { text: "Write tests", completed: true },
-        { text: "Deploy", completed: false },
+        { text: "Fix bug", completed: false, lineNumber: 3 },
+        { text: "Write tests", completed: true, lineNumber: 4 },
+        { text: "Deploy", completed: false, lineNumber: 5 },
       ],
     });
   });
@@ -50,7 +50,7 @@ describe("scanTodoMd", () => {
       total: 1,
       completed: 1,
       pending: 0,
-      items: [{ text: "Done item", completed: true }],
+      items: [{ text: "Done item", completed: true, lineNumber: 1 }],
     });
   });
 
@@ -63,7 +63,7 @@ describe("scanTodoMd", () => {
       total: 1,
       completed: 0,
       pending: 1,
-      items: [{ text: "Real item", completed: false }],
+      items: [{ text: "Real item", completed: false, lineNumber: 5 }],
     });
   });
 });


### PR DESCRIPTION
## Summary

- TODO items in the project detail TODO tab are now clickable — click any item to toggle it done/undone
- Writes changes back to `TODO.md` atomically (same mutex + atomic-rename pattern as Manual Steps)
- Line numbers are now threaded through `TodoItem` so the UI knows which line to mutate

## Changes

- `src/lib/types.ts` — added `lineNumber?: number` to `TodoItem`
- `src/lib/scanner/todoMd.ts` — captures 1-based line number per item during parse
- `src/lib/todoWriter.ts` — added `toggleTodoInFile(projectPath, lineNumber)`
- `src/app/api/todos/[slug]/route.ts` — added `PATCH` handler that delegates to `toggleTodoInFile`
- `src/components/TodoList.tsx` — items are now clickable with `pointer` cursor and in-flight opacity feedback

## Test plan

- [ ] Open a project detail page → TODO tab
- [ ] Click an open item — it should flip to done (strikethrough, check icon) and the file should update
- [ ] Click a done item — it should flip back to open
- [ ] Switch filter to "Done" and toggle an item there
- [ ] `npm test` passes (194 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)