### PR TITLE
feat(agents+skills): agents & skills catalog pages with per-project tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Agents page (`/agents`)** — cross-project catalog of all available Claude Code agents (root `~/.claude/agents/`, installed plugins, and per-project `.claude/agents/`) with invocation counts, last-used timestamps, source/category badges, and inline body expansion. Search, source filter (user/plugin/project), and sort by name/invocations/last-used.
+- **Skills page (`/skills`)** — same catalog pattern for Claude Code skills (root `~/.claude/skills/`, plugins, and per-project `.claude/skills/`). Supports both bundled `SKILL.md`-in-dir and standalone `.md` layouts. Shows version, user-invocable, and argument-hint chips where available.
+- **Agents and Skills tabs on project detail pages** — each project's detail view now has "Agents" and "Skills" tabs showing (a) project-local definitions and (b) agents/skills invoked in that project's sessions, with per-project invocation counts.
+- **`GET /api/agents`** and **`GET /api/agents/[id]`** — catalog + usage stats for agents. Supports `?source`, `?project`, `?q` filters.
+- **`GET /api/skills`** and **`GET /api/skills/[id]`** — catalog + usage stats for skills. Same filters.
 - **System Status page (`/status`)** — live cross-project view of all Claude Code sessions grouped into four buckets: Needs Approval, Working, Waiting for You, and Other/Stale. Polls every 3 seconds. Worktree sessions appear labeled by branch. The nav "Status" item shows an approval-bucket count badge (updates every 10s). Classification uses a 4-state heuristic: stalled mtime on write-type tools (Edit/Write/MultiEdit/NotebookEdit) → Approval; active tools → Working; clean `end_turn` with no pending tools → Waiting; stale > 10min → Other.
 - **Memory tab on project detail pages** — browse Claude Code's auto-memory files for each project (`~/.claude/projects/<encoded>/memory/`). MEMORY.md rendered as an index overview pane; other `.md` files listed in a two-panel browser with YAML-frontmatter type badges (user/feedback/project/reference) and on-demand content rendering.
 - **`GET /api/status`** — new route returning live session classifications across all projects and worktrees (3s server-side cache with cross-poll mtime tracking for approval detection).
@@ -20,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Cost estimates are now consistent across `/sessions`, `/usage`, and `/stats`. Previously, session scanning used hardcoded Sonnet-3.5-era pricing constants while `/usage` used LiteLLM-backed per-model pricing, causing divergent numbers. All cost calculations now route through `costCalculator.ts` with per-model token attribution.
 - **Usage "By Project" deduplication** — worktree sessions (e.g., `.worktrees/my-branch` or `.claude-worktrees/feature`) were appearing as separate projects in the By Project breakdown. They are now correctly merged into their parent project.
+- **Agents/Skills "Invoked here" now works** — the project filter in `/api/agents` and `/api/skills` was comparing scanner slugs (e.g. `project-minder`) against usage slugs (e.g. `dev-project-minder`), so "Invoked here" always showed zero results. Both routes now translate the project path to the correct usage-format slug via `pathToUsageSlug`.
+- **Project agents/skills now appear after first scan** — `loadCatalog({ includeProjects: true })` could cache an empty project list if called before the first scan completed; subsequent requests would see no project-local entries for the full 5-minute TTL. The catalog now skips caching the `withProjects` slot when the scan cache is empty, and the scan route explicitly invalidates the catalog cache so project entries appear immediately after a scan.
 
 ## [0.9.3] - 2026-04-16
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ Project: **Project Minder** — local-only dashboard that auto-scans `C:\dev\*` 
 - `GET /api/usage/export` — CSV/JSON export (`?format=csv|json`, same period/project params)
 - `GET /api/sessions` — all session summaries (2-min cache, `?project=slug` filter)
 - `GET /api/sessions/[sessionId]` — full session detail (timeline, file ops, subagents)
+- `GET /api/agents` — catalog of all agents (user/plugin/project sources) joined with usage stats; `?source=user|plugin|project`, `?project=slug`, `?q=search`
+- `GET /api/agents/[id]` — single agent entry with full body text + usage stats
+- `GET /api/skills` — catalog of all skills with usage stats; same query params
+- `GET /api/skills/[id]` — single skill entry with full body text + usage stats
 
 ### UI (`src/components/`)
 - Dashboard: `DashboardGrid` with search, status filter, sort options, `ProjectCard` grid
@@ -104,6 +108,8 @@ Project: **Project Minder** — local-only dashboard that auto-scans `C:\dev\*` 
 - Stats: `StatsDashboard` at `/stats` with `StatCard`, `BarChart`, `HealthBar` sub-components
 - Sessions: `SessionsBrowser` at `/sessions` lists all Claude Code sessions with one-shot rate badges. `SessionDetailView` at `/sessions/[sessionId]` with timeline, file ops, subagents tabs. Parser (`claudeConversations.ts`) reads `~/.claude/projects/` JSONL files
 - Usage: `UsageDashboard` at `/usage` — token cost analytics with period filters, per-model/project/category breakdowns, daily cost chart, tool/shell/MCP stats, CSV/JSON export
+- Agents: `AgentsBrowser` at `/agents` — cross-project catalog with search/filter/sort and inline expansion. `ProjectAgentsTab` per-project. Indexer at `src/lib/indexer/` (walks root, plugins, project-level agents).
+- Skills: `SkillsBrowser` at `/skills` — same shape for skills. `ProjectSkillsTab` per-project. Supports bundled (`SKILL.md`-in-dir) and standalone `.md` layouts.
 - `DevServerControl` — compact mode on cards (start/stop badge), full mode on detail page (start/stop/restart, open in browser, output viewer)
 - Hand-rolled UI primitives in `src/components/ui/` (badge, button, input, tabs, skeleton, toast)
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,14 @@
 - [x] **Use dropdown menu dep** — `@radix-ui/react-dropdown-menu` now used for project card action menu.
 - [x] **Remove `@radix-ui/react-separator`** — Uninstalled.
 
+## Agents & Skills Pages (Phase 2)
+
+- [ ] **Per-agent cost attribution** — re-include sidechain entries in `parser.ts` behind an `includeSidechains` flag. Build `attachAgentCost()` that groups sidechain turns by `parentToolUseID` and sums token costs. Verify `/usage` totals don't shift.
+- [ ] **ProjectCard agent/skill badges** — show a small count of project-local agents/skills in the attention signals row (`src/components/ProjectCard.tsx:181-219`).
+- [ ] **Frontmatter linting** — skill/agent rows flagged with a lint chip when `name` or `description` is missing/truncated. Inspiration from skillfile spec.
+- [ ] **Slash commands indexing** — extend catalog to index `commands/*.md` files (with `allowed-tools` frontmatter) as a third catalog kind, alongside agents and skills.
+- [ ] **Per-item detail pages** — dedicated `/agents/[id]` and `/skills/[id]` routes when usage-history graphs / time-series views become valuable.
+
 ## Public Repo Hardening (follow-ups to branch protection)
 
 - [ ] **Community files** — Add `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant), `SECURITY.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `.github/ISSUE_TEMPLATE/` issue forms. Add `CODEOWNERS` listing yourself so GitHub auto-requests your review on external PRs.

--- a/docs/help/agents.md
+++ b/docs/help/agents.md
@@ -1,0 +1,31 @@
+# Agents
+
+The Agents page shows every Claude Code agent available to you — from your personal `~/.claude/agents/` folder, installed plugins, and any project-specific agents — alongside how often each has been invoked.
+
+## What Is an Agent?
+
+An agent is a named persona defined in a Markdown file with YAML frontmatter. It can have a specific model, a restricted toolset, and a system-style description. Agents are invoked via the `Agent` tool (with a `subagent_type` argument) inside Claude Code sessions.
+
+## Sources
+
+- **User** — agents in `~/.claude/agents/` (and category subdirectories like `engineering/`, `marketing/`)
+- **Plugin** — agents shipped with installed plugins (e.g., `feature-dev:code-reviewer`)
+- **Project** — agents in `<project>/.claude/agents/` scoped to a specific project
+
+## Cross-Project Browser (`/agents`)
+
+- **Search** — filters by name, description, category, and plugin name
+- **Source filter** — narrow to user / plugin / project agents
+- **Sort** — by most invoked, recently used, or name A–Z
+- **Expand row** — shows tools, body excerpt, recent session links, and a "View full body" toggle
+
+## Per-Project Agents Tab
+
+On each project's detail page, the **Agents** tab shows:
+
+- **Available (project-local)** — agents defined in the project's `.claude/agents/` folder
+- **Invoked here** — any agent used in this project's sessions, sorted by invocation count
+
+## Usage Statistics
+
+Invocation counts come from session history (`~/.claude/projects/`). The `Agent` tool call's `subagent_type` argument is matched against the catalog. Plugin-namespaced invocations (e.g., `feature-dev:code-architect`) that don't match a catalog entry appear as **Plugin (uncategorized)** rows.

--- a/docs/help/skills.md
+++ b/docs/help/skills.md
@@ -1,0 +1,39 @@
+# Skills
+
+The Skills page catalogs all Claude Code skills available to you — from your personal `~/.claude/skills/` directory, installed plugins, and per-project skill definitions — alongside invocation statistics.
+
+## What Is a Skill?
+
+A skill is a reusable prompt template invoked via the `Skill` tool inside Claude Code sessions. Skills live as Markdown files with YAML frontmatter and can be user-invocable (triggered via `/skillname` slash commands) or invoked programmatically.
+
+## File Layouts
+
+Two layouts are supported:
+
+- **Bundled** — a directory named after the skill containing `SKILL.md` (e.g., `~/.claude/skills/audit/SKILL.md`)
+- **Standalone** — a plain `.md` file directly in the skills root
+
+## Sources
+
+- **User** — skills in `~/.claude/skills/`
+- **Plugin** — skills from installed plugins (e.g., `vercel:nextjs`, `clerk-setup`)
+- **Project** — skills in `<project>/.claude/skills/`
+
+## Cross-Project Browser (`/skills`)
+
+- **Search** — filters by name, description, and plugin name
+- **Source filter** — narrow to user / plugin / project skills
+- **Sort** — by most invoked, recently used, or name A–Z
+- **Row chips** — version badge, slash-command hint (for user-invocable skills), `standalone` layout indicator
+- **Expand row** — shows body excerpt, recent sessions, and a "View full body" toggle
+
+## Per-Project Skills Tab
+
+On each project's detail page, the **Skills** tab shows:
+
+- **Available (project-local)** — skills in the project's `.claude/skills/` folder
+- **Invoked here** — skills used in this project's session history, sorted by invocation count
+
+## Usage Statistics
+
+Invocation counts come from the `Skill` tool call's `skill` argument in session history. Plugin-namespaced invocations (e.g., `vercel:deploy`) are matched against the catalog by the `pluginname:slug` alias key. Unmatched names appear as **Plugin (uncategorized)** rows.

--- a/public/help/agents.md
+++ b/public/help/agents.md
@@ -1,0 +1,31 @@
+# Agents
+
+The Agents page shows every Claude Code agent available to you — from your personal `~/.claude/agents/` folder, installed plugins, and any project-specific agents — alongside how often each has been invoked.
+
+## What Is an Agent?
+
+An agent is a named persona defined in a Markdown file with YAML frontmatter. It can have a specific model, a restricted toolset, and a system-style description. Agents are invoked via the `Agent` tool (with a `subagent_type` argument) inside Claude Code sessions.
+
+## Sources
+
+- **User** — agents in `~/.claude/agents/` (and category subdirectories like `engineering/`, `marketing/`)
+- **Plugin** — agents shipped with installed plugins (e.g., `feature-dev:code-reviewer`)
+- **Project** — agents in `<project>/.claude/agents/` scoped to a specific project
+
+## Cross-Project Browser (`/agents`)
+
+- **Search** — filters by name, description, category, and plugin name
+- **Source filter** — narrow to user / plugin / project agents
+- **Sort** — by most invoked, recently used, or name A–Z
+- **Expand row** — shows tools, body excerpt, recent session links, and a "View full body" toggle
+
+## Per-Project Agents Tab
+
+On each project's detail page, the **Agents** tab shows:
+
+- **Available (project-local)** — agents defined in the project's `.claude/agents/` folder
+- **Invoked here** — any agent used in this project's sessions, sorted by invocation count
+
+## Usage Statistics
+
+Invocation counts come from session history (`~/.claude/projects/`). The `Agent` tool call's `subagent_type` argument is matched against the catalog. Plugin-namespaced invocations (e.g., `feature-dev:code-architect`) that don't match a catalog entry appear as **Plugin (uncategorized)** rows.

--- a/public/help/skills.md
+++ b/public/help/skills.md
@@ -1,0 +1,39 @@
+# Skills
+
+The Skills page catalogs all Claude Code skills available to you — from your personal `~/.claude/skills/` directory, installed plugins, and per-project skill definitions — alongside invocation statistics.
+
+## What Is a Skill?
+
+A skill is a reusable prompt template invoked via the `Skill` tool inside Claude Code sessions. Skills live as Markdown files with YAML frontmatter and can be user-invocable (triggered via `/skillname` slash commands) or invoked programmatically.
+
+## File Layouts
+
+Two layouts are supported:
+
+- **Bundled** — a directory named after the skill containing `SKILL.md` (e.g., `~/.claude/skills/audit/SKILL.md`)
+- **Standalone** — a plain `.md` file directly in the skills root
+
+## Sources
+
+- **User** — skills in `~/.claude/skills/`
+- **Plugin** — skills from installed plugins (e.g., `vercel:nextjs`, `clerk-setup`)
+- **Project** — skills in `<project>/.claude/skills/`
+
+## Cross-Project Browser (`/skills`)
+
+- **Search** — filters by name, description, and plugin name
+- **Source filter** — narrow to user / plugin / project skills
+- **Sort** — by most invoked, recently used, or name A–Z
+- **Row chips** — version badge, slash-command hint (for user-invocable skills), `standalone` layout indicator
+- **Expand row** — shows body excerpt, recent sessions, and a "View full body" toggle
+
+## Per-Project Skills Tab
+
+On each project's detail page, the **Skills** tab shows:
+
+- **Available (project-local)** — skills in the project's `.claude/skills/` folder
+- **Invoked here** — skills used in this project's session history, sorted by invocation count
+
+## Usage Statistics
+
+Invocation counts come from the `Skill` tool call's `skill` argument in session history. Plugin-namespaced invocations (e.g., `vercel:deploy`) are matched against the catalog by the `pluginname:slug` alias key. Unmatched names appear as **Plugin (uncategorized)** rows.

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { AgentsBrowser } from "@/components/AgentsBrowser";
+
+export default function AgentsPage() {
+  return <AgentsBrowser />;
+}

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import { loadCatalog } from "@/lib/indexer/catalog";
+import { parseAllSessions } from "@/lib/usage/parser";
+import { groupAgentCalls } from "@/lib/usage/agentParser";
+import { buildAgentAliasMap } from "@/lib/indexer/canonicalize";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const catalog = await loadCatalog({ includeProjects: true });
+  const entry = catalog.agents.find((a) => a.id === id);
+
+  if (!entry) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const [bodyText, sessionMap] = await Promise.all([
+    fs.readFile(entry.filePath, "utf-8").catch(() => ""),
+    parseAllSessions(),
+  ]);
+
+  const allTurns = Array.from(sessionMap.values()).flat();
+  const statsArr = groupAgentCalls(allTurns);
+  const aliasMap = buildAgentAliasMap(catalog.agents);
+  const usage = statsArr.find(
+    (s) => aliasMap.get(s.name.toLowerCase()) === entry
+  );
+
+  return NextResponse.json({ entry, bodyFull: bodyText, usage });
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { loadCatalog } from "@/lib/indexer/catalog";
+import { buildAgentAliasMap } from "@/lib/indexer/canonicalize";
+import { parseAllSessions } from "@/lib/usage/parser";
+import { groupAgentCalls } from "@/lib/usage/agentParser";
+import { getCachedScan } from "@/lib/cache";
+import { pathToUsageSlug } from "@/lib/usage/slug";
+import type { AgentStats } from "@/lib/usage/types";
+import type { AgentEntry } from "@/lib/indexer/types";
+
+const CACHE_TTL_MS = 2 * 60 * 1000;
+
+interface AgentRow {
+  entry?: AgentEntry;
+  usage?: AgentStats;
+  catalogMissing?: boolean;
+}
+
+const globalForAgents = globalThis as unknown as {
+  __agentsRouteCache?: Map<string, { data: AgentRow[]; cachedAt: number }>;
+};
+
+function getRouteCache(key: string): AgentRow[] | null {
+  const cache = globalForAgents.__agentsRouteCache;
+  if (!cache) return null;
+  const slot = cache.get(key);
+  if (!slot) return null;
+  if (Date.now() - slot.cachedAt < CACHE_TTL_MS) return slot.data;
+  return null;
+}
+
+function setRouteCache(key: string, data: AgentRow[]) {
+  if (!globalForAgents.__agentsRouteCache) {
+    globalForAgents.__agentsRouteCache = new Map();
+  }
+  globalForAgents.__agentsRouteCache.set(key, { data, cachedAt: Date.now() });
+}
+
+export async function GET(request: NextRequest) {
+  const source = request.nextUrl.searchParams.get("source");
+  const projectSlug = request.nextUrl.searchParams.get("project");
+  const query = request.nextUrl.searchParams.get("q")?.toLowerCase();
+
+  const cacheKey = `${source ?? ""}|${projectSlug ?? ""}|${query ?? ""}`;
+  const cached = getRouteCache(cacheKey);
+  if (cached) return NextResponse.json(cached);
+
+  const [catalog, sessionMap] = await Promise.all([
+    loadCatalog({ includeProjects: true }),
+    parseAllSessions(),
+  ]);
+
+  // Flatten all turns
+  const allTurns = Array.from(sessionMap.values()).flat();
+  const statsArr = groupAgentCalls(allTurns);
+
+  const aliasMap = buildAgentAliasMap(catalog.agents);
+  const rows: AgentRow[] = [];
+  const matchedNames = new Set<string>();
+
+  // Emit catalog entries, attach usage if available
+  for (const entry of catalog.agents) {
+    const usage = statsArr.find(
+      (s) => aliasMap.get(s.name.toLowerCase()) === entry
+    );
+    if (usage) matchedNames.add(usage.name);
+    rows.push({ entry, usage });
+  }
+
+  // Orphan stats: invoked names not matched to any catalog entry
+  for (const stat of statsArr) {
+    if (!matchedNames.has(stat.name)) {
+      rows.push({ usage: stat, catalogMissing: true });
+    }
+  }
+
+  // Apply filters
+  let result = rows;
+
+  if (source) {
+    result = result.filter((r) => r.entry?.source === source || r.catalogMissing);
+  }
+
+  if (projectSlug) {
+    // The usage module stores project keys in the encoded path format
+    // (e.g. "c--dev-project-minder") while the scanner uses the short
+    // directory-basename form ("project-minder"). Look up the project path
+    // and compute the matching usage slug so "Invoked here" works correctly.
+    const scan = getCachedScan();
+    const projectPath = scan?.projects?.find((p) => p.slug === projectSlug)?.path;
+    const usageSlug = projectPath ? pathToUsageSlug(projectPath) : projectSlug;
+
+    result = result.filter(
+      (r) =>
+        r.entry?.projectSlug === projectSlug ||
+        (r.usage?.projects[usageSlug] ?? 0) > 0 ||
+        (r.usage?.projects[projectSlug] ?? 0) > 0
+    );
+  }
+
+  if (query) {
+    result = result.filter((r) => {
+      const text = [
+        r.entry?.name,
+        r.entry?.description,
+        r.entry?.category,
+        r.entry?.pluginName,
+        r.usage?.name,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return text.includes(query);
+    });
+  }
+
+  setRouteCache(cacheKey, result);
+  return NextResponse.json(result);
+}

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -36,6 +36,10 @@ function setRouteCache(key: string, data: AgentRow[]) {
   globalForAgents.__agentsRouteCache.set(key, { data, cachedAt: Date.now() });
 }
 
+export function invalidateAgentsRouteCache() {
+  globalForAgents.__agentsRouteCache = new Map();
+}
+
 export async function GET(request: NextRequest) {
   const source = request.nextUrl.searchParams.get("source");
   const projectSlug = request.nextUrl.searchParams.get("project");
@@ -50,7 +54,6 @@ export async function GET(request: NextRequest) {
     parseAllSessions(),
   ]);
 
-  // Flatten all turns
   const allTurns = Array.from(sessionMap.values()).flat();
   const statsArr = groupAgentCalls(allTurns);
 
@@ -58,7 +61,6 @@ export async function GET(request: NextRequest) {
   const rows: AgentRow[] = [];
   const matchedNames = new Set<string>();
 
-  // Emit catalog entries, attach usage if available
   for (const entry of catalog.agents) {
     const usage = statsArr.find(
       (s) => aliasMap.get(s.name.toLowerCase()) === entry
@@ -67,25 +69,22 @@ export async function GET(request: NextRequest) {
     rows.push({ entry, usage });
   }
 
-  // Orphan stats: invoked names not matched to any catalog entry
   for (const stat of statsArr) {
     if (!matchedNames.has(stat.name)) {
       rows.push({ usage: stat, catalogMissing: true });
     }
   }
 
-  // Apply filters
   let result = rows;
 
   if (source) {
-    result = result.filter((r) => r.entry?.source === source || r.catalogMissing);
+    // catalogMissing rows are orphan invocations — treat as plugin-origin only
+    result = result.filter(
+      (r) => r.entry?.source === source || (source === "plugin" && r.catalogMissing)
+    );
   }
 
   if (projectSlug) {
-    // The usage module stores project keys in the encoded path format
-    // (e.g. "c--dev-project-minder") while the scanner uses the short
-    // directory-basename form ("project-minder"). Look up the project path
-    // and compute the matching usage slug so "Invoked here" works correctly.
     const scan = getCachedScan();
     const projectPath = scan?.projects?.find((p) => p.slug === projectSlug)?.path;
     const usageSlug = projectPath ? pathToUsageSlug(projectPath) : projectSlug;
@@ -96,6 +95,17 @@ export async function GET(request: NextRequest) {
         (r.usage?.projects[usageSlug] ?? 0) > 0 ||
         (r.usage?.projects[projectSlug] ?? 0) > 0
     );
+
+    // Normalize: expose the count under the scanner slug so components don't
+    // need to know about the usage slug format.
+    if (usageSlug !== projectSlug) {
+      result = result.map((r) => {
+        if (!r.usage) return r;
+        const count = r.usage.projects[usageSlug] ?? 0;
+        if (count === 0 || r.usage.projects[projectSlug]) return r;
+        return { ...r, usage: { ...r.usage, projects: { ...r.usage.projects, [projectSlug]: count } } };
+      });
+    }
   }
 
   if (query) {

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -2,10 +2,14 @@ import { NextResponse } from "next/server";
 import { scanAllProjects } from "@/lib/scanner";
 import { invalidateCache, setCachedScan } from "@/lib/cache";
 import { invalidateCatalogCache } from "@/lib/indexer/catalog";
+import { invalidateAgentsRouteCache } from "@/app/api/agents/route";
+import { invalidateSkillsRouteCache } from "@/app/api/skills/route";
 
 export async function POST() {
   invalidateCache();
   invalidateCatalogCache();
+  invalidateAgentsRouteCache();
+  invalidateSkillsRouteCache();
   const result = await scanAllProjects();
   setCachedScan(result);
   return NextResponse.json(result);

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
 import { scanAllProjects } from "@/lib/scanner";
 import { invalidateCache, setCachedScan } from "@/lib/cache";
+import { invalidateCatalogCache } from "@/lib/indexer/catalog";
 
 export async function POST() {
   invalidateCache();
+  invalidateCatalogCache();
   const result = await scanAllProjects();
   setCachedScan(result);
   return NextResponse.json(result);

--- a/src/app/api/skills/[id]/route.ts
+++ b/src/app/api/skills/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import { loadCatalog } from "@/lib/indexer/catalog";
+import { parseAllSessions } from "@/lib/usage/parser";
+import { groupSkillCalls } from "@/lib/usage/skillParser";
+import { buildSkillAliasMap } from "@/lib/indexer/canonicalize";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const catalog = await loadCatalog({ includeProjects: true });
+  const entry = catalog.skills.find((s) => s.id === id);
+
+  if (!entry) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const [bodyText, sessionMap] = await Promise.all([
+    fs.readFile(entry.filePath, "utf-8").catch(() => ""),
+    parseAllSessions(),
+  ]);
+
+  const allTurns = Array.from(sessionMap.values()).flat();
+  const statsArr = groupSkillCalls(allTurns);
+  const aliasMap = buildSkillAliasMap(catalog.skills);
+  const usage = statsArr.find(
+    (s) => aliasMap.get(s.name.toLowerCase()) === entry
+  );
+
+  return NextResponse.json({ entry, bodyFull: bodyText, usage });
+}

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -36,6 +36,10 @@ function setRouteCache(key: string, data: SkillRow[]) {
   globalForSkills.__skillsRouteCache.set(key, { data, cachedAt: Date.now() });
 }
 
+export function invalidateSkillsRouteCache() {
+  globalForSkills.__skillsRouteCache = new Map();
+}
+
 export async function GET(request: NextRequest) {
   const source = request.nextUrl.searchParams.get("source");
   const projectSlug = request.nextUrl.searchParams.get("project");
@@ -74,7 +78,10 @@ export async function GET(request: NextRequest) {
   let result = rows;
 
   if (source) {
-    result = result.filter((r) => r.entry?.source === source || r.catalogMissing);
+    // catalogMissing rows are orphan invocations — treat as plugin-origin only
+    result = result.filter(
+      (r) => r.entry?.source === source || (source === "plugin" && r.catalogMissing)
+    );
   }
 
   if (projectSlug) {
@@ -88,6 +95,17 @@ export async function GET(request: NextRequest) {
         (r.usage?.projects[usageSlug] ?? 0) > 0 ||
         (r.usage?.projects[projectSlug] ?? 0) > 0
     );
+
+    // Normalize: expose the count under the scanner slug so components don't
+    // need to know about the usage slug format.
+    if (usageSlug !== projectSlug) {
+      result = result.map((r) => {
+        if (!r.usage) return r;
+        const count = r.usage.projects[usageSlug] ?? 0;
+        if (count === 0 || r.usage.projects[projectSlug]) return r;
+        return { ...r, usage: { ...r.usage, projects: { ...r.usage.projects, [projectSlug]: count } } };
+      });
+    }
   }
 
   if (query) {

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { loadCatalog } from "@/lib/indexer/catalog";
+import { buildSkillAliasMap } from "@/lib/indexer/canonicalize";
+import { parseAllSessions } from "@/lib/usage/parser";
+import { groupSkillCalls } from "@/lib/usage/skillParser";
+import { getCachedScan } from "@/lib/cache";
+import { pathToUsageSlug } from "@/lib/usage/slug";
+import type { SkillStats } from "@/lib/usage/types";
+import type { SkillEntry } from "@/lib/indexer/types";
+
+const CACHE_TTL_MS = 2 * 60 * 1000;
+
+interface SkillRow {
+  entry?: SkillEntry;
+  usage?: SkillStats;
+  catalogMissing?: boolean;
+}
+
+const globalForSkills = globalThis as unknown as {
+  __skillsRouteCache?: Map<string, { data: SkillRow[]; cachedAt: number }>;
+};
+
+function getRouteCache(key: string): SkillRow[] | null {
+  const cache = globalForSkills.__skillsRouteCache;
+  if (!cache) return null;
+  const slot = cache.get(key);
+  if (!slot) return null;
+  if (Date.now() - slot.cachedAt < CACHE_TTL_MS) return slot.data;
+  return null;
+}
+
+function setRouteCache(key: string, data: SkillRow[]) {
+  if (!globalForSkills.__skillsRouteCache) {
+    globalForSkills.__skillsRouteCache = new Map();
+  }
+  globalForSkills.__skillsRouteCache.set(key, { data, cachedAt: Date.now() });
+}
+
+export async function GET(request: NextRequest) {
+  const source = request.nextUrl.searchParams.get("source");
+  const projectSlug = request.nextUrl.searchParams.get("project");
+  const query = request.nextUrl.searchParams.get("q")?.toLowerCase();
+
+  const cacheKey = `${source ?? ""}|${projectSlug ?? ""}|${query ?? ""}`;
+  const cached = getRouteCache(cacheKey);
+  if (cached) return NextResponse.json(cached);
+
+  const [catalog, sessionMap] = await Promise.all([
+    loadCatalog({ includeProjects: true }),
+    parseAllSessions(),
+  ]);
+
+  const allTurns = Array.from(sessionMap.values()).flat();
+  const statsArr = groupSkillCalls(allTurns);
+
+  const aliasMap = buildSkillAliasMap(catalog.skills);
+  const rows: SkillRow[] = [];
+  const matchedNames = new Set<string>();
+
+  for (const entry of catalog.skills) {
+    const usage = statsArr.find(
+      (s) => aliasMap.get(s.name.toLowerCase()) === entry
+    );
+    if (usage) matchedNames.add(usage.name);
+    rows.push({ entry, usage });
+  }
+
+  for (const stat of statsArr) {
+    if (!matchedNames.has(stat.name)) {
+      rows.push({ usage: stat, catalogMissing: true });
+    }
+  }
+
+  let result = rows;
+
+  if (source) {
+    result = result.filter((r) => r.entry?.source === source || r.catalogMissing);
+  }
+
+  if (projectSlug) {
+    const scan = getCachedScan();
+    const projectPath = scan?.projects?.find((p) => p.slug === projectSlug)?.path;
+    const usageSlug = projectPath ? pathToUsageSlug(projectPath) : projectSlug;
+
+    result = result.filter(
+      (r) =>
+        r.entry?.projectSlug === projectSlug ||
+        (r.usage?.projects[usageSlug] ?? 0) > 0 ||
+        (r.usage?.projects[projectSlug] ?? 0) > 0
+    );
+  }
+
+  if (query) {
+    result = result.filter((r) => {
+      const text = [
+        r.entry?.name,
+        r.entry?.description,
+        r.entry?.pluginName,
+        r.usage?.name,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return text.includes(query);
+    });
+  }
+
+  setRouteCache(cacheKey, result);
+  return NextResponse.json(result);
+}

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SkillsBrowser } from "@/components/SkillsBrowser";
+
+export default function SkillsPage() {
+  return <SkillsBrowser />;
+}

--- a/src/components/AgentsBrowser.tsx
+++ b/src/components/AgentsBrowser.tsx
@@ -1,0 +1,542 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import { useAgents, type AgentRow } from "@/hooks/useAgents";
+import { Bot, Search, ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
+import Link from "next/link";
+
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (!isFinite(d.getTime())) return "—";
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString();
+}
+
+// ── Source badge ──────────────────────────────────────────────────────────────
+
+function SourceBadge({ row }: { row: AgentRow }) {
+  const source = row.entry?.source ?? "plugin";
+  const label = row.catalogMissing
+    ? `plugin (${row.usage?.name?.split(":")[0] ?? "?"})`
+    : source === "plugin"
+    ? `plugin: ${row.entry?.pluginName ?? ""}`
+    : source;
+  const color =
+    source === "user"
+      ? "var(--text-secondary)"
+      : source === "plugin"
+      ? "var(--accent)"
+      : "var(--success, #4ade80)";
+
+  return (
+    <span
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6rem",
+        color,
+        background: "var(--bg-surface)",
+        border: `1px solid var(--border-subtle)`,
+        borderRadius: "3px",
+        padding: "1px 5px",
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ── Single row ────────────────────────────────────────────────────────────────
+
+function AgentRow({ row }: { row: AgentRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const [bodyFull, setBodyFull] = useState<string | null>(null);
+  const [bodyLoading, setBodyLoading] = useState(false);
+
+  const name = row.entry?.name ?? row.usage?.name ?? "Unknown";
+  const description = row.entry?.description ?? "";
+  const truncDesc =
+    description.length > 160 ? description.slice(0, 160) + "…" : description;
+
+  async function fetchBody() {
+    if (bodyFull !== null || !row.entry?.id) return;
+    setBodyLoading(true);
+    try {
+      const res = await fetch(`/api/agents/${encodeURIComponent(row.entry.id)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setBodyFull(data.bodyFull ?? "");
+      }
+    } finally {
+      setBodyLoading(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        padding: "10px 0",
+        borderBottom: "1px solid var(--border-subtle)",
+      }}
+    >
+      {/* Main row */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: "8px",
+          cursor: "pointer",
+        }}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span
+          style={{
+            marginTop: "2px",
+            color: "var(--text-muted)",
+            flexShrink: 0,
+          }}
+        >
+          {expanded ? (
+            <ChevronDown style={{ width: "12px", height: "12px" }} />
+          ) : (
+            <ChevronRight style={{ width: "12px", height: "12px" }} />
+          )}
+        </span>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              flexWrap: "wrap",
+              marginBottom: "3px",
+            }}
+          >
+            <span
+              style={{
+                fontSize: "0.78rem",
+                fontWeight: 600,
+                color: "var(--text-primary)",
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {name}
+            </span>
+            <SourceBadge row={row} />
+            {row.entry?.category && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.6rem",
+                  color: "var(--text-muted)",
+                  background: "var(--bg-surface)",
+                  border: "1px solid var(--border-subtle)",
+                  borderRadius: "3px",
+                  padding: "1px 5px",
+                }}
+              >
+                {row.entry.category}
+              </span>
+            )}
+            {row.entry?.model && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.6rem",
+                  color: "var(--text-muted)",
+                }}
+              >
+                {row.entry.model}
+              </span>
+            )}
+          </div>
+          {truncDesc && (
+            <p
+              style={{
+                fontSize: "0.72rem",
+                color: "var(--text-secondary)",
+                margin: 0,
+                lineHeight: 1.45,
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {truncDesc}
+            </p>
+          )}
+        </div>
+
+        {/* Stats */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-end",
+            gap: "2px",
+            flexShrink: 0,
+          }}
+        >
+          {row.usage && row.usage.invocations > 0 && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.65rem",
+                fontWeight: 600,
+                color: "var(--accent)",
+              }}
+            >
+              {row.usage.invocations}×
+            </span>
+          )}
+          {row.usage?.lastUsed && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6rem",
+                color: "var(--text-muted)",
+              }}
+            >
+              {formatDate(row.usage.lastUsed)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div
+          style={{
+            marginTop: "10px",
+            marginLeft: "20px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+          }}
+        >
+          {row.entry?.tools && row.entry.tools.length > 0 && (
+            <div
+              style={{
+                fontSize: "0.65rem",
+                color: "var(--text-muted)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              tools: {row.entry.tools.join(", ")}
+            </div>
+          )}
+
+          {row.entry?.bodyExcerpt && (
+            <pre
+              style={{
+                fontSize: "0.68rem",
+                color: "var(--text-secondary)",
+                fontFamily: "var(--font-mono)",
+                background: "var(--bg-surface)",
+                border: "1px solid var(--border-subtle)",
+                borderRadius: "var(--radius)",
+                padding: "8px",
+                margin: 0,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                maxHeight: "140px",
+                overflow: "hidden",
+              }}
+            >
+              {bodyFull ?? row.entry.bodyExcerpt}
+            </pre>
+          )}
+
+          {row.entry?.id && bodyFull === null && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                fetchBody();
+              }}
+              disabled={bodyLoading}
+              style={{
+                alignSelf: "flex-start",
+                background: "transparent",
+                border: "none",
+                padding: 0,
+                fontSize: "0.65rem",
+                color: "var(--accent)",
+                cursor: "pointer",
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {bodyLoading ? "loading…" : "View full body →"}
+            </button>
+          )}
+
+          {row.usage && row.usage.sessions.length > 0 && (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
+              {row.usage.sessions.slice(0, 5).map((sid) => (
+                <Link
+                  key={sid}
+                  href={`/sessions/${sid}`}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "3px",
+                    fontSize: "0.6rem",
+                    fontFamily: "var(--font-mono)",
+                    color: "var(--text-muted)",
+                    textDecoration: "none",
+                  }}
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                >
+                  <ExternalLink style={{ width: "9px", height: "9px" }} />
+                  {sid.slice(0, 8)}
+                </Link>
+              ))}
+              {row.usage.sessions.length > 5 && (
+                <span
+                  style={{
+                    fontSize: "0.6rem",
+                    color: "var(--text-muted)",
+                    fontFamily: "var(--font-mono)",
+                  }}
+                >
+                  +{row.usage.sessions.length - 5} more
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main browser ──────────────────────────────────────────────────────────────
+
+type SortKey = "name" | "invocations" | "lastUsed";
+type SourceFilter = "all" | "user" | "plugin" | "project";
+
+export function AgentsBrowser() {
+  const [rawQuery, setRawQuery] = useState("");
+  const [query, setQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const [sortBy, setSortBy] = useState<SortKey>("invocations");
+
+  // 300ms debounce on search
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(rawQuery), 300);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  const { data, loading } = useAgents();
+
+  const filtered = useMemo(() => {
+    let rows = data;
+
+    if (sourceFilter !== "all") {
+      rows = rows.filter((r) => {
+        if (r.catalogMissing) return sourceFilter === "plugin";
+        return r.entry?.source === sourceFilter;
+      });
+    }
+
+    if (query) {
+      const q = query.toLowerCase();
+      rows = rows.filter((r) => {
+        const text = [
+          r.entry?.name,
+          r.entry?.description,
+          r.entry?.category,
+          r.entry?.pluginName,
+          r.usage?.name,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        return text.includes(q);
+      });
+    }
+
+    rows = [...rows].sort((a, b) => {
+      if (sortBy === "name") {
+        const an = a.entry?.name ?? a.usage?.name ?? "";
+        const bn = b.entry?.name ?? b.usage?.name ?? "";
+        return an.localeCompare(bn);
+      }
+      if (sortBy === "invocations") {
+        return (b.usage?.invocations ?? 0) - (a.usage?.invocations ?? 0);
+      }
+      // lastUsed
+      const at = a.usage?.lastUsed ?? "";
+      const bt = b.usage?.lastUsed ?? "";
+      return bt.localeCompare(at);
+    });
+
+    return rows;
+  }, [data, sourceFilter, query, sortBy]);
+
+  const total = data.length;
+  const invoked = data.filter((r) => (r.usage?.invocations ?? 0) > 0).length;
+
+  const segmentStyle = (active: boolean): React.CSSProperties => ({
+    padding: "3px 9px",
+    fontSize: "0.65rem",
+    fontFamily: "var(--font-body)",
+    fontWeight: active ? 600 : 400,
+    color: active ? "var(--accent)" : "var(--text-muted)",
+    background: active ? "var(--accent-bg)" : "transparent",
+    border: "1px solid var(--border-subtle)",
+    borderRadius: "var(--radius)",
+    cursor: "pointer",
+  });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <Bot style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
+        <h1
+          style={{
+            fontSize: "0.72rem",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--text-secondary)",
+            fontFamily: "var(--font-body)",
+          }}
+        >
+          Agents
+        </h1>
+        {total > 0 && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.65rem",
+              color: "var(--text-muted)",
+            }}
+          >
+            {total} total · {invoked} invoked
+          </span>
+        )}
+      </div>
+
+      {/* Toolbar */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+        {/* Search */}
+        <div style={{ position: "relative", flex: "1 1 200px", minWidth: "160px" }}>
+          <Search
+            style={{
+              position: "absolute",
+              left: "9px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              width: "13px",
+              height: "13px",
+              color: "var(--text-muted)",
+              pointerEvents: "none",
+            }}
+          />
+          <input
+            type="text"
+            placeholder="Search agents…"
+            value={rawQuery}
+            onChange={(e) => setRawQuery(e.target.value)}
+            style={{
+              width: "100%",
+              padding: "5px 9px 5px 28px",
+              fontSize: "0.72rem",
+              fontFamily: "var(--font-body)",
+              background: "var(--bg-surface)",
+              border: "1px solid var(--border-subtle)",
+              borderRadius: "var(--radius)",
+              color: "var(--text-primary)",
+              outline: "none",
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        {/* Source filter */}
+        <div style={{ display: "flex", gap: "3px" }}>
+          {(["all", "user", "plugin", "project"] as SourceFilter[]).map((s) => (
+            <button key={s} onClick={() => setSourceFilter(s)} style={segmentStyle(sourceFilter === s)}>
+              {s}
+            </button>
+          ))}
+        </div>
+
+        {/* Sort */}
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as SortKey)}
+          style={{
+            fontSize: "0.65rem",
+            fontFamily: "var(--font-body)",
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius)",
+            color: "var(--text-secondary)",
+            padding: "4px 7px",
+            cursor: "pointer",
+          }}
+        >
+          <option value="invocations">Most invoked</option>
+          <option value="lastUsed">Recently used</option>
+          <option value="name">Name A–Z</option>
+        </select>
+      </div>
+
+      {/* List */}
+      {loading ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          {[...Array(6)].map((_, i) => (
+            <div
+              key={i}
+              style={{
+                height: "48px",
+                background: "var(--bg-surface)",
+                borderRadius: "var(--radius)",
+                opacity: 0.5,
+              }}
+            />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div
+          style={{
+            textAlign: "center",
+            padding: "60px 20px",
+            color: "var(--text-muted)",
+          }}
+        >
+          <Bot style={{ width: "28px", height: "28px", opacity: 0.3, margin: "0 auto 8px" }} />
+          <p style={{ fontSize: "0.75rem", fontFamily: "var(--font-body)" }}>
+            {query || sourceFilter !== "all" ? "No agents match your filters." : "No agents found."}
+          </p>
+        </div>
+      ) : (
+        <div>
+          <div
+            style={{
+              fontSize: "0.62rem",
+              color: "var(--text-muted)",
+              fontFamily: "var(--font-mono)",
+              marginBottom: "4px",
+            }}
+          >
+            {filtered.length} agent{filtered.length !== 1 ? "s" : ""}
+          </div>
+          {filtered.map((row, i) => (
+            <AgentRow key={row.entry?.id ?? row.usage?.name ?? i} row={row} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -8,6 +8,8 @@ import type { LiveSession } from "@/lib/types";
 const navItems = [
   { href: "/manual-steps", label: "Steps",    badge: "steps"    },
   { href: "/insights",     label: "Insights"                    },
+  { href: "/agents",       label: "Agents"                      },
+  { href: "/skills",       label: "Skills"                      },
   { href: "/sessions",     label: "Sessions"                    },
   { href: "/status",       label: "Status",   badge: "approval" },
   { href: "/usage",        label: "Usage"                       },

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -18,6 +18,8 @@ const slugTitles: Record<HelpSlug, string> = {
   stats: "Stats Dashboard",
   sessions: "Sessions Browser",
   insights: "Insights",
+  agents: "Agents",
+  skills: "Skills",
   usage: "Usage Dashboard",
   status: "System Status",
   memory: "Memory Browser",

--- a/src/components/ProjectAgentsTab.tsx
+++ b/src/components/ProjectAgentsTab.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { Bot, ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { useAgents, type AgentRow } from "@/hooks/useAgents";
+
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (!isFinite(d.getTime())) return "—";
+  const diffDays = Math.floor((Date.now() - d.getTime()) / 86_400_000);
+  if (diffDays < 1) return "today";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString();
+}
+
+function CompactRow({ row, projectSlug }: { row: AgentRow; projectSlug: string }) {
+  const name = row.entry?.name ?? row.usage?.name ?? "Unknown";
+  const invocations = row.usage?.projects[projectSlug] ?? row.usage?.invocations ?? 0;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "7px 0",
+        borderBottom: "1px solid var(--border-subtle)",
+      }}
+    >
+      <span
+        style={{
+          fontSize: "0.78rem",
+          fontWeight: 500,
+          color: "var(--text-primary)",
+          fontFamily: "var(--font-body)",
+          flex: 1,
+          minWidth: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {name}
+      </span>
+      {row.entry?.model && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6rem",
+            color: "var(--text-muted)",
+          }}
+        >
+          {row.entry.model}
+        </span>
+      )}
+      {invocations > 0 && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.65rem",
+            fontWeight: 600,
+            color: "var(--accent)",
+          }}
+        >
+          {invocations}×
+        </span>
+      )}
+      {row.usage?.lastUsed && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6rem",
+            color: "var(--text-muted)",
+            flexShrink: 0,
+          }}
+        >
+          {formatDate(row.usage.lastUsed)}
+        </span>
+      )}
+      {row.usage?.sessions && row.usage.sessions[0] && (
+        <Link
+          href={`/sessions/${row.usage.sessions[0]}`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            color: "var(--text-muted)",
+            textDecoration: "none",
+          }}
+          title="Latest session"
+        >
+          <ExternalLink style={{ width: "10px", height: "10px" }} />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function SectionLabel({ label, count }: { label: string; count: number }) {
+  return (
+    <div
+      style={{
+        fontSize: "0.6rem",
+        fontWeight: 700,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: "var(--text-muted)",
+        fontFamily: "var(--font-body)",
+        marginBottom: "4px",
+        marginTop: "16px",
+      }}
+    >
+      {label}
+      <span style={{ marginLeft: "6px", fontWeight: 400 }}>({count})</span>
+    </div>
+  );
+}
+
+interface Props {
+  slug: string;
+}
+
+export function ProjectAgentsTab({ slug }: Props) {
+  const { data, loading } = useAgents(undefined, slug);
+
+  if (loading) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            style={{
+              height: "32px",
+              background: "var(--bg-surface)",
+              borderRadius: "var(--radius)",
+              opacity: 0.5,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const available = data.filter(
+    (r) => r.entry?.source === "project" && r.entry.projectSlug === slug
+  );
+  const invoked = data
+    .filter((r) => (r.usage?.projects[slug] ?? 0) > 0)
+    .sort((a, b) => (b.usage?.projects[slug] ?? 0) - (a.usage?.projects[slug] ?? 0));
+
+  const totalInvocations = invoked.reduce(
+    (sum, r) => sum + (r.usage?.projects[slug] ?? 0),
+    0
+  );
+
+  if (available.length === 0 && invoked.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          textAlign: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "8px",
+        }}
+      >
+        <Bot style={{ width: "24px", height: "24px", color: "var(--text-muted)", opacity: 0.3 }} />
+        <p style={{ fontSize: "0.78rem", color: "var(--text-muted)" }}>
+          No agents defined or invoked in this project.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {available.length > 0 && (
+        <>
+          <SectionLabel label="Available (project-local)" count={available.length} />
+          {available.map((row, i) => (
+            <CompactRow
+              key={row.entry?.id ?? i}
+              row={row}
+              projectSlug={slug}
+            />
+          ))}
+        </>
+      )}
+
+      {invoked.length > 0 && (
+        <>
+          <SectionLabel
+            label={`Invoked here · ${totalInvocations} total`}
+            count={invoked.length}
+          />
+          {invoked.map((row, i) => (
+            <CompactRow
+              key={row.entry?.id ?? row.usage?.name ?? i}
+              row={row}
+              projectSlug={slug}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -13,6 +13,8 @@ import { ProjectSessions } from "./ProjectSessions";
 import { GitStatusCompact } from "./GitStatus";
 import { MarkdownContent } from "./MarkdownContent";
 import { MemoryTab } from "./MemoryTab";
+import { ProjectAgentsTab } from "./ProjectAgentsTab";
+import { ProjectSkillsTab } from "./ProjectSkillsTab";
 import {
   ArrowLeft,
   ExternalLink,
@@ -30,7 +32,7 @@ import { formatDistanceToNow } from "date-fns";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-type TabKey = "overview" | "context" | "todos" | "sessions" | "manual-steps" | "insights" | "memory";
+type TabKey = "overview" | "context" | "todos" | "sessions" | "manual-steps" | "insights" | "memory" | "agents" | "skills";
 
 interface ProjectDetailProps {
   project: ProjectData;
@@ -102,6 +104,8 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
     { key: "manual-steps", label: "Manual Steps" },
     { key: "insights",    label: "Insights" },
     { key: "memory",      label: "Memory" },
+    { key: "agents",      label: "Agents" },
+    { key: "skills",      label: "Skills" },
   ];
 
   const actionBtn = (label: string, icon: React.ReactNode, onClick: () => void, href?: string) => {
@@ -483,6 +487,16 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
           {/* ── MEMORY ────────────────────────────────────────────────── */}
           {activeTab === "memory" && (
             <MemoryTab slug={project.slug} />
+          )}
+
+          {/* ── AGENTS ───────────────────────────────────────────────── */}
+          {activeTab === "agents" && (
+            <ProjectAgentsTab slug={project.slug} />
+          )}
+
+          {/* ── SKILLS ───────────────────────────────────────────────── */}
+          {activeTab === "skills" && (
+            <ProjectSkillsTab slug={project.slug} />
           )}
         </div>
       </div>

--- a/src/components/ProjectSkillsTab.tsx
+++ b/src/components/ProjectSkillsTab.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { Wrench, ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { useSkills, type SkillRow } from "@/hooks/useSkills";
+
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (!isFinite(d.getTime())) return "—";
+  const diffDays = Math.floor((Date.now() - d.getTime()) / 86_400_000);
+  if (diffDays < 1) return "today";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString();
+}
+
+function CompactRow({ row, projectSlug }: { row: SkillRow; projectSlug: string }) {
+  const name = row.entry?.name ?? row.usage?.name ?? "Unknown";
+  const invocations = row.usage?.projects[projectSlug] ?? row.usage?.invocations ?? 0;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "7px 0",
+        borderBottom: "1px solid var(--border-subtle)",
+      }}
+    >
+      <span
+        style={{
+          fontSize: "0.78rem",
+          fontWeight: 500,
+          color: "var(--text-primary)",
+          fontFamily: "var(--font-body)",
+          flex: 1,
+          minWidth: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {name}
+      </span>
+      {row.entry?.version && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6rem",
+            color: "var(--text-muted)",
+          }}
+        >
+          v{row.entry.version}
+        </span>
+      )}
+      {invocations > 0 && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.65rem",
+            fontWeight: 600,
+            color: "var(--accent)",
+          }}
+        >
+          {invocations}×
+        </span>
+      )}
+      {row.usage?.lastUsed && (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.6rem",
+            color: "var(--text-muted)",
+            flexShrink: 0,
+          }}
+        >
+          {formatDate(row.usage.lastUsed)}
+        </span>
+      )}
+      {row.usage?.sessions && row.usage.sessions[0] && (
+        <Link
+          href={`/sessions/${row.usage.sessions[0]}`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            color: "var(--text-muted)",
+            textDecoration: "none",
+          }}
+          title="Latest session"
+        >
+          <ExternalLink style={{ width: "10px", height: "10px" }} />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function SectionLabel({ label, count }: { label: string; count: number }) {
+  return (
+    <div
+      style={{
+        fontSize: "0.6rem",
+        fontWeight: 700,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: "var(--text-muted)",
+        fontFamily: "var(--font-body)",
+        marginBottom: "4px",
+        marginTop: "16px",
+      }}
+    >
+      {label}
+      <span style={{ marginLeft: "6px", fontWeight: 400 }}>({count})</span>
+    </div>
+  );
+}
+
+interface Props {
+  slug: string;
+}
+
+export function ProjectSkillsTab({ slug }: Props) {
+  const { data, loading } = useSkills(undefined, slug);
+
+  if (loading) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            style={{
+              height: "32px",
+              background: "var(--bg-surface)",
+              borderRadius: "var(--radius)",
+              opacity: 0.5,
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const available = data.filter(
+    (r) => r.entry?.source === "project" && r.entry.projectSlug === slug
+  );
+  const invoked = data
+    .filter((r) => (r.usage?.projects[slug] ?? 0) > 0)
+    .sort((a, b) => (b.usage?.projects[slug] ?? 0) - (a.usage?.projects[slug] ?? 0));
+
+  const totalInvocations = invoked.reduce(
+    (sum, r) => sum + (r.usage?.projects[slug] ?? 0),
+    0
+  );
+
+  if (available.length === 0 && invoked.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          textAlign: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "8px",
+        }}
+      >
+        <Wrench style={{ width: "24px", height: "24px", color: "var(--text-muted)", opacity: 0.3 }} />
+        <p style={{ fontSize: "0.78rem", color: "var(--text-muted)" }}>
+          No skills defined or invoked in this project.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {available.length > 0 && (
+        <>
+          <SectionLabel label="Available (project-local)" count={available.length} />
+          {available.map((row, i) => (
+            <CompactRow
+              key={row.entry?.id ?? i}
+              row={row}
+              projectSlug={slug}
+            />
+          ))}
+        </>
+      )}
+
+      {invoked.length > 0 && (
+        <>
+          <SectionLabel
+            label={`Invoked here · ${totalInvocations} total`}
+            count={invoked.length}
+          />
+          {invoked.map((row, i) => (
+            <CompactRow
+              key={row.entry?.id ?? row.usage?.name ?? i}
+              row={row}
+              projectSlug={slug}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/SkillsBrowser.tsx
+++ b/src/components/SkillsBrowser.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import { useSkills, type SkillRow } from "@/hooks/useSkills";
+import { Wrench, Search, ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
+import Link from "next/link";
+
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (!isFinite(d.getTime())) return "—";
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString();
+}
+
+function SourceBadge({ row }: { row: SkillRow }) {
+  const source = row.entry?.source ?? "plugin";
+  const label = row.catalogMissing
+    ? `plugin (${row.usage?.name?.split(":")[0] ?? "?"})`
+    : source === "plugin"
+    ? `plugin: ${row.entry?.pluginName ?? ""}`
+    : source;
+  const color =
+    source === "user"
+      ? "var(--text-secondary)"
+      : source === "plugin"
+      ? "var(--accent)"
+      : "var(--success, #4ade80)";
+
+  return (
+    <span
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6rem",
+        color,
+        background: "var(--bg-surface)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "3px",
+        padding: "1px 5px",
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function SkillRow({ row }: { row: SkillRow }) {
+  const [expanded, setExpanded] = useState(false);
+  const [bodyFull, setBodyFull] = useState<string | null>(null);
+  const [bodyLoading, setBodyLoading] = useState(false);
+
+  const name = row.entry?.name ?? row.usage?.name ?? "Unknown";
+  const description = row.entry?.description ?? "";
+  const truncDesc =
+    description.length > 160 ? description.slice(0, 160) + "…" : description;
+
+  async function fetchBody() {
+    if (bodyFull !== null || !row.entry?.id) return;
+    setBodyLoading(true);
+    try {
+      const res = await fetch(`/api/skills/${encodeURIComponent(row.entry.id)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setBodyFull(data.bodyFull ?? "");
+      }
+    } finally {
+      setBodyLoading(false);
+    }
+  }
+
+  return (
+    <div style={{ padding: "10px 0", borderBottom: "1px solid var(--border-subtle)" }}>
+      <div
+        style={{ display: "flex", alignItems: "flex-start", gap: "8px", cursor: "pointer" }}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span style={{ marginTop: "2px", color: "var(--text-muted)", flexShrink: 0 }}>
+          {expanded ? (
+            <ChevronDown style={{ width: "12px", height: "12px" }} />
+          ) : (
+            <ChevronRight style={{ width: "12px", height: "12px" }} />
+          )}
+        </span>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              flexWrap: "wrap",
+              marginBottom: "3px",
+            }}
+          >
+            <span
+              style={{
+                fontSize: "0.78rem",
+                fontWeight: 600,
+                color: "var(--text-primary)",
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {name}
+            </span>
+            <SourceBadge row={row} />
+            {row.entry?.userInvocable && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.6rem",
+                  color: "var(--text-muted)",
+                  background: "var(--bg-surface)",
+                  border: "1px solid var(--border-subtle)",
+                  borderRadius: "3px",
+                  padding: "1px 5px",
+                }}
+              >
+                /{row.entry.argumentHint ?? row.entry.slug}
+              </span>
+            )}
+            {row.entry?.version && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.6rem",
+                  color: "var(--text-muted)",
+                }}
+              >
+                v{row.entry.version}
+              </span>
+            )}
+            {row.entry?.layout === "standalone" && (
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.6rem",
+                  color: "var(--text-muted)",
+                  opacity: 0.7,
+                }}
+              >
+                standalone
+              </span>
+            )}
+          </div>
+          {truncDesc && (
+            <p
+              style={{
+                fontSize: "0.72rem",
+                color: "var(--text-secondary)",
+                margin: 0,
+                lineHeight: 1.45,
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {truncDesc}
+            </p>
+          )}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-end",
+            gap: "2px",
+            flexShrink: 0,
+          }}
+        >
+          {row.usage && row.usage.invocations > 0 && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.65rem",
+                fontWeight: 600,
+                color: "var(--accent)",
+              }}
+            >
+              {row.usage.invocations}×
+            </span>
+          )}
+          {row.usage?.lastUsed && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6rem",
+                color: "var(--text-muted)",
+              }}
+            >
+              {formatDate(row.usage.lastUsed)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <div
+          style={{
+            marginTop: "10px",
+            marginLeft: "20px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+          }}
+        >
+          {row.entry?.bodyExcerpt && (
+            <pre
+              style={{
+                fontSize: "0.68rem",
+                color: "var(--text-secondary)",
+                fontFamily: "var(--font-mono)",
+                background: "var(--bg-surface)",
+                border: "1px solid var(--border-subtle)",
+                borderRadius: "var(--radius)",
+                padding: "8px",
+                margin: 0,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                maxHeight: "140px",
+                overflow: "hidden",
+              }}
+            >
+              {bodyFull ?? row.entry.bodyExcerpt}
+            </pre>
+          )}
+
+          {row.entry?.id && bodyFull === null && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                fetchBody();
+              }}
+              disabled={bodyLoading}
+              style={{
+                alignSelf: "flex-start",
+                background: "transparent",
+                border: "none",
+                padding: 0,
+                fontSize: "0.65rem",
+                color: "var(--accent)",
+                cursor: "pointer",
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {bodyLoading ? "loading…" : "View full body →"}
+            </button>
+          )}
+
+          {row.usage && row.usage.sessions.length > 0 && (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "4px" }}>
+              {row.usage.sessions.slice(0, 5).map((sid) => (
+                <Link
+                  key={sid}
+                  href={`/sessions/${sid}`}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "3px",
+                    fontSize: "0.6rem",
+                    fontFamily: "var(--font-mono)",
+                    color: "var(--text-muted)",
+                    textDecoration: "none",
+                  }}
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                >
+                  <ExternalLink style={{ width: "9px", height: "9px" }} />
+                  {sid.slice(0, 8)}
+                </Link>
+              ))}
+              {row.usage.sessions.length > 5 && (
+                <span
+                  style={{
+                    fontSize: "0.6rem",
+                    color: "var(--text-muted)",
+                    fontFamily: "var(--font-mono)",
+                  }}
+                >
+                  +{row.usage.sessions.length - 5} more
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type SortKey = "name" | "invocations" | "lastUsed";
+type SourceFilter = "all" | "user" | "plugin" | "project";
+
+export function SkillsBrowser() {
+  const [rawQuery, setRawQuery] = useState("");
+  const [query, setQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const [sortBy, setSortBy] = useState<SortKey>("invocations");
+
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(rawQuery), 300);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  const { data, loading } = useSkills();
+
+  const filtered = useMemo(() => {
+    let rows = data;
+
+    if (sourceFilter !== "all") {
+      rows = rows.filter((r) => {
+        if (r.catalogMissing) return sourceFilter === "plugin";
+        return r.entry?.source === sourceFilter;
+      });
+    }
+
+    if (query) {
+      const q = query.toLowerCase();
+      rows = rows.filter((r) => {
+        const text = [
+          r.entry?.name,
+          r.entry?.description,
+          r.entry?.pluginName,
+          r.usage?.name,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        return text.includes(q);
+      });
+    }
+
+    rows = [...rows].sort((a, b) => {
+      if (sortBy === "name") {
+        const an = a.entry?.name ?? a.usage?.name ?? "";
+        const bn = b.entry?.name ?? b.usage?.name ?? "";
+        return an.localeCompare(bn);
+      }
+      if (sortBy === "invocations") {
+        return (b.usage?.invocations ?? 0) - (a.usage?.invocations ?? 0);
+      }
+      const at = a.usage?.lastUsed ?? "";
+      const bt = b.usage?.lastUsed ?? "";
+      return bt.localeCompare(at);
+    });
+
+    return rows;
+  }, [data, sourceFilter, query, sortBy]);
+
+  const total = data.length;
+  const invoked = data.filter((r) => (r.usage?.invocations ?? 0) > 0).length;
+
+  const segmentStyle = (active: boolean): React.CSSProperties => ({
+    padding: "3px 9px",
+    fontSize: "0.65rem",
+    fontFamily: "var(--font-body)",
+    fontWeight: active ? 600 : 400,
+    color: active ? "var(--accent)" : "var(--text-muted)",
+    background: active ? "var(--accent-bg)" : "transparent",
+    border: "1px solid var(--border-subtle)",
+    borderRadius: "var(--radius)",
+    cursor: "pointer",
+  });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <Wrench style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
+        <h1
+          style={{
+            fontSize: "0.72rem",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--text-secondary)",
+            fontFamily: "var(--font-body)",
+          }}
+        >
+          Skills
+        </h1>
+        {total > 0 && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.65rem",
+              color: "var(--text-muted)",
+            }}
+          >
+            {total} total · {invoked} invoked
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+        <div style={{ position: "relative", flex: "1 1 200px", minWidth: "160px" }}>
+          <Search
+            style={{
+              position: "absolute",
+              left: "9px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              width: "13px",
+              height: "13px",
+              color: "var(--text-muted)",
+              pointerEvents: "none",
+            }}
+          />
+          <input
+            type="text"
+            placeholder="Search skills…"
+            value={rawQuery}
+            onChange={(e) => setRawQuery(e.target.value)}
+            style={{
+              width: "100%",
+              padding: "5px 9px 5px 28px",
+              fontSize: "0.72rem",
+              fontFamily: "var(--font-body)",
+              background: "var(--bg-surface)",
+              border: "1px solid var(--border-subtle)",
+              borderRadius: "var(--radius)",
+              color: "var(--text-primary)",
+              outline: "none",
+              boxSizing: "border-box",
+            }}
+          />
+        </div>
+
+        <div style={{ display: "flex", gap: "3px" }}>
+          {(["all", "user", "plugin", "project"] as SourceFilter[]).map((s) => (
+            <button key={s} onClick={() => setSourceFilter(s)} style={segmentStyle(sourceFilter === s)}>
+              {s}
+            </button>
+          ))}
+        </div>
+
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as SortKey)}
+          style={{
+            fontSize: "0.65rem",
+            fontFamily: "var(--font-body)",
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius)",
+            color: "var(--text-secondary)",
+            padding: "4px 7px",
+            cursor: "pointer",
+          }}
+        >
+          <option value="invocations">Most invoked</option>
+          <option value="lastUsed">Recently used</option>
+          <option value="name">Name A–Z</option>
+        </select>
+      </div>
+
+      {loading ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          {[...Array(6)].map((_, i) => (
+            <div
+              key={i}
+              style={{
+                height: "48px",
+                background: "var(--bg-surface)",
+                borderRadius: "var(--radius)",
+                opacity: 0.5,
+              }}
+            />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div
+          style={{
+            textAlign: "center",
+            padding: "60px 20px",
+            color: "var(--text-muted)",
+          }}
+        >
+          <Wrench style={{ width: "28px", height: "28px", opacity: 0.3, margin: "0 auto 8px" }} />
+          <p style={{ fontSize: "0.75rem", fontFamily: "var(--font-body)" }}>
+            {query || sourceFilter !== "all" ? "No skills match your filters." : "No skills found."}
+          </p>
+        </div>
+      ) : (
+        <div>
+          <div
+            style={{
+              fontSize: "0.62rem",
+              color: "var(--text-muted)",
+              fontFamily: "var(--font-mono)",
+              marginBottom: "4px",
+            }}
+          >
+            {filtered.length} skill{filtered.length !== 1 ? "s" : ""}
+          </div>
+          {filtered.map((row, i) => (
+            <SkillRow key={row.entry?.id ?? row.usage?.name ?? i} row={row} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useAgents.ts
+++ b/src/hooks/useAgents.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface AgentRow {
+  entry?: {
+    id: string;
+    slug: string;
+    name: string;
+    description?: string;
+    source: "user" | "plugin" | "project";
+    pluginName?: string;
+    projectSlug?: string;
+    category?: string;
+    filePath: string;
+    bodyExcerpt: string;
+    frontmatter: Record<string, unknown>;
+    mtime: string;
+    ctime: string;
+    model?: string;
+    tools?: string[];
+    color?: string;
+    emoji?: string;
+  };
+  usage?: {
+    name: string;
+    invocations: number;
+    firstUsed?: string;
+    lastUsed?: string;
+    projects: Record<string, number>;
+    sessions: string[];
+  };
+  catalogMissing?: boolean;
+}
+
+export function useAgents(source?: string, project?: string, query?: string) {
+  const [data, setData] = useState<AgentRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    const params = new URLSearchParams();
+    if (source) params.set("source", source);
+    if (project) params.set("project", project);
+    if (query) params.set("q", query);
+    const qs = params.toString();
+    try {
+      const res = await fetch(`/api/agents${qs ? `?${qs}` : ""}`);
+      if (res.ok) setData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [source, project, query]);
+
+  useEffect(() => {
+    setLoading(true);
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, refresh };
+}

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface SkillRow {
+  entry?: {
+    id: string;
+    slug: string;
+    name: string;
+    description?: string;
+    source: "user" | "plugin" | "project";
+    pluginName?: string;
+    projectSlug?: string;
+    category?: string;
+    filePath: string;
+    bodyExcerpt: string;
+    frontmatter: Record<string, unknown>;
+    mtime: string;
+    ctime: string;
+    layout: "bundled" | "standalone";
+    version?: string;
+    userInvocable?: boolean;
+    argumentHint?: string;
+  };
+  usage?: {
+    name: string;
+    invocations: number;
+    firstUsed?: string;
+    lastUsed?: string;
+    projects: Record<string, number>;
+    sessions: string[];
+  };
+  catalogMissing?: boolean;
+}
+
+export function useSkills(source?: string, project?: string, query?: string) {
+  const [data, setData] = useState<SkillRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    const params = new URLSearchParams();
+    if (source) params.set("source", source);
+    if (project) params.set("project", project);
+    if (query) params.set("q", query);
+    const qs = params.toString();
+    try {
+      const res = await fetch(`/api/skills${qs ? `?${qs}` : ""}`);
+      if (res.ok) setData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [source, project, query]);
+
+  useEffect(() => {
+    setLoading(true);
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, refresh };
+}

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -10,6 +10,8 @@ export const helpMapping: Record<string, string> = {
   '/sessions': 'sessions',
   '/sessions/[sessionId]': 'sessions',
   '/insights': 'insights',
+  '/agents': 'agents',
+  '/skills': 'skills',
   '/usage': 'usage',
   '/status': 'status',
   '/config': 'config',
@@ -27,6 +29,8 @@ export const tabHelpMapping: Record<string, string> = {
   sessions: 'sessions',
   'manual-steps': 'manual-steps',
   insights: 'insights',
+  agents: 'agents',
+  skills: 'skills',
   memory: 'memory',
 }
 
@@ -44,6 +48,8 @@ export const helpSlugs = [
   'stats',
   'sessions',
   'insights',
+  'agents',
+  'skills',
   'usage',
   'status',
   'memory',

--- a/src/lib/indexer/canonicalize.ts
+++ b/src/lib/indexer/canonicalize.ts
@@ -1,0 +1,40 @@
+import type { AgentEntry, CatalogEntry, SkillEntry } from "./types";
+
+export type CatalogMap = Map<string, CatalogEntry>;
+
+function addKey(map: CatalogMap, key: string, entry: CatalogEntry) {
+  if (key && !map.has(key.toLowerCase())) {
+    map.set(key.toLowerCase(), entry);
+  }
+}
+
+export function buildAgentAliasMap(agents: AgentEntry[]): CatalogMap {
+  const map: CatalogMap = new Map();
+  for (const agent of agents) {
+    addKey(map, agent.slug, agent);
+    addKey(map, agent.name, agent);
+    // Plugin agents: also index as "pluginname:slug" and "pluginname:name"
+    if (agent.pluginName) {
+      addKey(map, `${agent.pluginName}:${agent.slug}`, agent);
+      addKey(map, `${agent.pluginName}:${agent.name}`, agent);
+    }
+  }
+  return map;
+}
+
+export function buildSkillAliasMap(skills: SkillEntry[]): CatalogMap {
+  const map: CatalogMap = new Map();
+  for (const skill of skills) {
+    addKey(map, skill.slug, skill);
+    addKey(map, skill.name, skill);
+    if (skill.pluginName) {
+      addKey(map, `${skill.pluginName}:${skill.slug}`, skill);
+      addKey(map, `${skill.pluginName}:${skill.name}`, skill);
+    }
+  }
+  return map;
+}
+
+export function lookupEntry(map: CatalogMap, name: string): CatalogEntry | undefined {
+  return map.get(name.toLowerCase());
+}

--- a/src/lib/indexer/canonicalize.ts
+++ b/src/lib/indexer/canonicalize.ts
@@ -3,9 +3,9 @@ import type { AgentEntry, CatalogEntry, SkillEntry } from "./types";
 export type CatalogMap = Map<string, CatalogEntry>;
 
 function addKey(map: CatalogMap, key: string, entry: CatalogEntry) {
-  if (key && !map.has(key.toLowerCase())) {
-    map.set(key.toLowerCase(), entry);
-  }
+  // Last-write wins: catalog is built user → plugin → project, so project-local
+  // entries naturally override global ones with the same name.
+  if (key) map.set(key.toLowerCase(), entry);
 }
 
 export function buildAgentAliasMap(agents: AgentEntry[]): CatalogMap {

--- a/src/lib/indexer/catalog.ts
+++ b/src/lib/indexer/catalog.ts
@@ -1,0 +1,83 @@
+import { walkUserAgents, walkPluginAgents, walkProjectAgents } from "./walkAgents";
+import { walkUserSkills, walkPluginSkills, walkProjectSkills } from "./walkSkills";
+import { getCachedScan } from "@/lib/cache";
+import type { AgentEntry, CatalogResult, SkillEntry } from "./types";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const globalForCatalog = globalThis as unknown as {
+  __catalogCache?: {
+    withProjects: { data: CatalogResult; cachedAt: number } | null;
+    withoutProjects: { data: CatalogResult; cachedAt: number } | null;
+  };
+};
+
+function getCache(includeProjects: boolean) {
+  if (!globalForCatalog.__catalogCache) return null;
+  const slot = includeProjects
+    ? globalForCatalog.__catalogCache.withProjects
+    : globalForCatalog.__catalogCache.withoutProjects;
+  if (!slot) return null;
+  if (Date.now() - slot.cachedAt < CACHE_TTL_MS) return slot.data;
+  return null;
+}
+
+function setCache(includeProjects: boolean, data: CatalogResult) {
+  if (!globalForCatalog.__catalogCache) {
+    globalForCatalog.__catalogCache = { withProjects: null, withoutProjects: null };
+  }
+  const slot = { data, cachedAt: Date.now() };
+  if (includeProjects) {
+    globalForCatalog.__catalogCache.withProjects = slot;
+  } else {
+    globalForCatalog.__catalogCache.withoutProjects = slot;
+  }
+}
+
+export function invalidateCatalogCache() {
+  globalForCatalog.__catalogCache = { withProjects: null, withoutProjects: null };
+}
+
+export async function loadCatalog(
+  opts: { includeProjects?: boolean } = {}
+): Promise<CatalogResult> {
+  const includeProjects = opts.includeProjects ?? false;
+  const cached = getCache(includeProjects);
+  if (cached) return cached;
+
+  const [userAgents, pluginAgents, userSkills, pluginSkills] = await Promise.all([
+    walkUserAgents(),
+    walkPluginAgents(),
+    walkUserSkills(),
+    walkPluginSkills(),
+  ]);
+
+  const agents: AgentEntry[] = [...userAgents, ...pluginAgents];
+  const skills: SkillEntry[] = [...userSkills, ...pluginSkills];
+
+  let hadProjectScan = false;
+  if (includeProjects) {
+    const scan = getCachedScan();
+    const projects = scan?.projects ?? [];
+    hadProjectScan = projects.length > 0;
+
+    await Promise.all(
+      projects.map(async (project) => {
+        const [pAgents, pSkills] = await Promise.all([
+          walkProjectAgents(project.path, project.slug),
+          walkProjectSkills(project.path, project.slug),
+        ]);
+        agents.push(...pAgents);
+        skills.push(...pSkills);
+      })
+    );
+  }
+
+  const result: CatalogResult = { agents, skills };
+  // Don't cache the withProjects slot if the scan cache was empty — let the
+  // next request retry once the scan has run.
+  if (!includeProjects || hadProjectScan) {
+    setCache(includeProjects, result);
+  }
+  return result;
+}

--- a/src/lib/indexer/parseFrontmatter.ts
+++ b/src/lib/indexer/parseFrontmatter.ts
@@ -1,0 +1,31 @@
+import yaml from "js-yaml";
+
+export interface ParsedFrontmatter {
+  fm: Record<string, unknown>;
+  body: string;
+}
+
+export function parseFrontmatter(text: string): ParsedFrontmatter {
+  if (!text.startsWith("---")) {
+    return { fm: {}, body: text };
+  }
+
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) {
+    return { fm: {}, body: text };
+  }
+
+  const yamlText = text.slice(3, end).trim();
+  const body = text.slice(end + 4).trim();
+
+  try {
+    const parsed = yaml.load(yamlText);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { fm: parsed as Record<string, unknown>, body };
+    }
+  } catch {
+    // Malformed YAML (embedded XML, unescaped colons, etc.) — return empty fm
+  }
+
+  return { fm: {}, body };
+}

--- a/src/lib/indexer/parseFrontmatter.ts
+++ b/src/lib/indexer/parseFrontmatter.ts
@@ -6,7 +6,8 @@ export interface ParsedFrontmatter {
 }
 
 export function parseFrontmatter(text: string): ParsedFrontmatter {
-  if (!text.startsWith("---")) {
+  // Require "---\n" so a bare horizontal rule isn't treated as frontmatter
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
     return { fm: {}, body: text };
   }
 

--- a/src/lib/indexer/types.ts
+++ b/src/lib/indexer/types.ts
@@ -1,0 +1,45 @@
+export type CatalogSource = "user" | "plugin" | "project";
+
+interface CatalogEntryBase {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string;
+  source: CatalogSource;
+  pluginName?: string;
+  projectSlug?: string;
+  category?: string;
+  filePath: string;
+  bodyExcerpt: string;
+  frontmatter: Record<string, unknown>;
+  mtime: string;
+  ctime: string;
+}
+
+export interface AgentEntry extends CatalogEntryBase {
+  kind: "agent";
+  model?: string;
+  tools?: string[];
+  color?: string;
+  emoji?: string;
+}
+
+export interface SkillEntry extends CatalogEntryBase {
+  kind: "skill";
+  layout: "bundled" | "standalone";
+  version?: string;
+  userInvocable?: boolean;
+  argumentHint?: string;
+}
+
+export type CatalogEntry = AgentEntry | SkillEntry;
+
+export interface CatalogResult {
+  agents: AgentEntry[];
+  skills: SkillEntry[];
+}
+
+export interface InstalledPlugin {
+  pluginName: string;
+  installPath: string;
+}

--- a/src/lib/indexer/walkAgents.ts
+++ b/src/lib/indexer/walkAgents.ts
@@ -13,6 +13,7 @@ function makeAgentEntry(
     pluginName?: string;
     projectSlug?: string;
     category?: string;
+    relPath?: string;
     mtime: Date;
     ctime: Date;
   }
@@ -32,7 +33,9 @@ function makeAgentEntry(
   }
 
   const prefix = opts.pluginName ?? opts.projectSlug ?? "user";
-  const id = `${source}:${prefix}:${slug}`;
+  // Use relative path from the walk root so files with the same basename in
+  // different subdirectories (e.g. category/README.md vs README.md) get unique IDs.
+  const id = `${source}:${prefix}:${opts.relPath ?? slug}`;
 
   return {
     id,
@@ -59,7 +62,7 @@ function makeAgentEntry(
 async function readAgent(
   filePath: string,
   source: CatalogSource,
-  opts: { pluginName?: string; projectSlug?: string; category?: string }
+  opts: { pluginName?: string; projectSlug?: string; category?: string; relPath?: string }
 ): Promise<AgentEntry | null> {
   try {
     const [text, stat] = await Promise.all([
@@ -78,6 +81,7 @@ async function readAgent(
 
 async function walkDir(
   dir: string,
+  root: string,
   source: CatalogSource,
   opts: { pluginName?: string; projectSlug?: string },
   depth = 0
@@ -101,10 +105,11 @@ async function walkDir(
       const fullPath = path.join(dir, entry.name);
 
       if (entry.isDirectory() && !entry.isSymbolicLink()) {
-        const sub = await walkDir(fullPath, source, opts, depth + 1);
+        const sub = await walkDir(fullPath, root, source, opts, depth + 1);
         results.push(...sub);
       } else if (entry.isFile() && entry.name.endsWith(".md") && !entry.name.endsWith(".tmpl")) {
-        const agent = await readAgent(fullPath, source, { ...opts, category });
+        const relPath = path.relative(root, fullPath).replace(/\.md$/, "").replace(/\\/g, "/");
+        const agent = await readAgent(fullPath, source, { ...opts, category, relPath });
         if (agent) results.push(agent);
       }
     })
@@ -115,7 +120,7 @@ async function walkDir(
 
 export async function walkUserAgents(): Promise<AgentEntry[]> {
   const root = path.join(os.homedir(), ".claude", "agents");
-  return walkDir(root, "user", {});
+  return walkDir(root, root, "user", {});
 }
 
 export async function walkPluginAgents(): Promise<AgentEntry[]> {
@@ -130,7 +135,7 @@ export async function walkPluginAgents(): Promise<AgentEntry[]> {
       } catch {
         return;
       }
-      const entries = await walkDir(agentsDir, "plugin", { pluginName });
+      const entries = await walkDir(agentsDir, agentsDir, "plugin", { pluginName });
       all.push(...entries);
     })
   );
@@ -148,5 +153,5 @@ export async function walkProjectAgents(
   } catch {
     return [];
   }
-  return walkDir(agentsDir, "project", { projectSlug });
+  return walkDir(agentsDir, agentsDir, "project", { projectSlug });
 }

--- a/src/lib/indexer/walkAgents.ts
+++ b/src/lib/indexer/walkAgents.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { parseFrontmatter } from "./parseFrontmatter";
+import { loadInstalledPlugins } from "./walkPlugins";
+import type { AgentEntry, CatalogSource } from "./types";
+
+function makeAgentEntry(
+  filePath: string,
+  text: string,
+  source: CatalogSource,
+  opts: {
+    pluginName?: string;
+    projectSlug?: string;
+    category?: string;
+    mtime: Date;
+    ctime: Date;
+  }
+): AgentEntry {
+  const { fm, body } = parseFrontmatter(text);
+
+  const rawName = fm.name;
+  const slug = path.basename(filePath, ".md");
+  const name = typeof rawName === "string" && rawName ? rawName : slug;
+
+  const rawTools = fm.tools ?? fm["allowed-tools"];
+  let tools: string[] | undefined;
+  if (typeof rawTools === "string") {
+    tools = rawTools.split(",").map((t) => t.trim()).filter(Boolean);
+  } else if (Array.isArray(rawTools)) {
+    tools = rawTools.map(String);
+  }
+
+  const prefix = opts.pluginName ?? opts.projectSlug ?? "user";
+  const id = `${source}:${prefix}:${slug}`;
+
+  return {
+    id,
+    kind: "agent",
+    slug,
+    name,
+    description: typeof fm.description === "string" ? fm.description : undefined,
+    source,
+    pluginName: opts.pluginName,
+    projectSlug: opts.projectSlug,
+    category: opts.category,
+    filePath,
+    bodyExcerpt: body.slice(0, 400),
+    frontmatter: fm,
+    mtime: opts.mtime.toISOString(),
+    ctime: opts.ctime.toISOString(),
+    model: typeof fm.model === "string" ? fm.model : undefined,
+    tools,
+    color: typeof fm.color === "string" ? fm.color : undefined,
+    emoji: typeof fm.emoji === "string" ? fm.emoji : undefined,
+  };
+}
+
+async function readAgent(
+  filePath: string,
+  source: CatalogSource,
+  opts: { pluginName?: string; projectSlug?: string; category?: string }
+): Promise<AgentEntry | null> {
+  try {
+    const [text, stat] = await Promise.all([
+      fs.readFile(filePath, "utf-8"),
+      fs.stat(filePath),
+    ]);
+    return makeAgentEntry(filePath, text, source, {
+      ...opts,
+      mtime: stat.mtime,
+      ctime: stat.ctime,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function walkDir(
+  dir: string,
+  source: CatalogSource,
+  opts: { pluginName?: string; projectSlug?: string },
+  depth = 0
+): Promise<AgentEntry[]> {
+  if (depth > 4) return [];
+
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: AgentEntry[] = [];
+  const category = depth === 1 ? path.basename(dir) : undefined;
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.name.startsWith(".")) return;
+
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        const sub = await walkDir(fullPath, source, opts, depth + 1);
+        results.push(...sub);
+      } else if (entry.isFile() && entry.name.endsWith(".md") && !entry.name.endsWith(".tmpl")) {
+        const agent = await readAgent(fullPath, source, { ...opts, category });
+        if (agent) results.push(agent);
+      }
+    })
+  );
+
+  return results;
+}
+
+export async function walkUserAgents(): Promise<AgentEntry[]> {
+  const root = path.join(os.homedir(), ".claude", "agents");
+  return walkDir(root, "user", {});
+}
+
+export async function walkPluginAgents(): Promise<AgentEntry[]> {
+  const plugins = await loadInstalledPlugins();
+  const all: AgentEntry[] = [];
+
+  await Promise.all(
+    plugins.map(async ({ pluginName, installPath }) => {
+      const agentsDir = path.join(installPath, "agents");
+      try {
+        await fs.access(agentsDir);
+      } catch {
+        return;
+      }
+      const entries = await walkDir(agentsDir, "plugin", { pluginName });
+      all.push(...entries);
+    })
+  );
+
+  return all;
+}
+
+export async function walkProjectAgents(
+  projectPath: string,
+  projectSlug: string
+): Promise<AgentEntry[]> {
+  const agentsDir = path.join(projectPath, ".claude", "agents");
+  try {
+    await fs.access(agentsDir);
+  } catch {
+    return [];
+  }
+  return walkDir(agentsDir, "project", { projectSlug });
+}

--- a/src/lib/indexer/walkPlugins.ts
+++ b/src/lib/indexer/walkPlugins.ts
@@ -33,8 +33,10 @@ export async function loadInstalledPlugins(): Promise<InstalledPlugin[]> {
     for (const [key, installs] of Object.entries(pluginMap)) {
       if (!Array.isArray(installs) || installs.length === 0) continue;
 
-      // key format: "pluginname@marketplace" — take the part before @
-      const pluginName = key.includes("@") ? key.split("@")[0] : key;
+      // key format: "pluginname@marketplace" or "@scope/name@marketplace"
+      // Strip only the trailing @suffix so scoped names (e.g. @scope/name) are preserved.
+      const lastAt = key.lastIndexOf("@");
+      const pluginName = lastAt > 0 ? key.slice(0, lastAt) : key;
 
       // Use first install entry
       const install = installs[0];

--- a/src/lib/indexer/walkPlugins.ts
+++ b/src/lib/indexer/walkPlugins.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import type { InstalledPlugin } from "./types";
+
+interface PluginsFile {
+  version?: number;
+  plugins?: Record<string, PluginInstall[]>;
+}
+
+interface PluginInstall {
+  scope?: string;
+  installPath?: string;
+  version?: string;
+}
+
+export async function loadInstalledPlugins(): Promise<InstalledPlugin[]> {
+  const registryPath = path.join(
+    os.homedir(),
+    ".claude",
+    "plugins",
+    "installed_plugins.json"
+  );
+
+  try {
+    const raw = await fs.readFile(registryPath, "utf-8");
+    const data = JSON.parse(raw) as PluginsFile;
+
+    const pluginMap = data.plugins ?? {};
+    const results: InstalledPlugin[] = [];
+    const seen = new Set<string>();
+
+    for (const [key, installs] of Object.entries(pluginMap)) {
+      if (!Array.isArray(installs) || installs.length === 0) continue;
+
+      // key format: "pluginname@marketplace" — take the part before @
+      const pluginName = key.includes("@") ? key.split("@")[0] : key;
+
+      // Use first install entry
+      const install = installs[0];
+      if (!install.installPath) continue;
+
+      const installPath = path.normalize(install.installPath);
+
+      // Deduplicate by installPath
+      if (seen.has(installPath)) continue;
+      seen.add(installPath);
+
+      results.push({ pluginName, installPath });
+    }
+
+    return results;
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/indexer/walkSkills.ts
+++ b/src/lib/indexer/walkSkills.ts
@@ -1,0 +1,162 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { parseFrontmatter } from "./parseFrontmatter";
+import { loadInstalledPlugins } from "./walkPlugins";
+import type { SkillEntry, CatalogSource } from "./types";
+
+function makeSkillEntry(
+  filePath: string,
+  text: string,
+  source: CatalogSource,
+  layout: "bundled" | "standalone",
+  opts: {
+    pluginName?: string;
+    projectSlug?: string;
+    category?: string;
+    mtime: Date;
+    ctime: Date;
+  }
+): SkillEntry {
+  const { fm, body } = parseFrontmatter(text);
+
+  // For bundled skills, slug is the directory name; for standalone, the file basename
+  const slug =
+    layout === "bundled"
+      ? path.basename(path.dirname(filePath))
+      : path.basename(filePath, ".md");
+
+  const rawName = fm.name;
+  const name = typeof rawName === "string" && rawName ? rawName : slug;
+
+  const prefix = opts.pluginName ?? opts.projectSlug ?? "user";
+  const id = `${source}:${prefix}:${slug}`;
+
+  const userInvocable =
+    fm["user-invocable"] === true ||
+    fm["user-invocable"] === "true" ||
+    fm.userInvocable === true;
+
+  return {
+    id,
+    kind: "skill",
+    slug,
+    name,
+    description: typeof fm.description === "string" ? fm.description : undefined,
+    source,
+    pluginName: opts.pluginName,
+    projectSlug: opts.projectSlug,
+    category: opts.category,
+    filePath,
+    bodyExcerpt: body.slice(0, 400),
+    frontmatter: fm,
+    mtime: opts.mtime.toISOString(),
+    ctime: opts.ctime.toISOString(),
+    layout,
+    version: typeof fm.version === "string" ? fm.version : undefined,
+    userInvocable,
+    argumentHint: typeof fm["argument-hint"] === "string" ? fm["argument-hint"] : undefined,
+  };
+}
+
+async function walkSkillsRoot(
+  root: string,
+  source: CatalogSource,
+  opts: { pluginName?: string; projectSlug?: string }
+): Promise<SkillEntry[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: SkillEntry[] = [];
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.name.startsWith(".")) return;
+
+      const fullPath = path.join(root, entry.name);
+
+      if (entry.isDirectory() && !entry.isSymbolicLink()) {
+        // Check for SKILL.md inside — bundled layout
+        const skillMdPath = path.join(fullPath, "SKILL.md");
+        try {
+          const [text, stat] = await Promise.all([
+            fs.readFile(skillMdPath, "utf-8"),
+            fs.stat(skillMdPath),
+          ]);
+          const skill = makeSkillEntry(skillMdPath, text, source, "bundled", {
+            ...opts,
+            mtime: stat.mtime,
+            ctime: stat.ctime,
+          });
+          results.push(skill);
+        } catch {
+          // No SKILL.md — skip this directory
+        }
+      } else if (
+        entry.isFile() &&
+        entry.name.endsWith(".md") &&
+        !entry.name.endsWith(".tmpl")
+      ) {
+        // Standalone layout — top-level .md in a skills root
+        try {
+          const [text, stat] = await Promise.all([
+            fs.readFile(fullPath, "utf-8"),
+            fs.stat(fullPath),
+          ]);
+          const skill = makeSkillEntry(fullPath, text, source, "standalone", {
+            ...opts,
+            mtime: stat.mtime,
+            ctime: stat.ctime,
+          });
+          results.push(skill);
+        } catch {
+          // skip
+        }
+      }
+    })
+  );
+
+  return results;
+}
+
+export async function walkUserSkills(): Promise<SkillEntry[]> {
+  const root = path.join(os.homedir(), ".claude", "skills");
+  return walkSkillsRoot(root, "user", {});
+}
+
+export async function walkPluginSkills(): Promise<SkillEntry[]> {
+  const plugins = await loadInstalledPlugins();
+  const all: SkillEntry[] = [];
+
+  await Promise.all(
+    plugins.map(async ({ pluginName, installPath }) => {
+      const skillsDir = path.join(installPath, "skills");
+      try {
+        await fs.access(skillsDir);
+      } catch {
+        return;
+      }
+      const entries = await walkSkillsRoot(skillsDir, "plugin", { pluginName });
+      all.push(...entries);
+    })
+  );
+
+  return all;
+}
+
+export async function walkProjectSkills(
+  projectPath: string,
+  projectSlug: string
+): Promise<SkillEntry[]> {
+  const skillsDir = path.join(projectPath, ".claude", "skills");
+  try {
+    await fs.access(skillsDir);
+  } catch {
+    return [];
+  }
+  return walkSkillsRoot(skillsDir, "project", { projectSlug });
+}

--- a/src/lib/indexer/walkSkills.ts
+++ b/src/lib/indexer/walkSkills.ts
@@ -30,7 +30,11 @@ function makeSkillEntry(
   const name = typeof rawName === "string" && rawName ? rawName : slug;
 
   const prefix = opts.pluginName ?? opts.projectSlug ?? "user";
-  const id = `${source}:${prefix}:${slug}`;
+  // Prefix bundled IDs so a bundled "foo/SKILL.md" and standalone "foo.md"
+  // in the same root don't collide on slug "foo".
+  const id = layout === "bundled"
+    ? `${source}:${prefix}:bundled:${slug}`
+    : `${source}:${prefix}:${slug}`;
 
   const userInvocable =
     fm["user-invocable"] === true ||

--- a/src/lib/usage/agentParser.ts
+++ b/src/lib/usage/agentParser.ts
@@ -2,6 +2,8 @@ import type { AgentStats, UsageTurn } from "./types";
 
 export function groupAgentCalls(turns: UsageTurn[]): AgentStats[] {
   const statsMap = new Map<string, AgentStats>();
+  // Per-agent: sessionId → latest timestamp seen in that session (for sort + dedup)
+  const sessionTimes = new Map<string, Map<string, string>>();
 
   for (const turn of turns) {
     if (turn.role !== "assistant") continue;
@@ -13,37 +15,33 @@ export function groupAgentCalls(turns: UsageTurn[]): AgentStats[] {
 
       let stat = statsMap.get(agentType);
       if (!stat) {
-        stat = {
-          name: agentType,
-          invocations: 0,
-          projects: {},
-          sessions: [],
-        };
+        stat = { name: agentType, invocations: 0, projects: {}, sessions: [] };
         statsMap.set(agentType, stat);
+        sessionTimes.set(agentType, new Map());
       }
 
       stat.invocations++;
 
-      if (!stat.firstUsed || turn.timestamp < stat.firstUsed) {
-        stat.firstUsed = turn.timestamp;
-      }
-      if (!stat.lastUsed || turn.timestamp > stat.lastUsed) {
-        stat.lastUsed = turn.timestamp;
-      }
+      if (!stat.firstUsed || turn.timestamp < stat.firstUsed) stat.firstUsed = turn.timestamp;
+      if (!stat.lastUsed || turn.timestamp > stat.lastUsed) stat.lastUsed = turn.timestamp;
 
       stat.projects[turn.projectSlug] = (stat.projects[turn.projectSlug] ?? 0) + 1;
 
-      if (!stat.sessions.includes(turn.sessionId)) {
-        stat.sessions.push(turn.sessionId);
+      const times = sessionTimes.get(agentType)!;
+      const prev = times.get(turn.sessionId) ?? "";
+      if (!turn.timestamp || turn.timestamp > prev) {
+        times.set(turn.sessionId, turn.timestamp ?? "");
       }
     }
   }
 
-  // Sort each stats entry's sessions by most recent (desc) and cap at 50
   const results = Array.from(statsMap.values());
   for (const stat of results) {
-    stat.sessions.sort((a, b) => b.localeCompare(a));
-    if (stat.sessions.length > 50) stat.sessions = stat.sessions.slice(0, 50);
+    const times = sessionTimes.get(stat.name)!;
+    stat.sessions = [...times.entries()]
+      .sort((a, b) => b[1].localeCompare(a[1]))
+      .slice(0, 50)
+      .map(([id]) => id);
   }
 
   return results.sort((a, b) => b.invocations - a.invocations);

--- a/src/lib/usage/agentParser.ts
+++ b/src/lib/usage/agentParser.ts
@@ -1,0 +1,50 @@
+import type { AgentStats, UsageTurn } from "./types";
+
+export function groupAgentCalls(turns: UsageTurn[]): AgentStats[] {
+  const statsMap = new Map<string, AgentStats>();
+
+  for (const turn of turns) {
+    if (turn.role !== "assistant") continue;
+
+    for (const tc of turn.toolCalls) {
+      if (tc.name !== "Agent") continue;
+      const agentType = tc.arguments?.subagent_type;
+      if (typeof agentType !== "string" || !agentType) continue;
+
+      let stat = statsMap.get(agentType);
+      if (!stat) {
+        stat = {
+          name: agentType,
+          invocations: 0,
+          projects: {},
+          sessions: [],
+        };
+        statsMap.set(agentType, stat);
+      }
+
+      stat.invocations++;
+
+      if (!stat.firstUsed || turn.timestamp < stat.firstUsed) {
+        stat.firstUsed = turn.timestamp;
+      }
+      if (!stat.lastUsed || turn.timestamp > stat.lastUsed) {
+        stat.lastUsed = turn.timestamp;
+      }
+
+      stat.projects[turn.projectSlug] = (stat.projects[turn.projectSlug] ?? 0) + 1;
+
+      if (!stat.sessions.includes(turn.sessionId)) {
+        stat.sessions.push(turn.sessionId);
+      }
+    }
+  }
+
+  // Sort each stats entry's sessions by most recent (desc) and cap at 50
+  const results = Array.from(statsMap.values());
+  for (const stat of results) {
+    stat.sessions.sort((a, b) => b.localeCompare(a));
+    if (stat.sessions.length > 50) stat.sessions = stat.sessions.slice(0, 50);
+  }
+
+  return results.sort((a, b) => b.invocations - a.invocations);
+}

--- a/src/lib/usage/skillParser.ts
+++ b/src/lib/usage/skillParser.ts
@@ -2,6 +2,8 @@ import type { SkillStats, UsageTurn } from "./types";
 
 export function groupSkillCalls(turns: UsageTurn[]): SkillStats[] {
   const statsMap = new Map<string, SkillStats>();
+  // Per-skill: sessionId → latest timestamp seen in that session (for sort + dedup)
+  const sessionTimes = new Map<string, Map<string, string>>();
 
   for (const turn of turns) {
     if (turn.role !== "assistant") continue;
@@ -13,36 +15,33 @@ export function groupSkillCalls(turns: UsageTurn[]): SkillStats[] {
 
       let stat = statsMap.get(skillName);
       if (!stat) {
-        stat = {
-          name: skillName,
-          invocations: 0,
-          projects: {},
-          sessions: [],
-        };
+        stat = { name: skillName, invocations: 0, projects: {}, sessions: [] };
         statsMap.set(skillName, stat);
+        sessionTimes.set(skillName, new Map());
       }
 
       stat.invocations++;
 
-      if (!stat.firstUsed || turn.timestamp < stat.firstUsed) {
-        stat.firstUsed = turn.timestamp;
-      }
-      if (!stat.lastUsed || turn.timestamp > stat.lastUsed) {
-        stat.lastUsed = turn.timestamp;
-      }
+      if (!stat.firstUsed || turn.timestamp < stat.firstUsed) stat.firstUsed = turn.timestamp;
+      if (!stat.lastUsed || turn.timestamp > stat.lastUsed) stat.lastUsed = turn.timestamp;
 
       stat.projects[turn.projectSlug] = (stat.projects[turn.projectSlug] ?? 0) + 1;
 
-      if (!stat.sessions.includes(turn.sessionId)) {
-        stat.sessions.push(turn.sessionId);
+      const times = sessionTimes.get(skillName)!;
+      const prev = times.get(turn.sessionId) ?? "";
+      if (!turn.timestamp || turn.timestamp > prev) {
+        times.set(turn.sessionId, turn.timestamp ?? "");
       }
     }
   }
 
   const results = Array.from(statsMap.values());
   for (const stat of results) {
-    stat.sessions.sort((a, b) => b.localeCompare(a));
-    if (stat.sessions.length > 50) stat.sessions = stat.sessions.slice(0, 50);
+    const times = sessionTimes.get(stat.name)!;
+    stat.sessions = [...times.entries()]
+      .sort((a, b) => b[1].localeCompare(a[1]))
+      .slice(0, 50)
+      .map(([id]) => id);
   }
 
   return results.sort((a, b) => b.invocations - a.invocations);

--- a/src/lib/usage/skillParser.ts
+++ b/src/lib/usage/skillParser.ts
@@ -1,0 +1,49 @@
+import type { SkillStats, UsageTurn } from "./types";
+
+export function groupSkillCalls(turns: UsageTurn[]): SkillStats[] {
+  const statsMap = new Map<string, SkillStats>();
+
+  for (const turn of turns) {
+    if (turn.role !== "assistant") continue;
+
+    for (const tc of turn.toolCalls) {
+      if (tc.name !== "Skill") continue;
+      const skillName = tc.arguments?.skill;
+      if (typeof skillName !== "string" || !skillName) continue;
+
+      let stat = statsMap.get(skillName);
+      if (!stat) {
+        stat = {
+          name: skillName,
+          invocations: 0,
+          projects: {},
+          sessions: [],
+        };
+        statsMap.set(skillName, stat);
+      }
+
+      stat.invocations++;
+
+      if (!stat.firstUsed || turn.timestamp < stat.firstUsed) {
+        stat.firstUsed = turn.timestamp;
+      }
+      if (!stat.lastUsed || turn.timestamp > stat.lastUsed) {
+        stat.lastUsed = turn.timestamp;
+      }
+
+      stat.projects[turn.projectSlug] = (stat.projects[turn.projectSlug] ?? 0) + 1;
+
+      if (!stat.sessions.includes(turn.sessionId)) {
+        stat.sessions.push(turn.sessionId);
+      }
+    }
+  }
+
+  const results = Array.from(statsMap.values());
+  for (const stat of results) {
+    stat.sessions.sort((a, b) => b.localeCompare(a));
+    if (stat.sessions.length > 50) stat.sessions = stat.sessions.slice(0, 50);
+  }
+
+  return results.sort((a, b) => b.invocations - a.invocations);
+}

--- a/src/lib/usage/slug.ts
+++ b/src/lib/usage/slug.ts
@@ -1,0 +1,13 @@
+import { encodePath, toSlug } from "@/lib/scanner/claudeConversations";
+
+/**
+ * Converts a scanner project path (e.g. "C:\dev\project-minder") to the
+ * slug format used by the usage parser (e.g. "dev-project-minder").
+ *
+ * The usage parser derives slugs from encoded Claude session dir names
+ * (C--dev-project-minder → dev-project-minder via toSlug). This function
+ * produces the same result starting from the raw project path.
+ */
+export function pathToUsageSlug(projectPath: string): string {
+  return toSlug(encodePath(projectPath));
+}

--- a/src/lib/usage/types.ts
+++ b/src/lib/usage/types.ts
@@ -104,6 +104,24 @@ export interface ProjectDetail {
   mcpCalls: number;
 }
 
+export interface AgentStats {
+  name: string;
+  invocations: number;
+  firstUsed?: string;
+  lastUsed?: string;
+  projects: Record<string, number>;
+  sessions: string[];
+}
+
+export interface SkillStats {
+  name: string;
+  invocations: number;
+  firstUsed?: string;
+  lastUsed?: string;
+  projects: Record<string, number>;
+  sessions: string[];
+}
+
 export interface UsageReport {
   period: string;
   totalCost: number;

--- a/tests/agentParser.test.ts
+++ b/tests/agentParser.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { groupAgentCalls } from "@/lib/usage/agentParser";
+import type { UsageTurn } from "@/lib/usage/types";
+
+function makeTurn(
+  overrides: Partial<UsageTurn> & {
+    agentType?: string;
+    skillName?: string;
+  }
+): UsageTurn {
+  const { agentType, skillName, ...rest } = overrides;
+  const toolCalls = agentType
+    ? [{ name: "Agent", arguments: { subagent_type: agentType, description: "test" } }]
+    : skillName
+    ? [{ name: "Skill", arguments: { skill: skillName } }]
+    : [];
+
+  return {
+    timestamp: "2026-01-01T00:00:00Z",
+    sessionId: "sess-1",
+    projectSlug: "project-a",
+    projectDirName: "C--dev-project-a",
+    model: "claude-sonnet-4-6",
+    role: "assistant",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    toolCalls,
+    ...rest,
+  };
+}
+
+describe("groupAgentCalls", () => {
+  it("returns empty array for no turns", () => {
+    expect(groupAgentCalls([])).toEqual([]);
+  });
+
+  it("ignores non-assistant turns", () => {
+    const turn = makeTurn({ role: "user", agentType: "Explore" });
+    expect(groupAgentCalls([turn])).toEqual([]);
+  });
+
+  it("counts a single Agent call", () => {
+    const result = groupAgentCalls([makeTurn({ agentType: "Explore" })]);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Explore");
+    expect(result[0].invocations).toBe(1);
+  });
+
+  it("groups multiple calls to the same agent", () => {
+    const turns = [
+      makeTurn({ agentType: "Explore" }),
+      makeTurn({ agentType: "Explore", sessionId: "sess-2" }),
+    ];
+    const result = groupAgentCalls(turns);
+    expect(result[0].invocations).toBe(2);
+    expect(result[0].sessions).toHaveLength(2);
+  });
+
+  it("keeps agents with different subagent_type separate", () => {
+    const turns = [
+      makeTurn({ agentType: "Explore" }),
+      makeTurn({ agentType: "code-reviewer" }),
+    ];
+    const result = groupAgentCalls(turns);
+    expect(result).toHaveLength(2);
+  });
+
+  it("tracks per-project counts", () => {
+    const turns = [
+      makeTurn({ agentType: "Explore", projectSlug: "project-a" }),
+      makeTurn({ agentType: "Explore", projectSlug: "project-b" }),
+      makeTurn({ agentType: "Explore", projectSlug: "project-a" }),
+    ];
+    const result = groupAgentCalls(turns);
+    expect(result[0].projects["project-a"]).toBe(2);
+    expect(result[0].projects["project-b"]).toBe(1);
+  });
+
+  it("tracks first and last used timestamps", () => {
+    const turns = [
+      makeTurn({ agentType: "Explore", timestamp: "2026-01-01T00:00:00Z" }),
+      makeTurn({ agentType: "Explore", timestamp: "2026-02-01T00:00:00Z" }),
+    ];
+    const result = groupAgentCalls(turns);
+    expect(result[0].firstUsed).toBe("2026-01-01T00:00:00Z");
+    expect(result[0].lastUsed).toBe("2026-02-01T00:00:00Z");
+  });
+
+  it("deduplicates session IDs", () => {
+    const turns = [
+      makeTurn({ agentType: "Explore", sessionId: "same-session" }),
+      makeTurn({ agentType: "Explore", sessionId: "same-session" }),
+    ];
+    const result = groupAgentCalls(turns);
+    expect(result[0].sessions).toHaveLength(1);
+  });
+
+  it("ignores Skill tool calls", () => {
+    const result = groupAgentCalls([makeTurn({ skillName: "simplify" })]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("sorts by invocations descending", () => {
+    const turns = [
+      makeTurn({ agentType: "rare-agent" }),
+      makeTurn({ agentType: "common-agent" }),
+      makeTurn({ agentType: "common-agent", sessionId: "sess-2" }),
+    ];
+    const result = groupAgentCalls(turns);
+    expect(result[0].name).toBe("common-agent");
+    expect(result[1].name).toBe("rare-agent");
+  });
+});

--- a/tests/canonicalize.test.ts
+++ b/tests/canonicalize.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { buildAgentAliasMap, buildSkillAliasMap, lookupEntry } from "@/lib/indexer/canonicalize";
+import type { AgentEntry, SkillEntry } from "@/lib/indexer/types";
+
+function makeAgent(overrides: Partial<AgentEntry> = {}): AgentEntry {
+  return {
+    id: "user:user:test-agent",
+    slug: "test-agent",
+    name: "Test Agent",
+    source: "user",
+    filePath: "/fake/test-agent.md",
+    bodyExcerpt: "",
+    frontmatter: {},
+    mtime: "",
+    ctime: "",
+    kind: "agent",
+    ...overrides,
+  };
+}
+
+function makeSkill(overrides: Partial<SkillEntry> = {}): SkillEntry {
+  return {
+    id: "user:user:my-skill",
+    slug: "my-skill",
+    name: "My Skill",
+    source: "user",
+    filePath: "/fake/my-skill/SKILL.md",
+    bodyExcerpt: "",
+    frontmatter: {},
+    mtime: "",
+    ctime: "",
+    kind: "skill",
+    layout: "bundled",
+    ...overrides,
+  };
+}
+
+describe("buildAgentAliasMap", () => {
+  it("looks up by slug", () => {
+    const agent = makeAgent();
+    const map = buildAgentAliasMap([agent]);
+    expect(lookupEntry(map, "test-agent")).toBe(agent);
+  });
+
+  it("looks up by name (case-insensitive)", () => {
+    const agent = makeAgent();
+    const map = buildAgentAliasMap([agent]);
+    expect(lookupEntry(map, "test agent")).toBe(agent);
+    expect(lookupEntry(map, "TEST AGENT")).toBe(agent);
+  });
+
+  it("looks up plugin agent by pluginName:slug", () => {
+    const agent = makeAgent({
+      source: "plugin",
+      pluginName: "feature-dev",
+      slug: "code-reviewer",
+      id: "plugin:feature-dev:code-reviewer",
+    });
+    const map = buildAgentAliasMap([agent]);
+    expect(lookupEntry(map, "feature-dev:code-reviewer")).toBe(agent);
+  });
+
+  it("returns undefined for unknown name", () => {
+    const map = buildAgentAliasMap([makeAgent()]);
+    expect(lookupEntry(map, "nonexistent")).toBeUndefined();
+  });
+});
+
+describe("buildSkillAliasMap", () => {
+  it("looks up by slug", () => {
+    const skill = makeSkill();
+    const map = buildSkillAliasMap([skill]);
+    expect(lookupEntry(map, "my-skill")).toBe(skill);
+  });
+
+  it("looks up plugin skill by pluginName:slug", () => {
+    const skill = makeSkill({
+      source: "plugin",
+      pluginName: "vercel",
+      slug: "nextjs",
+      id: "plugin:vercel:nextjs",
+    });
+    const map = buildSkillAliasMap([skill]);
+    expect(lookupEntry(map, "vercel:nextjs")).toBe(skill);
+  });
+
+  it("is case-insensitive", () => {
+    const skill = makeSkill({ slug: "Simplify", name: "Simplify" });
+    const map = buildSkillAliasMap([skill]);
+    expect(lookupEntry(map, "simplify")).toBe(skill);
+  });
+});

--- a/tests/parseFrontmatter.test.ts
+++ b/tests/parseFrontmatter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { parseFrontmatter } from "@/lib/indexer/parseFrontmatter";
+
+describe("parseFrontmatter", () => {
+  it("returns empty fm and full text when there is no frontmatter", () => {
+    const result = parseFrontmatter("just some markdown");
+    expect(result.fm).toEqual({});
+    expect(result.body).toBe("just some markdown");
+  });
+
+  it("returns empty fm and full text for an empty string", () => {
+    const result = parseFrontmatter("");
+    expect(result.fm).toEqual({});
+    expect(result.body).toBe("");
+  });
+
+  it("parses a simple frontmatter block", () => {
+    const text = `---\nname: my-skill\ndescription: A test skill\n---\n\nBody here.`;
+    const result = parseFrontmatter(text);
+    expect(result.fm.name).toBe("my-skill");
+    expect(result.fm.description).toBe("A test skill");
+    expect(result.body).toBe("Body here.");
+  });
+
+  it("parses nested frontmatter (metadata block)", () => {
+    const text = `---\nname: nextjs\nmetadata:\n  priority: 5\n  docs:\n    - https://example.com\n---\nSkill body.`;
+    const result = parseFrontmatter(text);
+    expect(result.fm.name).toBe("nextjs");
+    expect((result.fm.metadata as Record<string, unknown>)?.priority).toBe(5);
+    expect(result.body).toBe("Skill body.");
+  });
+
+  it("does not throw on malformed YAML — returns empty fm", () => {
+    // Unescaped colon in description triggers YAML parse error
+    const text = `---\nname: test\ndescription: Use when user asks: <example>foo</example>\n---\nBody.`;
+    expect(() => parseFrontmatter(text)).not.toThrow();
+    const result = parseFrontmatter(text);
+    // fm may be {} or partial — what matters is no throw and body is present
+    expect(typeof result.body).toBe("string");
+  });
+
+  it("handles multi-line quoted description", () => {
+    const text = `---\nname: audit\ndescription: "Run checks\\nfor quality"\n---\nBody.`;
+    const result = parseFrontmatter(text);
+    expect(result.fm.name).toBe("audit");
+    expect(result.body).toBe("Body.");
+  });
+
+  it("returns empty fm when closing --- is missing", () => {
+    const text = `---\nname: broken`;
+    const result = parseFrontmatter(text);
+    expect(result.fm).toEqual({});
+  });
+});

--- a/tests/skillParser.test.ts
+++ b/tests/skillParser.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { groupSkillCalls } from "@/lib/usage/skillParser";
+import type { UsageTurn } from "@/lib/usage/types";
+
+function makeTurn(
+  overrides: Partial<UsageTurn> & { skillName?: string; agentType?: string }
+): UsageTurn {
+  const { skillName, agentType, ...rest } = overrides;
+  const toolCalls = skillName
+    ? [{ name: "Skill", arguments: { skill: skillName } }]
+    : agentType
+    ? [{ name: "Agent", arguments: { subagent_type: agentType } }]
+    : [];
+
+  return {
+    timestamp: "2026-01-01T00:00:00Z",
+    sessionId: "sess-1",
+    projectSlug: "my-project",
+    projectDirName: "C--dev-my-project",
+    model: "claude-sonnet-4-6",
+    role: "assistant",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    toolCalls,
+    ...rest,
+  };
+}
+
+describe("groupSkillCalls", () => {
+  it("returns empty array for no turns", () => {
+    expect(groupSkillCalls([])).toEqual([]);
+  });
+
+  it("counts a single Skill call", () => {
+    const result = groupSkillCalls([makeTurn({ skillName: "simplify" })]);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("simplify");
+    expect(result[0].invocations).toBe(1);
+  });
+
+  it("groups multiple calls to the same skill", () => {
+    const turns = [
+      makeTurn({ skillName: "simplify" }),
+      makeTurn({ skillName: "simplify", sessionId: "sess-2" }),
+    ];
+    const result = groupSkillCalls(turns);
+    expect(result[0].invocations).toBe(2);
+    expect(result[0].sessions).toHaveLength(2);
+  });
+
+  it("keeps plugin-namespaced skills separate from plain skills", () => {
+    const turns = [
+      makeTurn({ skillName: "vercel:deploy" }),
+      makeTurn({ skillName: "deploy" }),
+    ];
+    const result = groupSkillCalls(turns);
+    expect(result).toHaveLength(2);
+    const names = result.map((r) => r.name);
+    expect(names).toContain("vercel:deploy");
+    expect(names).toContain("deploy");
+  });
+
+  it("tracks per-project counts", () => {
+    const turns = [
+      makeTurn({ skillName: "simplify", projectSlug: "proj-x" }),
+      makeTurn({ skillName: "simplify", projectSlug: "proj-y" }),
+    ];
+    const result = groupSkillCalls(turns);
+    expect(result[0].projects["proj-x"]).toBe(1);
+    expect(result[0].projects["proj-y"]).toBe(1);
+  });
+
+  it("ignores Agent tool calls", () => {
+    const result = groupSkillCalls([makeTurn({ agentType: "Explore" })]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("ignores non-assistant turns", () => {
+    const result = groupSkillCalls([makeTurn({ skillName: "simplify", role: "user" })]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("sorts by invocations descending", () => {
+    const turns = [
+      makeTurn({ skillName: "rare" }),
+      makeTurn({ skillName: "common" }),
+      makeTurn({ skillName: "common", sessionId: "sess-2" }),
+    ];
+    const result = groupSkillCalls(turns);
+    expect(result[0].name).toBe("common");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `/agents` and `/skills` cross-project catalog pages — browse all Claude Code agents and skills from `~/.claude/`, installed plugins, and per-project `.claude/` directories, with invocation counts and last-used timestamps
- Adds **Agents** and **Skills** tabs to each project detail page showing project-local definitions and agents/skills invoked in that project's sessions
- New `src/lib/indexer/` layer (frontmatter parser, walkers, plugin registry, catalog facade, canonicalize alias map) + `agentParser`/`skillParser` usage rollups
- Fixes a slug mismatch (`project-minder` vs `dev-project-minder`) that caused "Invoked here" to always show zero — shared `pathToUsageSlug` utility in `src/lib/usage/slug.ts`
- Fixes a cold-start cache race where project-local agents/skills wouldn't appear until the 5-min catalog TTL expired after a scan

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 273 tests pass (24 test files)
- [ ] Visit `/agents` — confirm ~220+ rows, source filter, search, sort, and inline row expansion all work
- [ ] Visit `/skills` — confirm ~100+ rows, bundled/standalone layout chips, same filters
- [ ] Open a project detail page → Agents tab and Skills tab (try `perfect-palette` which has project-local skills and invocations)
- [ ] Trigger a scan, then reload `/agents?project=<slug>` — confirm project-local entries appear immediately (no TTL wait)

🤖 Generated with [Claude Code](https://claude.com/claude-code)