### PR TITLE
feat(indexer): support agents installed in ~/.agents/agents/

### DIFF
--- a/docs/help/agents.md
+++ b/docs/help/agents.md
@@ -17,15 +17,14 @@ An agent is a named persona defined in a Markdown file with YAML frontmatter. It
 Each row shows a badge indicating the agent's origin:
 
 - **Marketplace badge** (e.g. `claude-plugins-official`) — agent is part of a plugin from that marketplace
-- **GitHub repo badge** (e.g. `owner/repo`) — agent installed via the lockfile mechanism
 - **"local"** — user-authored with no upstream
 - **"project: slug"** — defined inside a project's `.claude/agents/` folder
 
-An **amber dot** on the badge means an update is available upstream.
+An **amber dot** on the badge means an update is available upstream (currently supported for marketplace plugin agents only).
 
 ## Update Detection
 
-Project Minder runs background update checks (24-hour TTL) for marketplace plugin agents and lockfile agents. See the [Skills help page](/help/skills) for full details on how checks work.
+Project Minder runs background update checks (24-hour TTL) for marketplace plugin agents. See the [Skills help page](/help/skills) for full details on how checks work.
 
 ## Cross-Project Browser (`/agents`)
 

--- a/public/help/agents.md
+++ b/public/help/agents.md
@@ -17,15 +17,14 @@ An agent is a named persona defined in a Markdown file with YAML frontmatter. It
 Each row shows a badge indicating the agent's origin:
 
 - **Marketplace badge** (e.g. `claude-plugins-official`) — agent is part of a plugin from that marketplace
-- **GitHub repo badge** (e.g. `owner/repo`) — agent installed via the lockfile mechanism
 - **"local"** — user-authored with no upstream
 - **"project: slug"** — defined inside a project's `.claude/agents/` folder
 
-An **amber dot** on the badge means an update is available upstream.
+An **amber dot** on the badge means an update is available upstream (currently supported for marketplace plugin agents only).
 
 ## Update Detection
 
-Project Minder runs background update checks (24-hour TTL) for marketplace plugin agents and lockfile agents. See the [Skills help page](/help/skills) for full details on how checks work.
+Project Minder runs background update checks (24-hour TTL) for marketplace plugin agents. See the [Skills help page](/help/skills) for full details on how checks work.
 
 ## Cross-Project Browser (`/agents`)
 

--- a/src/hooks/useUpdateStatuses.ts
+++ b/src/hooks/useUpdateStatuses.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import type { SkillUpdateStatus } from "@/lib/skillUpdateCache";
 
 interface UpdateStatusResponse {
@@ -14,7 +14,6 @@ const POLL_INTERVAL = 10_000;
 export function useUpdateStatuses() {
   const [statuses, setStatuses] = useState<Record<string, SkillUpdateStatus>>({});
   const [pending, setPending] = useState(0);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
     let stopped = false;
@@ -26,24 +25,16 @@ export function useUpdateStatuses() {
         const data: UpdateStatusResponse = await res.json();
         setStatuses(data.statuses);
         setPending(data.pending);
-
-        if (data.pending === 0 && intervalRef.current) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        } else if (data.pending > 0 && !intervalRef.current) {
-          intervalRef.current = setInterval(poll, POLL_INTERVAL);
-        }
       } catch {
         // Network error, will retry
       }
     }
 
     poll();
-    intervalRef.current = setInterval(poll, POLL_INTERVAL);
-
+    const interval = setInterval(poll, POLL_INTERVAL);
     return () => {
       stopped = true;
-      if (intervalRef.current) clearInterval(intervalRef.current);
+      clearInterval(interval);
     };
   }, []);
 

--- a/src/lib/indexer/catalog.ts
+++ b/src/lib/indexer/catalog.ts
@@ -63,7 +63,7 @@ export async function loadCatalog(
   const seenPaths = new Set<string>(claudeAgents.map((e) => e.realPath ?? e.filePath));
   const mergedUserAgents = [
     ...claudeAgents,
-    ...installedAgents.filter((e) => !seenPaths.has(e.filePath)),
+    ...installedAgents.filter((e) => !seenPaths.has(e.realPath ?? e.filePath)),
   ];
 
   const agents: AgentEntry[] = [...mergedUserAgents, ...pluginAgents];

--- a/src/lib/indexer/catalog.ts
+++ b/src/lib/indexer/catalog.ts
@@ -1,4 +1,4 @@
-import { walkUserAgents, walkPluginAgents, walkProjectAgents } from "./walkAgents";
+import { walkUserAgents, walkInstalledAgents, walkPluginAgents, walkProjectAgents } from "./walkAgents";
 import { walkUserSkills, walkPluginSkills, walkProjectSkills } from "./walkSkills";
 import { loadProvenanceContext } from "./provenance";
 import { getCachedScan } from "@/lib/cache";
@@ -49,14 +49,24 @@ export async function loadCatalog(
   // Load provenance context once — shared across all walks
   const ctx = await loadProvenanceContext();
 
-  const [userAgents, pluginAgents, userSkills, pluginSkills] = await Promise.all([
+  const [claudeAgents, installedAgents, pluginAgents, userSkills, pluginSkills] = await Promise.all([
     walkUserAgents(ctx),
+    walkInstalledAgents(ctx),
     walkPluginAgents(ctx),
     walkUserSkills(ctx),
     walkPluginSkills(ctx),
   ]);
 
-  const agents: AgentEntry[] = [...userAgents, ...pluginAgents];
+  // Deduplicate: ~/.claude/agents/ symlink entries win over the same file in ~/.agents/agents/.
+  // Symlinked entries already carry realPath; direct ~/.agents/agents/ entries use filePath as
+  // the real path. Whichever appears first in claudeAgents claims the slot.
+  const seenPaths = new Set<string>(claudeAgents.map((e) => e.realPath ?? e.filePath));
+  const mergedUserAgents = [
+    ...claudeAgents,
+    ...installedAgents.filter((e) => !seenPaths.has(e.filePath)),
+  ];
+
+  const agents: AgentEntry[] = [...mergedUserAgents, ...pluginAgents];
   const skills: SkillEntry[] = [...userSkills, ...pluginSkills];
 
   let hadProjectScan = false;

--- a/src/lib/indexer/walkAgents.ts
+++ b/src/lib/indexer/walkAgents.ts
@@ -182,6 +182,16 @@ export async function walkUserAgents(ctx: ProvenanceContext): Promise<AgentEntry
   return walkDir(root, root, "user", { ctx });
 }
 
+export async function walkInstalledAgents(ctx: ProvenanceContext): Promise<AgentEntry[]> {
+  const root = path.join(os.homedir(), ".agents", "agents");
+  try {
+    await fs.access(root);
+  } catch {
+    return [];
+  }
+  return walkDir(root, root, "user", { ctx });
+}
+
 export async function walkPluginAgents(ctx: ProvenanceContext): Promise<AgentEntry[]> {
   const all: AgentEntry[] = [];
 

--- a/src/lib/skillUpdateCache.ts
+++ b/src/lib/skillUpdateCache.ts
@@ -140,7 +140,6 @@ class SkillUpdateCache {
     const dirPath = skillPath.replace(/\/SKILL\.md$/, "");
     const encodedPath = dirPath.split("/").map(encodeURIComponent).join("/");
 
-    const apiUrl = `https://api.github.com/repos/${ownerRepo}/commits?path=${encodedPath}&sha=HEAD&per_page=1`;
     const headers: Record<string, string> = {
       Accept: "application/vnd.github.v3+json",
       "User-Agent": "project-minder",
@@ -149,19 +148,41 @@ class SkillUpdateCache {
       headers["Authorization"] = `Bearer ${process.env.GITHUB_TOKEN}`;
     }
 
-    const res = await fetch(apiUrl, { headers });
-    if (!res.ok) return null; // don't cache on HTTP errors (rate-limit, 404)
+    // Step 1: fetch the latest commit for this path to get the root tree SHA.
+    // skillFolderHash is a git tree SHA, so we must traverse the tree — not compare
+    // against a commit SHA, which is a different object type.
+    const commitRes = await fetch(
+      `https://api.github.com/repos/${ownerRepo}/commits?path=${encodedPath}&per_page=1`,
+      { headers }
+    );
+    if (!commitRes.ok) return null;
 
-    const data = (await res.json()) as Array<{ sha?: string }>;
-    const upstreamHash = data[0]?.sha;
-    if (!upstreamHash) return base;
+    const commits = (await commitRes.json()) as Array<{
+      commit?: { tree?: { sha?: string } };
+    }>;
+    const rootTreeSha = commits[0]?.commit?.tree?.sha;
+    if (!rootTreeSha) return base;
 
-    const hasUpdate = upstreamHash !== skillFolderHash;
+    // Step 2: walk the recursive tree to find the directory entry's tree SHA.
+    const treeRes = await fetch(
+      `https://api.github.com/repos/${ownerRepo}/git/trees/${rootTreeSha}?recursive=1`,
+      { headers }
+    );
+    if (!treeRes.ok) return null;
+
+    const treeData = (await treeRes.json()) as {
+      tree?: Array<{ path?: string; type?: string; sha?: string }>;
+    };
+    const dirEntry = treeData.tree?.find((e) => e.path === dirPath && e.type === "tree");
+    if (!dirEntry?.sha) return base; // path not found (may have moved upstream)
+
+    const upstreamTreeSha = dirEntry.sha;
+    const hasUpdate = upstreamTreeSha !== skillFolderHash;
     return {
       ...base,
       hasUpdate,
       reason: hasUpdate ? "hash-mismatch" : undefined,
-      upstreamRef: upstreamHash.slice(0, 7),
+      upstreamRef: upstreamTreeSha.slice(0, 7),
       currentRef: skillFolderHash.slice(0, 7),
     };
   }


### PR DESCRIPTION
## Summary

- Adds `walkInstalledAgents()` that walks `~/.agents/agents/` if the directory exists (no-op if absent, so no breakage on machines that don't have it yet)
- `loadCatalog` now runs both `walkUserAgents` (from `~/.claude/agents/`) and `walkInstalledAgents` in parallel, then deduplicates by `realPath ?? filePath`
- Symlinked entries from `~/.claude/agents/` always win — they carry full `isSymlink`/`realPath` metadata. Direct entries from `~/.agents/agents/` only appear if they weren't already captured via a symlink.

This mirrors the existing skill pattern: `~/.claude/skills/` → symlinks → `~/.agents/skills/`. When `~/.agents/` gains an `.agent-lock.json`, provenance can be wired up by extending `resolveProvenance` with `entryKind === "agent"` — same gate used for skills in the previous PR.

## Test plan

- [ ] All 302 existing tests pass (`npm test`)
- [ ] `npm run typecheck` clean
- [ ] On a machine where `~/.agents/agents/` doesn't exist: no change in behavior
- [ ] On a machine where `~/.agents/agents/foo.md` exists AND `~/.claude/agents/foo.md` symlinks to it: only one entry appears, with `isSymlink: true`
- [ ] On a machine where `~/.agents/agents/bar.md` exists with no symlink: appears as a new `user-local` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)