### PR TITLE
fix(ux): critique-driven overhaul — a11y, polish, UX refinements, and simplify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- **Dev server stop confirmation** — compact and full-panel Stop buttons now prompt `window.confirm` before killing the process, preventing accidental shutdowns.
+- **Dev server error state** — compact card badge now shows a red "error" pill with last-output tooltip and a Retry button when the server exits non-zero; full-panel Start button relabels to "Retry" in error state.
+- **Dev server error details** — `doAction` extracts `error` field from non-ok API responses and shows it as the toast description ("Failed to start dev server", "EADDRINUSE: port in use") instead of the generic fallback.
 - **Archive consolidation** — "Hidden" UX path removed from the dashboard entirely. The card three-dot dropdown now says "Archive" (no confirmation required; archive is reversible). Archiving shows a toast with a 5-second "Undo" action. Scanner exclusion (`hidden[]`) remains a Setup-only power feature.
 - **Collapsed archived section** — when projects are archived and the status filter is "All", a collapsible "Archived (N)" row appears below the main grid. Expanding it shows a lightweight list of archived project names with one-click "Unarchive" buttons.
 - **Toast action buttons** — `showToast` now accepts an optional third `action: { label, onClick }` argument; the toast renders the action as a text button before the dismiss X.
@@ -16,7 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Conditional ProjectDetail tabs** — Sessions, Manual Steps, and Insights tabs are hidden when the project has no data for them (`sessionCount === 0`, no `MANUAL_STEPS.md`, zero insights). Memory, Agents, and Skills tabs always remain.
 
 ### Changed
-- **Sort label** — "Claude" sort option renamed to "By Claude" with `title="Sort by most recent Claude session"` tooltip.
+- **Dev server stop confirmation removed** — Stop (compact + full panel) no longer shows `window.confirm`. The status transition is immediate feedback; dev server stops are trivially reversible (restart in 2s).
+- **Sort label** — "By Claude" renamed to "Last Session" with a `Bot` icon; `title="Sort by most recent Claude session"` on hover.
+- **Toolbar icon treatment** — Status filter and Sort buttons now match the View mode toggle: icon above label, stacked vertically, `minHeight: 32px`. Each status has a unique icon (Layers/CircleDot/CirclePause/Archive); each sort has a unique icon (Clock/Bot/ArrowUpAZ). Quick Add and Rescan standalone buttons also gain `minHeight: 32px` for consistent hit-area sizing.
+- **Default sort** — dashboard initial sort changed from "Recent" (file activity) to "Last Session" (Claude session recency), matching the primary workflow of resuming Claude-assisted work. Saved config preference still takes precedence.
+- **Rescan error toast** — "Scan failed / Check the console" → "Rescan failed / Showing cached results", clarifying that the project list is preserved on failure.
 - **Pin button opacity** — unpinned pin button on full cards raised from 0.25 → 0.4 for better discoverability.
 - **Dashboard accessibility pass** — visually-hidden `<label>` for search input; `scope="col"` on all table header cells in the sparkline list; `aria-label` on pin buttons and session badge buttons; descriptive `title` attributes on `▲` attention indicators; `:focus-visible` ring (2px `--info` teal) applied globally via CSS.
 - **Pinned card visual treatment** — pinned cards in full and compact view now show a subtle `--info-bg` background tint and `--info-border` border, matching the sparkline row treatment. A direct pin button is now present on the full card face (hidden until hover, always visible when pinned) — no longer requires opening the three-dot dropdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Dev server stop confirmation** — compact and full-panel Stop buttons now prompt `window.confirm` before killing the process, preventing accidental shutdowns.
+- **Archive consolidation** — "Hidden" UX path removed from the dashboard entirely. The card three-dot dropdown now says "Archive" (no confirmation required; archive is reversible). Archiving shows a toast with a 5-second "Undo" action. Scanner exclusion (`hidden[]`) remains a Setup-only power feature.
+- **Collapsed archived section** — when projects are archived and the status filter is "All", a collapsible "Archived (N)" row appears below the main grid. Expanding it shows a lightweight list of archived project names with one-click "Unarchive" buttons.
+- **Toast action buttons** — `showToast` now accepts an optional third `action: { label, onClick }` argument; the toast renders the action as a text button before the dismiss X.
+- **Last-scan indicator** — the dashboard meta row now shows "Scanned Xm ago · Rescan" using the `scannedAt` timestamp from the scan result.
+- **Rescan keyboard shortcut** — `r` (no modifier, outside input fields) triggers a rescan from the dashboard.
+- **Conditional ProjectDetail tabs** — Sessions, Manual Steps, and Insights tabs are hidden when the project has no data for them (`sessionCount === 0`, no `MANUAL_STEPS.md`, zero insights). Memory, Agents, and Skills tabs always remain.
+
+### Changed
+- **Sort label** — "Claude" sort option renamed to "By Claude" with `title="Sort by most recent Claude session"` tooltip.
+- **Pin button opacity** — unpinned pin button on full cards raised from 0.25 → 0.4 for better discoverability.
 - **Dashboard accessibility pass** — visually-hidden `<label>` for search input; `scope="col"` on all table header cells in the sparkline list; `aria-label` on pin buttons and session badge buttons; descriptive `title` attributes on `▲` attention indicators; `:focus-visible` ring (2px `--info` teal) applied globally via CSS.
 - **Pinned card visual treatment** — pinned cards in full and compact view now show a subtle `--info-bg` background tint and `--info-border` border, matching the sparkline row treatment. A direct pin button is now present on the full card face (hidden until hover, always visible when pinned) — no longer requires opening the three-dot dropdown.
 - **Pin failure recovery** — `onTogglePin` now reverts the optimistic local state if the config PATCH fails, preventing pin state drift.

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { AgentsBrowser } from "@/components/AgentsBrowser";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function AgentsPage() {
+  useDocumentTitle("Agents");
   return <AgentsBrowser />;
 }

--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { ConfigDashboard } from "@/components/ConfigDashboard";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function ConfigPage() {
+  useDocumentTitle("Config");
   return <ConfigDashboard />;
 }

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { InsightsBrowser } from "@/components/InsightsBrowser";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function InsightsPage() {
+  useDocumentTitle("Insights");
   return <InsightsBrowser />;
 }

--- a/src/app/manual-steps/page.tsx
+++ b/src/app/manual-steps/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { ManualStepsDashboard } from "@/components/ManualStepsDashboard";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function ManualStepsPage() {
+  useDocumentTitle("Manual Steps");
   return <ManualStepsDashboard />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,16 +7,17 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function Home() {
   useDocumentTitle("Dashboard");
-  const { data, loading, rescan, hideProject } = useProjects();
+  const { data, loading, rescan, archiveProject, unarchiveProject } = useProjects();
   const { statuses } = useGitDirtyStatus();
 
   return (
     <DashboardGrid
       projects={data?.projects ?? []}
-      hiddenCount={data?.hiddenCount ?? 0}
       loading={loading}
       onRescan={rescan}
-      onHide={hideProject}
+      onArchive={archiveProject}
+      onUnarchive={unarchiveProject}
+      scannedAt={data?.scannedAt}
       gitDirtyOverrides={statuses}
     />
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,10 @@
 import { useProjects } from "@/hooks/useProjects";
 import { useGitDirtyStatus } from "@/hooks/useGitDirtyStatus";
 import { DashboardGrid } from "@/components/DashboardGrid";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function Home() {
+  useDocumentTitle("Dashboard");
   const { data, loading, rescan, hideProject } = useProjects();
   const { statuses } = useGitDirtyStatus();
 

--- a/src/app/project/[slug]/page.tsx
+++ b/src/app/project/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { useProject } from "@/hooks/useProjects";
 import { ProjectDetail } from "@/components/ProjectDetail";
 import { ProjectStatus } from "@/lib/types";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function ProjectPage({
   params,
@@ -13,6 +14,8 @@ export default function ProjectPage({
 }) {
   const { slug } = use(params);
   const { project, loading } = useProject(slug);
+
+  useDocumentTitle(project?.name ?? slug);
 
   const handleStatusChange = async (status: ProjectStatus) => {
     await fetch("/api/config", {

--- a/src/app/sessions/[sessionId]/page.tsx
+++ b/src/app/sessions/[sessionId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { use } from "react";
 import { SessionDetailView } from "@/components/SessionDetailView";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function SessionDetailPage({
   params,
@@ -9,5 +10,6 @@ export default function SessionDetailPage({
   params: Promise<{ sessionId: string }>;
 }) {
   const { sessionId } = use(params);
+  useDocumentTitle("Session");
   return <SessionDetailView sessionId={sessionId} />;
 }

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { SessionsBrowser } from "@/components/SessionsBrowser";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function SessionsPage() {
+  useDocumentTitle("Sessions");
   return <SessionsBrowser />;
 }

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { SetupGuide } from "@/components/SetupGuide";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function SetupPage() {
+  useDocumentTitle("Setup");
   return <SetupGuide />;
 }

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { SkillsBrowser } from "@/components/SkillsBrowser";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function SkillsPage() {
+  useDocumentTitle("Skills");
   return <SkillsBrowser />;
 }

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { StatsDashboard } from "@/components/StatsDashboard";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function StatsPage() {
+  useDocumentTitle("Stats");
   return <StatsDashboard />;
 }

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { StatusDashboard } from "@/components/StatusDashboard";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function StatusPage() {
+  useDocumentTitle("Status");
   return <StatusDashboard />;
 }

--- a/src/app/usage/page.tsx
+++ b/src/app/usage/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { UsageDashboard } from "@/components/UsageDashboard";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function UsagePage() {
+  useDocumentTitle("Usage");
   return <UsageDashboard />;
 }

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -14,8 +14,8 @@ const navItems = [
   { href: "/status",       label: "Status",   badge: "approval" },
   { href: "/usage",        label: "Usage"                       },
   { href: "/stats",        label: "Stats"                       },
-  { href: "/config",       label: "Config"                      },
-  { href: "/setup",        label: "Setup"                       },
+  { href: "/config",       label: "Config",   admin: true       },
+  { href: "/setup",        label: "Setup",    admin: true       },
 ];
 
 export function AppNav() {
@@ -71,55 +71,70 @@ export function AppNav() {
 
   return (
     <nav style={{ display: "flex", alignItems: "center", gap: "2px", flexWrap: "wrap" }}>
-      {navItems.map((item) => {
+      {navItems.map((item, idx) => {
         const isActive =
           pathname === item.href || pathname.startsWith(item.href + "/");
         const badgeCounts: Record<string, number> = { steps: stepsPending, approval: statusApproval };
         const badgeCount = item.badge ? (badgeCounts[item.badge] ?? 0) : 0;
         const showBadge = badgeCount > 0;
+        const isAdmin = "admin" in item && item.admin === true;
+        const prevIsAdmin = idx > 0 && "admin" in navItems[idx - 1] && navItems[idx - 1].admin === true;
+        const showSeparator = isAdmin && !prevIsAdmin;
 
         return (
-          <Link
-            key={item.href}
-            href={item.href}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "5px",
-              padding: "4px 10px",
-              borderRadius: "var(--radius)",
-              fontSize: "0.7rem",
-              fontWeight: 500,
-              letterSpacing: "0.04em",
-              textTransform: "uppercase",
-              fontFamily: "var(--font-body)",
-              textDecoration: "none",
-              color: isActive ? "var(--info)" : "var(--text-secondary)",
-              background: isActive ? "var(--info-bg)" : "transparent",
-              transition: "color 0.12s, background 0.12s",
-            }}
-          >
-            {item.label}
-            {showBadge && (
+          <span key={item.href} style={{ display: "contents" }}>
+            {showSeparator && (
               <span
+                aria-hidden="true"
                 style={{
-                  fontFamily: "var(--font-mono)",
-                  fontSize: "0.65rem",
-                  fontWeight: 600,
-                  letterSpacing: 0,
-                  textTransform: "none",
-                  background: "var(--accent-bg)",
-                  color: "var(--accent)",
-                  border: "1px solid var(--accent-border)",
-                  borderRadius: "3px",
-                  padding: "0 4px",
-                  lineHeight: "1.4",
+                  width: "1px", height: "14px", flexShrink: 0,
+                  background: "var(--border-default)",
+                  margin: "0 4px",
+                  alignSelf: "center",
                 }}
-              >
-                {badgeCount}
-              </span>
+              />
             )}
-          </Link>
+            <Link
+              href={item.href}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "5px",
+                padding: "4px 10px",
+                borderRadius: "var(--radius)",
+                fontSize: "0.7rem",
+                fontWeight: isAdmin ? 400 : 500,
+                letterSpacing: isAdmin ? "0.02em" : "0.04em",
+                textTransform: isAdmin ? "none" : "uppercase",
+                fontFamily: "var(--font-body)",
+                textDecoration: "none",
+                color: isActive ? "var(--info)" : isAdmin ? "var(--text-muted)" : "var(--text-secondary)",
+                background: isActive ? "var(--info-bg)" : "transparent",
+                transition: "color 0.12s, background 0.12s",
+              }}
+            >
+              {item.label}
+              {showBadge && (
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.65rem",
+                    fontWeight: 600,
+                    letterSpacing: 0,
+                    textTransform: "none",
+                    background: "var(--accent-bg)",
+                    color: "var(--accent)",
+                    border: "1px solid var(--accent-border)",
+                    borderRadius: "3px",
+                    padding: "0 4px",
+                    lineHeight: "1.4",
+                  }}
+                >
+                  {badgeCount}
+                </span>
+              )}
+            </Link>
+          </span>
         );
       })}
     </nav>

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -24,13 +24,10 @@ export function AppNav() {
   const [statusApproval, setStatusApproval] = useState(0);
 
   useEffect(() => {
-    let errors = 0;
-    let id: ReturnType<typeof setInterval>;
     async function fetchPending() {
       try {
         const res = await fetch("/api/manual-steps?pending=true");
-        if (!res.ok) { errors++; if (errors >= 5) clearInterval(id); return; }
-        errors = 0;
+        if (!res.ok) return;
         const data = await res.json();
         const total = data.reduce(
           (sum: number, p: { manualSteps: { pendingSteps: number } }) =>
@@ -39,33 +36,28 @@ export function AppNav() {
         );
         setStepsPending(total);
       } catch {
-        errors++;
-        if (errors >= 5) clearInterval(id);
+        // silently ignore, will retry on next tick
       }
     }
     fetchPending();
-    id = setInterval(fetchPending, 30_000);
+    const id = setInterval(fetchPending, 30_000);
     return () => clearInterval(id);
   }, []);
 
   useEffect(() => {
-    let errors = 0;
-    let id: ReturnType<typeof setInterval>;
     async function fetchApproval() {
       try {
         const res = await fetch("/api/status");
-        if (!res.ok) { errors++; if (errors >= 5) clearInterval(id); return; }
-        errors = 0;
+        if (!res.ok) return;
         const data = await res.json() as { sessions: LiveSession[] };
         const count = data.sessions?.filter((s) => s.status === "approval").length ?? 0;
         setStatusApproval(count);
       } catch {
-        errors++;
-        if (errors >= 5) clearInterval(id);
+        // silently ignore, will retry on next tick
       }
     }
     fetchApproval();
-    id = setInterval(fetchApproval, 10_000);
+    const id = setInterval(fetchApproval, 10_000);
     return () => clearInterval(id);
   }, []);
 

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -24,10 +24,13 @@ export function AppNav() {
   const [statusApproval, setStatusApproval] = useState(0);
 
   useEffect(() => {
+    let errors = 0;
+    let id: ReturnType<typeof setInterval>;
     async function fetchPending() {
       try {
         const res = await fetch("/api/manual-steps?pending=true");
-        if (!res.ok) return;
+        if (!res.ok) { errors++; if (errors >= 5) clearInterval(id); return; }
+        errors = 0;
         const data = await res.json();
         const total = data.reduce(
           (sum: number, p: { manualSteps: { pendingSteps: number } }) =>
@@ -36,33 +39,38 @@ export function AppNav() {
         );
         setStepsPending(total);
       } catch {
-        // ignore
+        errors++;
+        if (errors >= 5) clearInterval(id);
       }
     }
     fetchPending();
-    const id = setInterval(fetchPending, 30_000);
+    id = setInterval(fetchPending, 30_000);
     return () => clearInterval(id);
   }, []);
 
   useEffect(() => {
+    let errors = 0;
+    let id: ReturnType<typeof setInterval>;
     async function fetchApproval() {
       try {
         const res = await fetch("/api/status");
-        if (!res.ok) return;
+        if (!res.ok) { errors++; if (errors >= 5) clearInterval(id); return; }
+        errors = 0;
         const data = await res.json() as { sessions: LiveSession[] };
         const count = data.sessions?.filter((s) => s.status === "approval").length ?? 0;
         setStatusApproval(count);
       } catch {
-        // ignore
+        errors++;
+        if (errors >= 5) clearInterval(id);
       }
     }
     fetchApproval();
-    const id = setInterval(fetchApproval, 10_000);
+    id = setInterval(fetchApproval, 10_000);
     return () => clearInterval(id);
   }, []);
 
   return (
-    <nav style={{ display: "flex", alignItems: "center", gap: "2px" }}>
+    <nav style={{ display: "flex", alignItems: "center", gap: "2px", flexWrap: "wrap" }}>
       {navItems.map((item) => {
         const isActive =
           pathname === item.href || pathname.startsWith(item.href + "/");

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -5,10 +5,14 @@ import { ProjectData, ProjectStatus } from "@/lib/types";
 import { useLiveSessionStatus } from "@/hooks/useLiveSessionStatus";
 import { ProjectCard } from "./ProjectCard";
 import { SparklineList } from "./SparklineList";
-import { ManageHiddenProjects } from "./ManageHiddenProjects";
 import { Skeleton } from "./ui/skeleton";
 import { QuickAddTodosModal } from "./QuickAddTodosModal";
-import { Search, RefreshCw, Plus, LayoutGrid, Rows3, LayoutDashboard, CircleHelp } from "lucide-react";
+import { useToast } from "./ToastProvider";
+import Link from "next/link";
+import {
+  Search, RefreshCw, Plus, LayoutGrid, Rows3, LayoutDashboard,
+  CircleHelp, ChevronDown, ChevronRight, RotateCcw,
+} from "lucide-react";
 import { useHelp } from "./HelpProvider";
 import { usePathname } from "next/navigation";
 
@@ -22,41 +26,54 @@ interface DirtyStatusOverride {
 
 interface DashboardGridProps {
   projects: ProjectData[];
-  hiddenCount: number;
   loading: boolean;
   onRescan: () => void;
-  onHide: (slug: string, dirName: string) => void;
+  onArchive: (slug: string) => void;
+  onUnarchive: (slug: string) => void;
+  scannedAt?: string;
   gitDirtyOverrides?: Record<string, DirtyStatusOverride>;
+}
+
+function timeAgo(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
 }
 
 export function DashboardGrid({
   projects,
-  hiddenCount,
   loading,
   onRescan,
-  onHide,
+  onArchive,
+  onUnarchive,
+  scannedAt,
   gitDirtyOverrides,
 }: DashboardGridProps) {
-  const [search, setSearch]             = useState("");
-  const [statusFilter, setStatusFilter] = useState<ProjectStatus | "all">("all");
-  const [sortBy, setSortBy]             = useState<SortOption>("activity");
-  const [viewMode, setViewMode]         = useState<ViewMode>("full");
-  const [showHidden, setShowHidden]     = useState(false);
-  const [quickAddOpen, setQuickAddOpen] = useState(false);
-  const [activityData, setActivityData] = useState<Record<string, number[]>>({});
+  const [search, setSearch]               = useState("");
+  const [statusFilter, setStatusFilter]   = useState<ProjectStatus | "all">("all");
+  const [sortBy, setSortBy]               = useState<SortOption>("activity");
+  const [viewMode, setViewMode]           = useState<ViewMode>("full");
+  const [quickAddOpen, setQuickAddOpen]   = useState(false);
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
+  const [activityData, setActivityData]   = useState<Record<string, number[]>>({});
   const [activityError, setActivityError] = useState(false);
-  const [pinnedSlugs, setPinnedSlugs] = useState<string[]>([]);
+  const [pinnedSlugs, setPinnedSlugs]     = useState<string[]>([]);
   const activityFetched = useRef(false);
   const { openHelpForRoute } = useHelp();
   const pathname = usePathname();
   const liveStatus = useLiveSessionStatus();
+  const { showToast } = useToast();
 
   // Apply dashboard defaults from config on first mount
   useEffect(() => {
     fetch("/api/config")
       .then((r) => r.json())
       .then((cfg) => {
-        if (cfg.defaultSort)        setSortBy(cfg.defaultSort as SortOption);
+        if (cfg.defaultSort)         setSortBy(cfg.defaultSort as SortOption);
         if (cfg.defaultStatusFilter) setStatusFilter(cfg.defaultStatusFilter as ProjectStatus | "all");
         if (cfg.viewMode)            setViewMode(cfg.viewMode as ViewMode);
         if (Array.isArray(cfg.pinnedSlugs)) setPinnedSlugs(cfg.pinnedSlugs);
@@ -112,6 +129,16 @@ export function DashboardGrid({
     persistViewMode(mode);
   }, [persistViewMode]);
 
+  const handleArchive = useCallback((slug: string) => {
+    const project = projects.find((p) => p.slug === slug);
+    const name = project?.name ?? slug;
+    onArchive(slug);
+    showToast(`Archived "${name}".`, undefined, {
+      label: "Undo",
+      onClick: () => onUnarchive(slug),
+    });
+  }, [projects, onArchive, onUnarchive, showToast]);
+
   const filtered = useMemo(() => {
     let result = gitDirtyOverrides
       ? projects.map((p) => {
@@ -163,6 +190,11 @@ export function DashboardGrid({
     return result;
   }, [projects, search, statusFilter, sortBy, gitDirtyOverrides, pinnedSlugs]);
 
+  const archivedProjects = useMemo(
+    () => projects.filter((p) => p.status === "archived"),
+    [projects]
+  );
+
   // Keyboard shortcuts
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     const active = document.activeElement;
@@ -180,7 +212,11 @@ export function DashboardGrid({
       e.preventDefault();
       cycleViewMode();
     }
-  }, [cycleViewMode]);
+    if (e.key === "r" && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !inField) {
+      e.preventDefault();
+      onRescan();
+    }
+  }, [cycleViewMode, onRescan]);
 
   useEffect(() => {
     window.addEventListener("keydown", handleKeyDown);
@@ -194,10 +230,10 @@ export function DashboardGrid({
     { value: "archived", label: "Archived" },
   ];
 
-  const sortOptions: { value: SortOption; label: string }[] = [
-    { value: "activity", label: "Recent"  },
-    { value: "claude",   label: "Claude"  },
-    { value: "name",     label: "A–Z"     },
+  const sortOptions: { value: SortOption; label: string; title: string }[] = [
+    { value: "activity", label: "Recent",   title: "Sort by most recent file activity" },
+    { value: "claude",   label: "By Claude", title: "Sort by most recent Claude session" },
+    { value: "name",     label: "A–Z",       title: "Sort alphabetically" },
   ];
 
   const viewOptions: { value: ViewMode; icon: React.ReactNode; title: string; label: string }[] = [
@@ -206,8 +242,6 @@ export function DashboardGrid({
     { value: "list",    icon: <Rows3           style={{ width: "11px", height: "11px" }} />, title: "Sparkline list", label: "List"    },
   ];
 
-  const archivedCount = projects.filter((p) => p.status === "archived").length;
-
   const overlaidProjects = filtered.map((project) => {
     const liveKey = project.path.replace(/[:\\/]/g, "-");
     const live = liveStatus.get(liveKey);
@@ -215,6 +249,8 @@ export function DashboardGrid({
       ? { ...project, claude: { ...project.claude, mostRecentSessionStatus: live.status, mostRecentSessionId: live.sessionId } }
       : project;
   });
+
+  const showArchivedSection = statusFilter === "all" && archivedProjects.length > 0;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
@@ -287,6 +323,7 @@ export function DashboardGrid({
             <button
               key={opt.value}
               onClick={() => setSortBy(opt.value)}
+              title={opt.title}
               className="toolbar-btn"
               style={{
                 padding: "5px 11px", fontSize: "0.72rem",
@@ -359,7 +396,7 @@ export function DashboardGrid({
         <button
           onClick={onRescan}
           disabled={loading}
-          title="Rescan projects"
+          title="Rescan projects (r)"
           className="toolbar-btn"
           style={{
             display: "flex", alignItems: "center", gap: "5px",
@@ -396,7 +433,7 @@ export function DashboardGrid({
         </button>
       </div>
 
-      {/* ── Meta row: count + hidden ──────────────────────────────────────── */}
+      {/* ── Meta row ─────────────────────────────────────────────────────── */}
       <div
         style={{
           display: "flex", alignItems: "center", gap: "12px",
@@ -406,31 +443,26 @@ export function DashboardGrid({
         <span style={{ fontFamily: "var(--font-mono)" }}>
           {filtered.length} project{filtered.length !== 1 ? "s" : ""}
         </span>
-        {hiddenCount > 0 && (
-          <button
-            onClick={() => setShowHidden(true)}
-            style={{
-              background: "none", border: "none", color: "var(--text-muted)",
-              fontSize: "0.72rem", fontFamily: "var(--font-body)",
-              cursor: "pointer", padding: 0,
-              textDecoration: "underline", textUnderlineOffset: "2px",
-            }}
-          >
-            {hiddenCount} hidden
-          </button>
-        )}
-        {statusFilter === "all" && archivedCount > 0 && (
-          <button
-            onClick={() => setStatusFilter("archived")}
-            style={{
-              background: "none", border: "none", color: "var(--text-muted)",
-              fontSize: "0.72rem", fontFamily: "var(--font-body)",
-              cursor: "pointer", padding: 0,
-              textDecoration: "underline", textUnderlineOffset: "2px",
-            }}
-          >
-            {archivedCount} archived
-          </button>
+        {scannedAt && (
+          <>
+            <span aria-hidden="true" style={{ color: "var(--border-default)" }}>·</span>
+            <span style={{ fontFamily: "var(--font-mono)" }}>
+              Scanned {timeAgo(scannedAt)}
+            </span>
+            <button
+              onClick={onRescan}
+              disabled={loading}
+              style={{
+                background: "none", border: "none", padding: 0,
+                color: "var(--text-muted)", fontSize: "0.72rem",
+                fontFamily: "var(--font-body)", cursor: "pointer",
+                textDecoration: "underline", textUnderlineOffset: "2px",
+                opacity: loading ? 0.5 : 1,
+              }}
+            >
+              Rescan
+            </button>
+          </>
         )}
       </div>
 
@@ -469,7 +501,7 @@ export function DashboardGrid({
             <ProjectCard
               key={project.slug}
               project={project}
-              onHide={onHide}
+              onArchive={handleArchive}
               compact={viewMode === "compact"}
               pinned={pinnedSlugs.includes(project.slug)}
               onTogglePin={onTogglePin}
@@ -483,21 +515,86 @@ export function DashboardGrid({
         </div>
       )}
 
+      {/* ── Archived section ─────────────────────────────────────────────── */}
+      {showArchivedSection && (
+        <div
+          style={{
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius)",
+            overflow: "hidden",
+          }}
+        >
+          <button
+            onClick={() => setArchivedExpanded((v) => !v)}
+            style={{
+              width: "100%", display: "flex", alignItems: "center", gap: "6px",
+              padding: "8px 12px",
+              background: "transparent", border: "none",
+              fontSize: "0.72rem", fontFamily: "var(--font-body)",
+              color: "var(--text-muted)", cursor: "pointer",
+              textAlign: "left",
+            }}
+          >
+            {archivedExpanded
+              ? <ChevronDown style={{ width: "12px", height: "12px", flexShrink: 0 }} />
+              : <ChevronRight style={{ width: "12px", height: "12px", flexShrink: 0 }} />
+            }
+            Archived ({archivedProjects.length})
+          </button>
+          {archivedExpanded && (
+            <div
+              style={{
+                borderTop: "1px solid var(--border-subtle)",
+                display: "flex", flexDirection: "column",
+              }}
+            >
+              {archivedProjects.map((p, i) => (
+                <div
+                  key={p.slug}
+                  style={{
+                    display: "flex", alignItems: "center", gap: "10px",
+                    padding: "7px 12px",
+                    borderTop: i > 0 ? "1px solid var(--border-subtle)" : "none",
+                  }}
+                >
+                  <Link
+                    href={`/project/${p.slug}`}
+                    style={{
+                      flex: 1, minWidth: 0,
+                      fontSize: "0.8rem", fontFamily: "var(--font-body)",
+                      color: "var(--text-secondary)", textDecoration: "none",
+                      overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+                    }}
+                  >
+                    {p.name}
+                  </Link>
+                  <button
+                    onClick={() => onUnarchive(p.slug)}
+                    title="Unarchive"
+                    style={{
+                      display: "flex", alignItems: "center", gap: "4px",
+                      padding: "3px 8px", flexShrink: 0,
+                      fontSize: "0.68rem", fontFamily: "var(--font-body)",
+                      color: "var(--text-muted)", background: "transparent",
+                      border: "1px solid var(--border-subtle)", borderRadius: "3px",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <RotateCcw style={{ width: "9px", height: "9px" }} />
+                    Unarchive
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       <QuickAddTodosModal
         projects={projects}
         open={quickAddOpen}
         onClose={() => setQuickAddOpen(false)}
       />
-
-      {showHidden && (
-        <ManageHiddenProjects
-          onClose={() => setShowHidden(false)}
-          onUnhide={() => {
-            setShowHidden(false);
-            onRescan();
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import {
   Search, RefreshCw, Plus, LayoutGrid, Rows3, LayoutDashboard,
   CircleHelp, ChevronDown, ChevronRight, RotateCcw,
+  Layers, CircleDot, CirclePause, Archive, Clock, Bot, ArrowUpAZ,
 } from "lucide-react";
 import { useHelp } from "./HelpProvider";
 import { usePathname } from "next/navigation";
@@ -55,7 +56,7 @@ export function DashboardGrid({
 }: DashboardGridProps) {
   const [search, setSearch]               = useState("");
   const [statusFilter, setStatusFilter]   = useState<ProjectStatus | "all">("all");
-  const [sortBy, setSortBy]               = useState<SortOption>("activity");
+  const [sortBy, setSortBy]               = useState<SortOption>("claude");
   const [viewMode, setViewMode]           = useState<ViewMode>("full");
   const [quickAddOpen, setQuickAddOpen]   = useState(false);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
@@ -223,17 +224,17 @@ export function DashboardGrid({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
-  const statusOptions: { value: ProjectStatus | "all"; label: string }[] = [
-    { value: "all",      label: "All"      },
-    { value: "active",   label: "Active"   },
-    { value: "paused",   label: "Paused"   },
-    { value: "archived", label: "Archived" },
+  const statusOptions: { value: ProjectStatus | "all"; label: string; icon: React.ReactNode }[] = [
+    { value: "all",      label: "All",      icon: <Layers      style={{ width: "11px", height: "11px" }} /> },
+    { value: "active",   label: "Active",   icon: <CircleDot   style={{ width: "11px", height: "11px" }} /> },
+    { value: "paused",   label: "Paused",   icon: <CirclePause style={{ width: "11px", height: "11px" }} /> },
+    { value: "archived", label: "Archived", icon: <Archive     style={{ width: "11px", height: "11px" }} /> },
   ];
 
-  const sortOptions: { value: SortOption; label: string; title: string }[] = [
-    { value: "activity", label: "Recent",   title: "Sort by most recent file activity" },
-    { value: "claude",   label: "By Claude", title: "Sort by most recent Claude session" },
-    { value: "name",     label: "A–Z",       title: "Sort alphabetically" },
+  const sortOptions: { value: SortOption; label: string; title: string; icon: React.ReactNode }[] = [
+    { value: "activity", label: "Recent",       title: "Sort by most recent file activity",  icon: <Clock     style={{ width: "11px", height: "11px" }} /> },
+    { value: "claude",   label: "Last Session", title: "Sort by most recent Claude session", icon: <Bot       style={{ width: "11px", height: "11px" }} /> },
+    { value: "name",     label: "A–Z",          title: "Sort alphabetically",                icon: <ArrowUpAZ style={{ width: "11px", height: "11px" }} /> },
   ];
 
   const viewOptions: { value: ViewMode; icon: React.ReactNode; title: string; label: string }[] = [
@@ -295,18 +296,21 @@ export function DashboardGrid({
             <button
               key={opt.value}
               onClick={() => setStatusFilter(opt.value)}
+              title={opt.label}
               className="toolbar-btn"
               style={{
-                padding: "5px 11px", fontSize: "0.72rem",
-                fontWeight: statusFilter === opt.value ? 600 : 400,
-                fontFamily: "var(--font-body)", letterSpacing: "0.03em",
-                color: statusFilter === opt.value ? "var(--text-primary)" : "var(--text-secondary)",
+                display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+                gap: "2px", padding: "5px 10px", minHeight: "32px",
+                color: statusFilter === opt.value ? "var(--text-primary)" : "var(--text-muted)",
                 background: statusFilter === opt.value ? "var(--bg-elevated)" : "transparent",
                 border: "none", borderRight: "1px solid var(--border-subtle)",
                 cursor: "pointer", transition: "background 0.1s, color 0.1s", lineHeight: 1,
               }}
             >
-              {opt.label}
+              {opt.icon}
+              <span style={{ fontSize: "0.52rem", fontFamily: "var(--font-mono)", letterSpacing: "0.04em", lineHeight: 1 }}>
+                {opt.label}
+              </span>
             </button>
           ))}
         </div>
@@ -326,16 +330,18 @@ export function DashboardGrid({
               title={opt.title}
               className="toolbar-btn"
               style={{
-                padding: "5px 11px", fontSize: "0.72rem",
-                fontWeight: sortBy === opt.value ? 600 : 400,
-                fontFamily: "var(--font-body)", letterSpacing: "0.03em",
-                color: sortBy === opt.value ? "var(--text-primary)" : "var(--text-secondary)",
+                display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+                gap: "2px", padding: "5px 10px", minHeight: "32px",
+                color: sortBy === opt.value ? "var(--text-primary)" : "var(--text-muted)",
                 background: sortBy === opt.value ? "var(--bg-elevated)" : "transparent",
                 border: "none", borderRight: "1px solid var(--border-subtle)",
                 cursor: "pointer", transition: "background 0.1s, color 0.1s", lineHeight: 1,
               }}
             >
-              {opt.label}
+              {opt.icon}
+              <span style={{ fontSize: "0.52rem", fontFamily: "var(--font-mono)", letterSpacing: "0.04em", lineHeight: 1 }}>
+                {opt.label}
+              </span>
             </button>
           ))}
         </div>
@@ -381,7 +387,7 @@ export function DashboardGrid({
           className="toolbar-btn"
           style={{
             display: "flex", alignItems: "center", gap: "5px",
-            padding: "5px 11px", fontSize: "0.72rem",
+            padding: "5px 11px", fontSize: "0.72rem", minHeight: "32px",
             fontFamily: "var(--font-body)", letterSpacing: "0.03em",
             color: "var(--text-secondary)", background: "var(--bg-surface)",
             border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)",
@@ -400,7 +406,7 @@ export function DashboardGrid({
           className="toolbar-btn"
           style={{
             display: "flex", alignItems: "center", gap: "5px",
-            padding: "5px 11px", fontSize: "0.72rem",
+            padding: "5px 11px", fontSize: "0.72rem", minHeight: "32px",
             fontFamily: "var(--font-body)", letterSpacing: "0.03em",
             color: "var(--text-secondary)",
             background: "var(--bg-surface)",

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -31,7 +31,7 @@ interface DashboardGridProps {
   loading: boolean;
   onRescan: () => void;
   onArchive: (slug: string) => void;
-  onUnarchive: (slug: string) => void;
+  onUnarchive: (slug: string, status?: ProjectStatus) => void;
   scannedAt?: string;
   gitDirtyOverrides?: Record<string, DirtyStatusOverride>;
 }
@@ -145,10 +145,11 @@ export function DashboardGrid({
   const handleArchive = useCallback((slug: string) => {
     const project = projects.find((p) => p.slug === slug);
     const name = project?.name ?? slug;
+    const prevStatus = project?.status ?? "active";
     onArchive(slug);
     showToast(`Archived "${name}".`, undefined, {
       label: "Undo",
-      onClick: () => onUnarchive(slug),
+      onClick: () => onUnarchive(slug, prevStatus),
     });
   }, [projects, onArchive, onUnarchive, showToast]);
 
@@ -203,10 +204,19 @@ export function DashboardGrid({
     return result;
   }, [projects, search, statusFilter, sortBy, gitDirtyOverrides, pinnedSlugs]);
 
-  const archivedProjects = useMemo(
-    () => projects.filter((p) => p.status === "archived"),
-    [projects]
-  );
+  const archivedProjects = useMemo(() => {
+    let result = projects.filter((p) => p.status === "archived");
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter((p) =>
+        p.name.toLowerCase().includes(q) ||
+        p.framework?.toLowerCase().includes(q) ||
+        p.orm?.toLowerCase().includes(q) ||
+        p.slug.includes(q)
+      );
+    }
+    return result;
+  }, [projects, search]);
 
   // Keyboard shortcuts
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -525,6 +535,8 @@ export function DashboardGrid({
         >
           <button
             onClick={() => setArchivedExpanded((v) => !v)}
+            aria-expanded={archivedExpanded}
+            aria-controls="archived-projects-list"
             style={{
               width: "100%", display: "flex", alignItems: "center", gap: "6px",
               padding: "8px 12px",
@@ -542,6 +554,7 @@ export function DashboardGrid({
           </button>
           {archivedExpanded && (
             <div
+              id="archived-projects-list"
               style={{
                 borderTop: "1px solid var(--border-subtle)",
                 display: "flex", flexDirection: "column",

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useHelp } from "./HelpProvider";
 import { usePathname } from "next/navigation";
+import { formatRelativeTime } from "@/lib/utils";
 
 type SortOption = "activity" | "name" | "claude";
 type ViewMode = "full" | "compact" | "list";
@@ -35,15 +36,26 @@ interface DashboardGridProps {
   gitDirtyOverrides?: Record<string, DirtyStatusOverride>;
 }
 
-function timeAgo(iso: string): string {
-  const diffMs = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diffMs / 60_000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+const NEXT_VIEW: Record<ViewMode, ViewMode> = { full: "compact", compact: "list", list: "full" };
+
+const statusOptions = [
+  { value: "all" as const,      label: "All",      icon: <Layers      style={{ width: "11px", height: "11px" }} /> },
+  { value: "active" as const,   label: "Active",   icon: <CircleDot   style={{ width: "11px", height: "11px" }} /> },
+  { value: "paused" as const,   label: "Paused",   icon: <CirclePause style={{ width: "11px", height: "11px" }} /> },
+  { value: "archived" as const, label: "Archived", icon: <Archive     style={{ width: "11px", height: "11px" }} /> },
+];
+
+const sortOptions = [
+  { value: "activity" as const, label: "Recent",       title: "Sort by most recent file activity",  icon: <Clock     style={{ width: "11px", height: "11px" }} /> },
+  { value: "claude" as const,   label: "Last Session", title: "Sort by most recent Claude session", icon: <Bot       style={{ width: "11px", height: "11px" }} /> },
+  { value: "name" as const,     label: "A–Z",          title: "Sort alphabetically",                icon: <ArrowUpAZ style={{ width: "11px", height: "11px" }} /> },
+];
+
+const viewOptions = [
+  { value: "full" as const,    icon: <LayoutGrid      style={{ width: "11px", height: "11px" }} />, title: "Full cards",     label: "Full"    },
+  { value: "compact" as const, icon: <LayoutDashboard style={{ width: "11px", height: "11px" }} />, title: "Compact cards",  label: "Compact" },
+  { value: "list" as const,    icon: <Rows3           style={{ width: "11px", height: "11px" }} />, title: "Sparkline list", label: "List"    },
+];
 
 export function DashboardGrid({
   projects,
@@ -119,7 +131,7 @@ export function DashboardGrid({
 
   const cycleViewMode = useCallback(() => {
     setViewMode((prev) => {
-      const next: ViewMode = prev === "full" ? "compact" : prev === "compact" ? "list" : "full";
+      const next = NEXT_VIEW[prev];
       persistViewMode(next);
       return next;
     });
@@ -224,32 +236,13 @@ export function DashboardGrid({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
-  const statusOptions: { value: ProjectStatus | "all"; label: string; icon: React.ReactNode }[] = [
-    { value: "all",      label: "All",      icon: <Layers      style={{ width: "11px", height: "11px" }} /> },
-    { value: "active",   label: "Active",   icon: <CircleDot   style={{ width: "11px", height: "11px" }} /> },
-    { value: "paused",   label: "Paused",   icon: <CirclePause style={{ width: "11px", height: "11px" }} /> },
-    { value: "archived", label: "Archived", icon: <Archive     style={{ width: "11px", height: "11px" }} /> },
-  ];
-
-  const sortOptions: { value: SortOption; label: string; title: string; icon: React.ReactNode }[] = [
-    { value: "activity", label: "Recent",       title: "Sort by most recent file activity",  icon: <Clock     style={{ width: "11px", height: "11px" }} /> },
-    { value: "claude",   label: "Last Session", title: "Sort by most recent Claude session", icon: <Bot       style={{ width: "11px", height: "11px" }} /> },
-    { value: "name",     label: "A–Z",          title: "Sort alphabetically",                icon: <ArrowUpAZ style={{ width: "11px", height: "11px" }} /> },
-  ];
-
-  const viewOptions: { value: ViewMode; icon: React.ReactNode; title: string; label: string }[] = [
-    { value: "full",    icon: <LayoutGrid      style={{ width: "11px", height: "11px" }} />, title: "Full cards",     label: "Full"    },
-    { value: "compact", icon: <LayoutDashboard style={{ width: "11px", height: "11px" }} />, title: "Compact cards",  label: "Compact" },
-    { value: "list",    icon: <Rows3           style={{ width: "11px", height: "11px" }} />, title: "Sparkline list", label: "List"    },
-  ];
-
-  const overlaidProjects = filtered.map((project) => {
+  const overlaidProjects = useMemo(() => filtered.map((project) => {
     const liveKey = project.path.replace(/[:\\/]/g, "-");
     const live = liveStatus.get(liveKey);
     return live && project.claude
       ? { ...project, claude: { ...project.claude, mostRecentSessionStatus: live.status, mostRecentSessionId: live.sessionId } }
       : project;
-  });
+  }), [filtered, liveStatus]);
 
   const showArchivedSection = statusFilter === "all" && archivedProjects.length > 0;
 
@@ -453,7 +446,7 @@ export function DashboardGrid({
           <>
             <span aria-hidden="true" style={{ color: "var(--border-default)" }}>·</span>
             <span style={{ fontFamily: "var(--font-mono)" }}>
-              Scanned {timeAgo(scannedAt)}
+              Scanned {formatRelativeTime(scannedAt)}
             </span>
             <button
               onClick={onRescan}

--- a/src/components/DevServerControl.tsx
+++ b/src/components/DevServerControl.tsx
@@ -143,7 +143,7 @@ export function DevServerControl({
             {server!.status === "starting" ? "starting…" : `●  :${port || "?"}`}
           </span>
           <button
-            onClick={(e) => { e.preventDefault(); e.stopPropagation(); doAction("stop"); }}
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); if (window.confirm("Stop dev server?")) doAction("stop"); }}
             disabled={loading}
             title="Stop dev server"
             aria-label="Stop dev server"
@@ -228,7 +228,7 @@ export function DevServerControl({
           </Button>
         ) : (
           <>
-            <Button variant="destructive" size="sm" onClick={() => doAction("stop")} disabled={loading}>
+            <Button variant="destructive" size="sm" onClick={() => { if (window.confirm("Stop dev server?")) doAction("stop"); }} disabled={loading}>
               <Square className="h-4 w-4 mr-1" />
               Stop
             </Button>

--- a/src/components/DevServerControl.tsx
+++ b/src/components/DevServerControl.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Button } from "./ui/button";
-import { Play, Square, RotateCw, Terminal, ExternalLink } from "lucide-react";
+import { Play, Square, RotateCw, Terminal, ExternalLink, AlertCircle } from "lucide-react";
 import { useToast } from "./ToastProvider";
 
 interface DevServerInfo {
@@ -71,7 +71,6 @@ export function DevServerControl({
     }
   }, [slug]);
 
-  // Poll for status when server is running/starting
   useEffect(() => {
     fetchStatus();
   }, [fetchStatus]);
@@ -87,7 +86,6 @@ export function DevServerControl({
     };
   }, [server?.status, fetchStatus]);
 
-  // Auto-scroll output
   useEffect(() => {
     if (outputRef.current && showOutput) {
       outputRef.current.scrollTop = outputRef.current.scrollHeight;
@@ -102,8 +100,10 @@ export function DevServerControl({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action, projectPath, port: devPort }),
       });
-      if (!res.ok) throw new Error(`Server responded ${res.status}`);
       const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || `Server responded ${res.status}`);
+      }
       if (data.command) {
         setServer(data);
         if (action === "start" || action === "restart") {
@@ -112,18 +112,58 @@ export function DevServerControl({
       } else {
         setServer(null);
       }
-    } catch {
-      showToast(`Failed to ${action} dev server`);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : "";
+      showToast(`Failed to ${action} dev server`, detail || undefined);
     } finally {
       setLoading(false);
     }
   };
 
-  const isActive =
-    server?.status === "running" || server?.status === "starting";
+  const isActive = server?.status === "running" || server?.status === "starting";
   const port = server?.port || devPort;
 
   if (compact) {
+    // Errored state: show red pill + retry
+    if (server?.status === "errored") {
+      return (
+        <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+          <span
+            title={server.output?.slice(-3).join(" ") || "Server exited with an error"}
+            style={{
+              display: "inline-flex", alignItems: "center", gap: "3px",
+              fontFamily: "var(--font-mono)", fontSize: "0.68rem", fontWeight: 600,
+              color: "var(--status-error-text)", background: "var(--status-error-bg)",
+              border: "1px solid var(--status-error-border)",
+              borderRadius: "3px", padding: "2px 6px", lineHeight: 1.4,
+              cursor: "help",
+            }}
+          >
+            <AlertCircle style={{ width: "9px", height: "9px" }} />
+            error
+          </span>
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); doAction("start"); }}
+            disabled={loading}
+            title="Retry dev server"
+            aria-label="Retry dev server"
+            style={{
+              display: "flex", alignItems: "center", justifyContent: "center",
+              width: "32px", height: "32px",
+              background: "transparent",
+              border: "1px solid var(--border-default)",
+              borderRadius: "3px",
+              color: "var(--text-secondary)",
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            <RotateCw style={{ width: "9px", height: "9px" }} />
+          </button>
+        </div>
+      );
+    }
+
     if (isActive) {
       return (
         <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
@@ -143,7 +183,7 @@ export function DevServerControl({
             {server!.status === "starting" ? "starting…" : `●  :${port || "?"}`}
           </span>
           <button
-            onClick={(e) => { e.preventDefault(); e.stopPropagation(); if (window.confirm("Stop dev server?")) doAction("stop"); }}
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); doAction("stop"); }}
             disabled={loading}
             title="Stop dev server"
             aria-label="Stop dev server"
@@ -164,7 +204,7 @@ export function DevServerControl({
       );
     }
 
-    // Stopped state — always rendered, disabled if no port configured
+    // Stopped state
     const canStart = !!devPort;
     return (
       <button
@@ -224,11 +264,11 @@ export function DevServerControl({
         {!isActive ? (
           <Button variant="default" size="sm" onClick={() => doAction("start")} disabled={loading}>
             <Play className="h-4 w-4 mr-1" />
-            {loading ? "Starting…" : "Start"}
+            {loading ? "Starting…" : server?.status === "errored" ? "Retry" : "Start"}
           </Button>
         ) : (
           <>
-            <Button variant="destructive" size="sm" onClick={() => { if (window.confirm("Stop dev server?")) doAction("stop"); }} disabled={loading}>
+            <Button variant="destructive" size="sm" onClick={() => doAction("stop")} disabled={loading}>
               <Square className="h-4 w-4 mr-1" />
               Stop
             </Button>

--- a/src/components/DevServerControl.tsx
+++ b/src/components/DevServerControl.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Button } from "./ui/button";
-import { Badge } from "./ui/badge";
 import { Play, Square, RotateCw, Terminal, ExternalLink } from "lucide-react";
 import { useToast } from "./ToastProvider";
 
@@ -23,16 +22,27 @@ interface DevServerControlProps {
   compact?: boolean;
 }
 
-const statusStyles: Record<string, string> = {
-  starting:
-    "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border-blue-200 dark:border-blue-800",
-  running:
-    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200 border-emerald-200 dark:border-emerald-800",
-  stopped:
-    "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 border-gray-200 dark:border-gray-700",
-  errored:
-    "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200 border-red-200 dark:border-red-800",
+const statusTokens: Record<string, { color: string; bg: string; border: string }> = {
+  starting: { color: "var(--info)",                bg: "var(--info-bg)",               border: "var(--info-border)"               },
+  running:  { color: "var(--status-active-text)",  bg: "var(--status-active-bg)",       border: "var(--status-active-border)"      },
+  stopped:  { color: "var(--status-archived-text)",bg: "var(--status-archived-bg)",     border: "var(--status-archived-border)"    },
+  errored:  { color: "var(--status-error-text)",   bg: "var(--status-error-bg)",        border: "var(--status-error-border)"       },
 };
+
+function StatusPill({ status }: { status: string }) {
+  const t = statusTokens[status] ?? statusTokens.stopped;
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center",
+      fontFamily: "var(--font-mono)", fontSize: "0.65rem", fontWeight: 600,
+      letterSpacing: "0.06em", textTransform: "uppercase",
+      color: t.color, background: t.bg, border: `1px solid ${t.border}`,
+      borderRadius: "3px", padding: "2px 8px", lineHeight: 1.4,
+    }}>
+      {status}
+    </span>
+  );
+}
 
 export function DevServerControl({
   slug,
@@ -67,13 +77,13 @@ export function DevServerControl({
   }, [fetchStatus]);
 
   useEffect(() => {
-    const isActive =
-      server?.status === "running" || server?.status === "starting";
-    if (isActive) {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+    const shouldPoll = server?.status === "running" || server?.status === "starting";
+    if (shouldPoll) {
       pollRef.current = setInterval(fetchStatus, 2000);
     }
     return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
+      if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
     };
   }, [server?.status, fetchStatus]);
 
@@ -135,10 +145,11 @@ export function DevServerControl({
           <button
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); doAction("stop"); }}
             disabled={loading}
-            title="Stop server"
+            title="Stop dev server"
+            aria-label="Stop dev server"
             style={{
               display: "flex", alignItems: "center", justifyContent: "center",
-              width: "22px", height: "22px",
+              width: "28px", height: "28px",
               background: "transparent",
               border: "1px solid var(--border-default)",
               borderRadius: "3px",
@@ -186,59 +197,47 @@ export function DevServerControl({
   }
 
   return (
-    <div className="rounded-lg border p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium flex items-center gap-2">
-          <Terminal className="h-4 w-4" />
+    <div style={{
+      borderRadius: "var(--radius)",
+      border: "1px solid var(--border-subtle)",
+      padding: "16px",
+      display: "flex",
+      flexDirection: "column",
+      gap: "12px",
+      background: "var(--bg-surface)",
+    }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <h3 style={{
+          display: "flex", alignItems: "center", gap: "8px",
+          fontFamily: "var(--font-body)", fontWeight: 500, fontSize: "0.875rem",
+          color: "var(--text-primary)", margin: 0,
+        }}>
+          <Terminal style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
           Dev Server
         </h3>
-        {server && (
-          <Badge className={statusStyles[server.status]}>{server.status}</Badge>
-        )}
-        {!server && (
-          <Badge className={statusStyles.stopped}>stopped</Badge>
-        )}
+        <StatusPill status={server?.status ?? "stopped"} />
       </div>
 
-      <div className="flex items-center gap-2">
+      {/* Actions */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
         {!isActive ? (
-          <Button
-            variant="default"
-            size="sm"
-            onClick={() => doAction("start")}
-            disabled={loading}
-          >
+          <Button variant="default" size="sm" onClick={() => doAction("start")} disabled={loading}>
             <Play className="h-4 w-4 mr-1" />
-            {loading ? "Starting..." : "Start"}
+            {loading ? "Starting…" : "Start"}
           </Button>
         ) : (
           <>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => doAction("stop")}
-              disabled={loading}
-            >
+            <Button variant="destructive" size="sm" onClick={() => doAction("stop")} disabled={loading}>
               <Square className="h-4 w-4 mr-1" />
               Stop
             </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => doAction("restart")}
-              disabled={loading}
-            >
+            <Button variant="outline" size="sm" onClick={() => doAction("restart")} disabled={loading}>
               <RotateCw className="h-4 w-4 mr-1" />
               Restart
             </Button>
             {port && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() =>
-                  window.open(`http://localhost:${port}`, "_blank")
-                }
-              >
+              <Button variant="outline" size="sm" onClick={() => window.open(`http://localhost:${port}`, "_blank")}>
                 <ExternalLink className="h-4 w-4 mr-1" />
                 localhost:{port}
               </Button>
@@ -246,28 +245,48 @@ export function DevServerControl({
           </>
         )}
         {server?.output && server.output.length > 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowOutput(!showOutput)}
-          >
+          <Button variant="ghost" size="sm" onClick={() => setShowOutput(!showOutput)}>
             {showOutput ? "Hide Output" : "Show Output"}
           </Button>
         )}
       </div>
 
+      {/* Meta */}
       {server && (
-        <div className="text-xs text-[var(--muted-foreground)] space-y-1">
-          {server.pid > 0 && <p>PID: {server.pid}</p>}
-          {port && <p>Port: {port}</p>}
-          <p>Command: {server.command}</p>
+        <div style={{ display: "flex", flexDirection: "column", gap: "2px" }}>
+          {server.pid > 0 && (
+            <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)" }}>
+              PID: {server.pid}
+            </p>
+          )}
+          {port && (
+            <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)" }}>
+              Port: {port}
+            </p>
+          )}
+          <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)" }}>
+            {server.command}
+          </p>
         </div>
       )}
 
+      {/* Output */}
       {showOutput && server?.output && server.output.length > 0 && (
         <pre
           ref={outputRef}
-          className="bg-[var(--secondary)] rounded-md p-3 text-xs font-mono max-h-64 overflow-auto whitespace-pre-wrap"
+          style={{
+            background: "var(--bg-elevated)",
+            borderRadius: "var(--radius)",
+            border: "1px solid var(--border-subtle)",
+            padding: "12px",
+            fontSize: "0.72rem",
+            fontFamily: "var(--font-mono)",
+            color: "var(--text-secondary)",
+            maxHeight: "256px",
+            overflow: "auto",
+            whiteSpace: "pre-wrap",
+            margin: 0,
+          }}
         >
           {server.output.join("\n")}
         </pre>

--- a/src/components/DevServerControl.tsx
+++ b/src/components/DevServerControl.tsx
@@ -22,15 +22,15 @@ interface DevServerControlProps {
   compact?: boolean;
 }
 
-const statusTokens: Record<string, { color: string; bg: string; border: string }> = {
+const statusTokens: Record<DevServerInfo["status"], { color: string; bg: string; border: string }> = {
   starting: { color: "var(--info)",                bg: "var(--info-bg)",               border: "var(--info-border)"               },
   running:  { color: "var(--status-active-text)",  bg: "var(--status-active-bg)",       border: "var(--status-active-border)"      },
   stopped:  { color: "var(--status-archived-text)",bg: "var(--status-archived-bg)",     border: "var(--status-archived-border)"    },
   errored:  { color: "var(--status-error-text)",   bg: "var(--status-error-bg)",        border: "var(--status-error-border)"       },
 };
 
-function StatusPill({ status }: { status: string }) {
-  const t = statusTokens[status] ?? statusTokens.stopped;
+function StatusPill({ status }: { status: DevServerInfo["status"] }) {
+  const t = statusTokens[status];
   return (
     <span style={{
       display: "inline-flex", alignItems: "center",
@@ -67,7 +67,7 @@ export function DevServerControl({
         setServer(null);
       }
     } catch {
-      // ignore
+      // network errors are expected during dev server restarts
     }
   }, [slug]);
 
@@ -122,9 +122,9 @@ export function DevServerControl({
 
   const isActive = server?.status === "running" || server?.status === "starting";
   const port = server?.port || devPort;
+  const startLabel = loading ? "Starting…" : server?.status === "errored" ? "Retry" : "Start";
 
   if (compact) {
-    // Errored state: show red pill + retry
     if (server?.status === "errored") {
       return (
         <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
@@ -204,7 +204,6 @@ export function DevServerControl({
       );
     }
 
-    // Stopped state
     const canStart = !!devPort;
     return (
       <button
@@ -264,7 +263,7 @@ export function DevServerControl({
         {!isActive ? (
           <Button variant="default" size="sm" onClick={() => doAction("start")} disabled={loading}>
             <Play className="h-4 w-4 mr-1" />
-            {loading ? "Starting…" : server?.status === "errored" ? "Retry" : "Start"}
+            {startLabel}
           </Button>
         ) : (
           <>

--- a/src/components/DevServerControl.tsx
+++ b/src/components/DevServerControl.tsx
@@ -149,7 +149,7 @@ export function DevServerControl({
             aria-label="Stop dev server"
             style={{
               display: "flex", alignItems: "center", justifyContent: "center",
-              width: "28px", height: "28px",
+              width: "32px", height: "32px",
               background: "transparent",
               border: "1px solid var(--border-default)",
               borderRadius: "3px",
@@ -255,16 +255,16 @@ export function DevServerControl({
       {server && (
         <div style={{ display: "flex", flexDirection: "column", gap: "2px" }}>
           {server.pid > 0 && (
-            <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)" }}>
+            <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)", lineHeight: 1.5 }}>
               PID: {server.pid}
             </p>
           )}
           {port && (
-            <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)" }}>
+            <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)", lineHeight: 1.5 }}>
               Port: {port}
             </p>
           )}
-          <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)" }}>
+          <p style={{ margin: 0, fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-muted)", lineHeight: 1.5 }}>
             {server.command}
           </p>
         </div>

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -364,7 +364,7 @@ function MarkdownRenderer({
   };
 
   return (
-    <div onClick={handleClick} style={{ display: "flex", flexDirection: "column" }}>
+    <div role="presentation" onClick={handleClick} style={{ display: "flex", flexDirection: "column" }}>
       {elements}
     </div>
   );

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -31,7 +31,6 @@ export function ProjectCard({ project, onArchive, compact = false, pinned = fals
   const [devPort, setDevPort] = useState(project.devPort);
   const router = useRouter();
 
-
   // ── Aggregate worktree counts ──────────────────────────────────────────
   const pendingTodos = (() => {
     const main = project.todos?.pending ?? 0;

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -16,22 +16,21 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "./ui/dropdown-menu";
-import { Database, MoreVertical, EyeOff, CheckSquare, ClipboardList, Lightbulb, Pin, PinOff } from "lucide-react";
+import { Archive, Database, MoreVertical, CheckSquare, ClipboardList, Lightbulb, Pin, PinOff } from "lucide-react";
 import { StatusDot } from "./ui/StatusDot";
 
 interface ProjectCardProps {
   project: ProjectData;
-  onHide?: (slug: string, dirName: string) => void;
+  onArchive?: (slug: string) => void;
   compact?: boolean;
   pinned?: boolean;
   onTogglePin?: (slug: string) => void;
 }
 
-export function ProjectCard({ project, onHide, compact = false, pinned = false, onTogglePin }: ProjectCardProps) {
+export function ProjectCard({ project, onArchive, compact = false, pinned = false, onTogglePin }: ProjectCardProps) {
   const [devPort, setDevPort] = useState(project.devPort);
   const router = useRouter();
 
-  const dirName = project.path.split(/[\\/]/).pop() || project.slug;
 
   // ── Aggregate worktree counts ──────────────────────────────────────────
   const pendingTodos = (() => {
@@ -255,7 +254,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                   width: "32px", height: "32px", padding: 0,
                   background: "none", border: "none", cursor: "pointer",
                   color: pinned ? "var(--info)" : "var(--text-muted)",
-                  opacity: pinned ? 1 : 0.25,
+                  opacity: pinned ? 1 : 0.4,
                   transition: "opacity 0.1s, color 0.1s",
                 }}
               >
@@ -263,7 +262,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
               </button>
             )}
 
-            {onHide && (
+            {onArchive && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <button
@@ -284,15 +283,9 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                   align="end"
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
                 >
-                  <DropdownMenuItem
-                    onClick={() => {
-                      if (window.confirm(`Hide "${project.name}" from the dashboard? You can unhide it later.`)) {
-                        onHide(project.slug, dirName);
-                      }
-                    }}
-                  >
-                    <EyeOff style={{ width: "12px", height: "12px", marginRight: "6px" }} />
-                    Hide project
+                  <DropdownMenuItem onClick={() => onArchive(project.slug)}>
+                    <Archive style={{ width: "12px", height: "12px", marginRight: "6px" }} />
+                    Archive
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -133,7 +133,8 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                 title={`${pluralize(pendingTodos, "todo")}${pendingSteps > 0 ? ` + ${pluralize(pendingSteps, "manual step")}` : ""} pending`}
                 style={{ fontSize: "0.6rem", color: "var(--accent)", fontFamily: "var(--font-mono)", cursor: "default" }}
               >
-                {pendingTodos + pendingSteps}▲
+                {pendingTodos + pendingSteps}<span aria-hidden="true">▲</span>
+                <span className="sr-only"> pending items</span>
               </span>
             )}
             <StatusBadge status={project.status} />
@@ -145,7 +146,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                 className="compact-pin-btn"
                 style={{
                   display: "flex", alignItems: "center", justifyContent: "center",
-                  width: "18px", height: "18px", padding: 0,
+                  width: "28px", height: "28px", padding: 0,
                   background: "none", border: "none", cursor: "pointer",
                   color: pinned ? "var(--info)" : "var(--text-muted)",
                   opacity: pinned ? 1 : 0.55,
@@ -251,7 +252,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                 data-pinned={pinned ? "" : undefined}
                 style={{
                   display: "flex", alignItems: "center", justifyContent: "center",
-                  width: "20px", height: "20px", padding: 0,
+                  width: "28px", height: "28px", padding: 0,
                   background: "none", border: "none", cursor: "pointer",
                   color: pinned ? "var(--info)" : "var(--text-muted)",
                   opacity: pinned ? 1 : 0.25,
@@ -270,7 +271,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                     aria-label="More options"
                     style={{
                       display: "flex", alignItems: "center", justifyContent: "center",
-                      width: "20px", height: "20px",
+                      width: "28px", height: "28px",
                       borderRadius: "3px", background: "transparent", border: "none",
                       color: "var(--text-muted)", cursor: "pointer", padding: 0,
                     }}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -146,7 +146,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                 className="compact-pin-btn"
                 style={{
                   display: "flex", alignItems: "center", justifyContent: "center",
-                  width: "28px", height: "28px", padding: 0,
+                  width: "32px", height: "32px", padding: 0,
                   background: "none", border: "none", cursor: "pointer",
                   color: pinned ? "var(--info)" : "var(--text-muted)",
                   opacity: pinned ? 1 : 0.55,
@@ -252,7 +252,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                 data-pinned={pinned ? "" : undefined}
                 style={{
                   display: "flex", alignItems: "center", justifyContent: "center",
-                  width: "28px", height: "28px", padding: 0,
+                  width: "32px", height: "32px", padding: 0,
                   background: "none", border: "none", cursor: "pointer",
                   color: pinned ? "var(--info)" : "var(--text-muted)",
                   opacity: pinned ? 1 : 0.25,
@@ -271,7 +271,7 @@ export function ProjectCard({ project, onHide, compact = false, pinned = false, 
                     aria-label="More options"
                     style={{
                       display: "flex", alignItems: "center", justifyContent: "center",
-                      width: "28px", height: "28px",
+                      width: "32px", height: "32px",
                       borderRadius: "3px", background: "transparent", border: "none",
                       color: "var(--text-muted)", cursor: "pointer", padding: 0,
                     }}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -445,7 +445,7 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
                   <p style={{ fontSize: "0.8rem", color: "var(--text-muted)", margin: 0 }}>
                     No TODO items found. Add one below to create <code style={{ fontFamily: "var(--font-mono)", fontSize: "0.85em", color: "var(--accent)", background: "var(--accent-bg)", padding: "1px 4px", borderRadius: "3px" }}>TODO.md</code>.
                   </p>
-                  <AddTodoForm slug={project.slug} onAdded={setTodos} />
+                  <AddTodoForm slug={project.slug} onAddedAction={setTodos} />
                   {project.worktrees?.some((wt) => wt.todos) && (
                     <TodoList
                       todos={{ total: 0, completed: 0, pending: 0, items: [] }}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -96,13 +96,20 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
     window.open(`wt.exe -d "${project.path}"`, "_blank");
   };
 
+  const hasManualSteps = !!(project.manualSteps || project.worktrees?.some((wt) => wt.manualSteps));
+  const hasInsights = !!(
+    (project.insights?.total ?? 0) > 0 ||
+    project.worktrees?.some((wt) => (wt.insights?.total ?? 0) > 0)
+  );
+  const hasSessions = !!(project.claude && project.claude.sessionCount > 0);
+
   const tabs: { key: TabKey; label: string }[] = [
     { key: "overview",    label: "Overview" },
     { key: "context",     label: "Context" },
     { key: "todos",       label: `TODOs${todos ? ` (${todos.pending})` : ""}` },
-    { key: "sessions",    label: "Sessions" },
-    { key: "manual-steps", label: "Manual Steps" },
-    { key: "insights",    label: "Insights" },
+    ...(hasSessions     ? [{ key: "sessions"     as TabKey, label: "Sessions"     }] : []),
+    ...(hasManualSteps  ? [{ key: "manual-steps" as TabKey, label: "Manual Steps" }] : []),
+    ...(hasInsights     ? [{ key: "insights"     as TabKey, label: "Insights"     }] : []),
     { key: "memory",      label: "Memory" },
     { key: "agents",      label: "Agents" },
     { key: "skills",      label: "Skills" },

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useSessionDetail } from "@/hooks/useSessions";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { SessionTimeline } from "./SessionTimeline";
 import { SessionFileOps } from "./SessionFileOps";
 import { SessionSubagents } from "./SessionSubagents";
@@ -162,6 +163,7 @@ function TabBar({
 export function SessionDetailView({ sessionId }: { sessionId: string }) {
   const { data, loading } = useSessionDetail(sessionId);
   const [activeTab, setActiveTab] = useState<TabKey>("timeline");
+  useDocumentTitle(data ? (data.projectPath?.split(/[\\/]/).pop() ?? "Session") : "Session");
 
   if (loading) {
     return (

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -4,7 +4,7 @@ import { useStats } from "@/hooks/useStats";
 import { BarChart } from "./stats/BarChart";
 import { HealthBar } from "./stats/HealthBar";
 import { Skeleton } from "./ui/skeleton";
-import { FolderOpen, Bot, CheckCircle2, ClipboardList, DollarSign, Cpu, Wrench } from "lucide-react";
+import { FolderOpen, Bot, CheckCircle2, ClipboardList, DollarSign, Cpu } from "lucide-react";
 import type { ReactNode } from "react";
 
 function formatTokens(n: number): string {

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -31,39 +31,53 @@ interface StatusBadgeProps {
   onClick?: () => void;
 }
 
+const statusBadgeStyle = (cfg: { textVar: string; bgVar: string; borderVar: string }, clickable: boolean) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "5px",
+  fontFamily: "var(--font-body)",
+  fontSize: "0.65rem",
+  fontWeight: 600,
+  letterSpacing: "0.07em",
+  textTransform: "uppercase" as const,
+  color: `var(${cfg.textVar})`,
+  background: `var(${cfg.bgVar})`,
+  border: `1px solid var(${cfg.borderVar})`,
+  borderRadius: "3px",
+  padding: "2px 6px",
+  cursor: clickable ? "pointer" : "default",
+  userSelect: "none" as const,
+  lineHeight: 1.4,
+});
+
+const dot = (textVar: string) => ({
+  width: "5px",
+  height: "5px",
+  borderRadius: "50%",
+  background: `var(${textVar})`,
+  flexShrink: 0,
+});
+
 export function StatusBadge({ status, onClick }: StatusBadgeProps) {
   const cfg = statusConfig[status];
+  const shared = statusBadgeStyle(cfg, !!onClick);
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        style={{ ...shared, appearance: "none" }}
+      >
+        <span style={dot(cfg.textVar)} />
+        {cfg.label}
+      </button>
+    );
+  }
+
   return (
-    <span
-      onClick={onClick}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: "5px",
-        fontFamily: "var(--font-body)",
-        fontSize: "0.65rem",
-        fontWeight: 600,
-        letterSpacing: "0.07em",
-        textTransform: "uppercase",
-        color: `var(${cfg.textVar})`,
-        background: `var(${cfg.bgVar})`,
-        border: `1px solid var(${cfg.borderVar})`,
-        borderRadius: "3px",
-        padding: "2px 6px",
-        cursor: onClick ? "pointer" : "default",
-        userSelect: "none",
-        lineHeight: 1.4,
-      }}
-    >
-      <span
-        style={{
-          width: "5px",
-          height: "5px",
-          borderRadius: "50%",
-          background: `var(${cfg.textVar})`,
-          flexShrink: 0,
-        }}
-      />
+    <span style={shared}>
+      <span style={dot(cfg.textVar)} />
       {cfg.label}
     </span>
   );

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -10,8 +10,13 @@ import {
 } from "react";
 import { ToastContainer, type ToastMessage } from "./ui/toast";
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface ToastContextValue {
-  showToast: (title: string, description?: string) => void;
+  showToast: (title: string, description?: string, action?: ToastAction) => void;
 }
 
 const ToastContext = createContext<ToastContextValue | null>(null);
@@ -27,9 +32,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const showToast = useCallback(
-    (title: string, description?: string) => {
+    (title: string, description?: string, action?: ToastAction) => {
       const id = String(nextId.current++);
-      setMessages((prev) => [...prev, { id, title, description }]);
+      setMessages((prev) => [...prev, { id, title, description, action }]);
       setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
     },
     [dismiss]

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -8,12 +8,7 @@ import {
   useRef,
   type ReactNode,
 } from "react";
-import { ToastContainer, type ToastMessage } from "./ui/toast";
-
-interface ToastAction {
-  label: string;
-  onClick: () => void;
-}
+import { ToastContainer, type ToastMessage, type ToastAction } from "./ui/toast";
 
 interface ToastContextValue {
   showToast: (title: string, description?: string, action?: ToastAction) => void;

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -57,7 +57,7 @@ export function TodoList({ todos, slug, onChange, worktrees }: TodoListProps) {
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
           <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
             {/* Filter buttons */}
-            {(["all", "open", "done"] as const).map((f, i) => {
+            {(["all", "open", "done"] as const).map((f) => {
               const active = filter === f;
               const labels = { all: "All", open: "Open", done: "Done" } as const;
               return (
@@ -179,23 +179,23 @@ export function TodoList({ todos, slug, onChange, worktrees }: TodoListProps) {
       )}
 
       {/* Add form */}
-      {slug && <AddTodoForm slug={slug} onAdded={onChange} />}
+      {slug && <AddTodoForm slug={slug} onAddedAction={onChange} />}
     </div>
   );
 }
 
 export function AddTodoForm({
   slug,
-  onAdded,
+  onAddedAction,
 }: {
   slug: string;
-  onAdded?: (updated: TodoInfo) => void;
+  onAddedAction?: (updated: TodoInfo) => void;
 }) {
   const [text, setText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const { showToast } = useToast();
 
-  const submit = async (e: React.FormEvent) => {
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const trimmed = text.trim();
     if (!trimmed || submitting) return;
@@ -213,7 +213,7 @@ export function AddTodoForm({
       }
       const body = await res.json();
       setText("");
-      onAdded?.(body.todos as TodoInfo);
+      onAddedAction?.(body.todos as TodoInfo);
       showToast("TODO added", trimmed);
     } catch (err) {
       showToast(

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  "inline-flex items-center rounded-[3px] border px-2.5 py-0.5 text-xs font-semibold transition-colors",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,15 +4,15 @@ import { cn } from "@/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--info)] disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default: "bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90",
         destructive: "bg-[var(--destructive)] text-[var(--destructive-foreground)] hover:opacity-90",
-        outline: "border border-[var(--input)] bg-[var(--background)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]",
+        outline: "border border-[var(--input)] bg-[var(--background)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]",
         secondary: "bg-[var(--secondary)] text-[var(--secondary-foreground)] hover:opacity-80",
-        ghost: "hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]",
+        ghost: "hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]",
         link: "text-[var(--primary)] underline-offset-4 hover:underline",
       },
       size: {

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -2,11 +2,16 @@
 
 import { X } from "lucide-react";
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface ToastMessage {
   id: string;
   title: string;
   description?: string;
-  action?: { label: string; onClick: () => void };
+  action?: ToastAction;
 }
 
 export function ToastContainer({
@@ -37,7 +42,7 @@ export function ToastContainer({
             <div className="flex items-center gap-2 shrink-0">
               {msg.action && (
                 <button
-                  onClick={() => { msg.action!.onClick(); onDismiss(msg.id); }}
+                  onClick={() => { msg.action?.onClick(); onDismiss(msg.id); }}
                   className="text-xs font-medium text-[var(--info)] hover:underline"
                 >
                   {msg.action.label}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -6,6 +6,7 @@ export interface ToastMessage {
   id: string;
   title: string;
   description?: string;
+  action?: { label: string; onClick: () => void };
 }
 
 export function ToastContainer({
@@ -25,7 +26,7 @@ export function ToastContainer({
           className="animate-slide-in-right rounded-lg border bg-[var(--card)] p-4 shadow-lg"
         >
           <div className="flex items-start justify-between gap-2">
-            <div className="space-y-1">
+            <div className="space-y-1 flex-1 min-w-0">
               <p className="text-sm font-medium">{msg.title}</p>
               {msg.description && (
                 <p className="text-xs text-[var(--muted-foreground)]">
@@ -33,12 +34,22 @@ export function ToastContainer({
                 </p>
               )}
             </div>
-            <button
-              onClick={() => onDismiss(msg.id)}
-              className="shrink-0 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-            >
-              <X className="h-4 w-4" />
-            </button>
+            <div className="flex items-center gap-2 shrink-0">
+              {msg.action && (
+                <button
+                  onClick={() => { msg.action!.onClick(); onDismiss(msg.id); }}
+                  className="text-xs font-medium text-[var(--info)] hover:underline"
+                >
+                  {msg.action.label}
+                </button>
+              )}
+              <button
+                onClick={() => onDismiss(msg.id)}
+                className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
           </div>
         </div>
       ))}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -42,6 +42,7 @@ export function ToastContainer({
             <div className="flex items-center gap-2 shrink-0">
               {msg.action && (
                 <button
+                  type="button"
                   onClick={() => { msg.action?.onClick(); onDismiss(msg.id); }}
                   className="text-xs font-medium text-[var(--info)] hover:underline"
                 >
@@ -49,6 +50,8 @@ export function ToastContainer({
                 </button>
               )}
               <button
+                type="button"
+                aria-label="Dismiss notification"
                 onClick={() => onDismiss(msg.id)}
                 className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
               >

--- a/src/hooks/useDocumentTitle.ts
+++ b/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+export function useDocumentTitle(title: string) {
+  useEffect(() => {
+    const prev = document.title;
+    document.title = title ? `${title} — Project Minder` : "Project Minder";
+    return () => { document.title = prev; };
+  }, [title]);
+}

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -35,7 +35,7 @@ export function useProjects() {
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
-      showToast("Scan failed", "Check the console for details");
+      showToast("Rescan failed", "Showing cached results");
     } finally {
       setLoading(false);
     }

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -70,31 +70,17 @@ export function useProjects() {
     fetchProjects();
   }, [fetchProjects]);
 
-  const hideProject = useCallback(
-    async (slug: string, dirName: string) => {
-      try {
-        await fetch("/api/config", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "hide", dirName }),
-        });
-        // Optimistic update: remove from list, bump hidden count
-        setData((prev) => {
-          if (!prev) return prev;
-          return {
-            ...prev,
-            projects: prev.projects.filter((p) => p.slug !== slug),
-            hiddenCount: prev.hiddenCount + 1,
-          };
-        });
-      } catch {
-        // Silently fail
-      }
-    },
-    []
+  const archiveProject = useCallback(
+    (slug: string) => updateStatus(slug, "archived"),
+    [updateStatus]
   );
 
-  return { data, loading, error, rescan, updateStatus, hideProject };
+  const unarchiveProject = useCallback(
+    (slug: string) => updateStatus(slug, "active"),
+    [updateStatus]
+  );
+
+  return { data, loading, error, rescan, updateStatus, archiveProject, unarchiveProject };
 }
 
 export function useProject(slug: string) {

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -44,12 +44,12 @@ export function useProjects() {
   const updateStatus = useCallback(
     async (slug: string, status: ProjectStatus) => {
       try {
-        await fetch("/api/config", {
+        const res = await fetch("/api/config", {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ slug, status }),
         });
-        // Update local state
+        if (!res.ok) return;
         setData((prev) => {
           if (!prev) return prev;
           return {
@@ -60,7 +60,7 @@ export function useProjects() {
           };
         });
       } catch {
-        // Silently fail
+        // network errors — local state left unchanged
       }
     },
     []
@@ -76,7 +76,7 @@ export function useProjects() {
   );
 
   const unarchiveProject = useCallback(
-    (slug: string) => updateStatus(slug, "active"),
+    (slug: string, status: ProjectStatus = "active") => updateStatus(slug, status),
     [updateStatus]
   );
 


### PR DESCRIPTION
## Summary

Implements improvements from two `/critique` passes (31→34/40 score) and a `/simplify` cleanup pass across the dashboard and dev server control surfaces.

### Critique improvements (4 commits)
- **Archive/Hide consolidation** — replaced two separate concepts with a single "Archive" action; archived projects collapse into a disclosure section with per-row Unarchive; toast with Undo action for quick recovery
- **Default sort → Claude session recency** — most relevant ordering for a dev context-switching tool
- **Dev server errored state** — red error pill with `AlertCircle` icon in compact mode, tooltip shows last 3 output lines, Retry button; full-panel Start relabels to "Retry" when errored
- **Toolbar polish** — Status and Sort segmented buttons now match View mode buttons exactly: icon + label stacked, 32px min-height, 0.52rem mono label; icons for all button groups
- **Stop confirmation removed** — asymmetry with Archive (no confirm) was the wrong UX pattern; toast Undo covers archive; stop is reversible with Restart
- **Conditional tabs** — Manual Steps, Insights, and Sessions tabs on project detail now hidden when empty
- **Scan indicator** — meta row shows "Scanned Xm ago · Rescan" with `r` keyboard shortcut
- **A11y / audit pass** — nav admin separation, touch targets, harden, polish

### Simplify pass (1 commit)
- **`DashboardGrid`** — replace inline `timeAgo` duplicate with `formatRelativeTime` from utils; hoist `statusOptions`/`sortOptions`/`viewOptions` to module scope (created once, not per-render); memoize `overlaidProjects` on `[filtered, liveStatus]` to prevent 61 new object identities on every 2s live poll tick; extract `NEXT_VIEW` lookup map to replace ternary chain
- **Toast** — export named `ToastAction` interface, remove duplicate local declaration in `ToastProvider`, fix `msg.action!.onClick()` non-null assertion to `?.`
- **`DevServerControl`** — tighten `statusTokens`/`StatusPill` from `Record<string>` to `Record<DevServerInfo["status"]>`; extract `startLabel`; remove WHAT comments

## Test plan
- [x] Typecheck passes (`tsgo --noEmit`)
- [x] All 302 tests pass
- [ ] Archive a project → toast appears with Undo; project moves to collapsed Archived section
- [ ] Undo via toast → project returns to main grid
- [ ] Unarchive via collapsed section row → project leaves section
- [ ] Start dev server → compact card shows `● :PORT` running badge
- [ ] Kill the process externally → compact card shows red `error` pill; Retry button works
- [ ] Default sort on fresh load = Last Session (Claude recency)
- [ ] `r` shortcut triggers rescan; meta row shows scanned timestamp
- [ ] All toolbar button groups are visually consistent (icon + mono label, 32px height)
- [ ] Project detail: Manual Steps / Insights / Sessions tabs hidden when no data

🤖 Generated with [Claude Code](https://claude.com/claude-code)