### PR TITLE
feat(config): surface project hooks, plugins, MCP servers, and CI/CD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Project config surfacing (hooks · plugins · MCP · CI/CD)** — three new scanner modules (`claudeHooks`, `mcpServers`, `cicd`) attach project-local config to `ProjectData`. CI/CD parsing is per-unit semantic: workflows expose normalized `on:` triggers, schedule crons, jobs (id, name, runs-on), and deduped action `uses:` references; vercel.json crons are extracted; dependabot updates are emitted per-ecosystem; multi-host detection covers Vercel, Railway, Fly, Render, Netlify, Heroku, and Docker. A new `userConfigCache` singleton (5-min TTL, modeled on `gitStatusCache`) reads `~/.claude/settings.json` and `installed_plugins.json` once per process for plugin and user-level hook/MCP data.
+- **`/config` page rebuilt as 5-tab shell** — Settings (existing MinderConfig editor) plus four cross-project catalog tabs: Hooks, Plugins, MCP, CI/CD. Each surfaces unit-level rows with project-source badges. Designed to feed a future template-builder feature that mines existing projects for reusable units.
+- **Project Config tab** — appears on a project detail page when project-local hooks, `.mcp.json`, or CI/CD config is present. Shows project-only data (no user-level repetition); user-level hooks/plugins/MCP live on `/config`.
+- **CI badge on dashboard cards** — small monospaced `CI` chip (next to the worktree badge) when `.github/workflows/*` is present; tooltip shows workflow count.
+- **`GET /api/claude-config?type=hooks|plugins|mcp|cicd|all&project=&q=`** — cross-project rollup for the `/config` page. 2-min global cache like `/api/agents`.
+- **`GET /api/claude-config/user`** — user-level config singleton (plugins + user-level hooks + user-level MCP).
 - **Dev server error state** — compact card badge now shows a red "error" pill with last-output tooltip and a Retry button when the server exits non-zero; full-panel Start button relabels to "Retry" in error state.
 - **Dev server error details** — `doAction` extracts `error` field from non-ok API responses and shows it as the toast description ("Failed to start dev server", "EADDRINUSE: port in use") instead of the generic fallback.
 - **Archive consolidation** — "Hidden" UX path removed from the dashboard entirely. The card three-dot dropdown now says "Archive" (no confirmation required; archive is reversible). Archiving shows a toast with a 5-second "Undo" action. Scanner exclusion (`hidden[]`) remains a Setup-only power feature.

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,6 @@
 - [ ] **CodeQL scanning** — Add `.github/workflows/codeql.yml` using `github/codeql-action`. Once it's run once, enable "Require code scanning results" in the ruleset.
 - [ ] **Release automation** — Tag-based GitHub Release workflow: on `v*` tag push, run CI, then create a release with auto-generated notes from squashed PR titles.
 - [ ] Support running the /insights command in Claude, then display the generated output file (~/.claude/usage-data/report.html) for the user to review. Let the user schedule running /insights to update the report.
-- [ ] Support running the /insights command in Claude, then display the generated output file (~/.claude/usage-data/report.html) for the user to review. Let the user schedule running /insights to update the report.
 
 ## Config Surfacing — Follow-ups
 

--- a/TODO.md
+++ b/TODO.md
@@ -40,3 +40,12 @@
 - [ ] **Signed commits** — Set up GPG or SSH commit signing on every machine you develop from, then enable "Require signed commits" in the `main-protection` ruleset.
 - [ ] **CodeQL scanning** — Add `.github/workflows/codeql.yml` using `github/codeql-action`. Once it's run once, enable "Require code scanning results" in the ruleset.
 - [ ] **Release automation** — Tag-based GitHub Release workflow: on `v*` tag push, run CI, then create a release with auto-generated notes from squashed PR titles.
+- [ ] Support running the /insights command in Claude, then display the generated output file (~/.claude/usage-data/report.html) for the user to review. Let the user schedule running /insights to update the report.
+- [ ] Support running the /insights command in Claude, then display the generated output file (~/.claude/usage-data/report.html) for the user to review. Let the user schedule running /insights to update the report.
+
+## Config Surfacing — Follow-ups
+
+- [ ] **Template-builder MVP** — cross-project dedupe of hook tuples / MCP server entries / workflow jobs; "copy this unit to project X" action on `/config` rows. Each scanner already retains `sourcePath` + per-unit identifiers, so this is mostly UI + a `POST /api/claude-config/apply` route.
+- [ ] **CI badge → /config deep link** — clicking the dashboard `CI` chip should navigate to `/config?type=cicd&project=<slug>` (currently the page ignores URL params; add `useSearchParams` wiring).
+- [ ] **`local` ProvenanceBadge variant** — surface `.claude/settings.local.json`-sourced hooks distinctly from `.claude/settings.json`-sourced ones in the cross-project hooks list (currently both show as "project: slug").
+- [ ] **Plugin-bundled hooks/MCP** — plugins can ship their own `hooks/hooks.json` and `.mcp.json` under `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`. Surfacing these would require iterating `loadInstalledPlugins()` and parsing each plugin's bundled config files; deferred because the signal is weaker than user-level + project-local config.

--- a/docs/help/config.md
+++ b/docs/help/config.md
@@ -1,6 +1,29 @@
 # Configuration
 
-The Config page (`/config`) lets you customize how Project Minder scans and displays your projects.
+The Config page (`/config`) is the single entry point for portfolio-wide configuration. It has five tabs:
+
+| Tab | What it shows |
+|-----|---------------|
+| **Settings** | Project Minder's own settings (scan roots, batch size, dashboard defaults, hidden projects) |
+| **Hooks** | Every Claude Code hook configured in `.claude/settings.json` / `.claude/settings.local.json` across all projects, plus user-level hooks |
+| **Plugins** | All Claude Code plugins installed via `~/.claude/plugins/installed_plugins.json` with their enabled / disabled / blocked status |
+| **MCP** | Every MCP server configured in any project's `.mcp.json` plus user-level servers from `~/.claude/settings.json` |
+| **CI / CD** | Every project that has a `.github/workflows/*.yml`, Vercel/Railway/Fly/Render/Netlify/Heroku/Docker hosting config, or Dependabot updates |
+
+The CI/CD tab parses workflows down to the **per-job** level: triggers, schedule crons, runs-on, and the deduped list of action `uses:` references for each job. It deliberately does **not** parse step `run:` scripts — those tend to be project-specific noise. Each row retains its source file path so a future template-builder feature can copy units verbatim across projects.
+
+User-level data (plugins, user-level hooks/MCP) lives only on `/config`. Per-project pages show only project-local config — see the [Project Config tab](#project-config-tab) below.
+
+## Project Config tab
+
+When a project has any project-local hooks (`.claude/settings.json`), MCP servers (`.mcp.json`), or CI/CD configuration, a **Config** tab appears on its detail page. The tab has four sections:
+
+- **Hooks** — events (PreToolUse / PostToolUse / etc.), matchers, and command previews; the `settings` / `settings.local` source is shown on the right.
+- **MCP Servers** — name, transport (stdio / http / sse), command + args (or URL), and the count of configured env keys (key names only — never values).
+- **GitHub Workflows** — file name, top-level workflow name, normalized triggers, cron schedules, and per-job rows with each job's `uses:` action references.
+- **Hosting & Automation** — host platform pills (Vercel, Railway, etc.), Vercel cron entries, Dependabot updates with their schedule interval.
+
+A small `CI` badge appears on the dashboard card whenever the project has at least one workflow file.
 
 ## Scan Roots
 

--- a/public/help/config.md
+++ b/public/help/config.md
@@ -1,6 +1,29 @@
 # Configuration
 
-The Config page (`/config`) lets you customize how Project Minder scans and displays your projects.
+The Config page (`/config`) is the single entry point for portfolio-wide configuration. It has five tabs:
+
+| Tab | What it shows |
+|-----|---------------|
+| **Settings** | Project Minder's own settings (scan roots, batch size, dashboard defaults, hidden projects) |
+| **Hooks** | Every Claude Code hook configured in `.claude/settings.json` / `.claude/settings.local.json` across all projects, plus user-level hooks |
+| **Plugins** | All Claude Code plugins installed via `~/.claude/plugins/installed_plugins.json` with their enabled / disabled / blocked status |
+| **MCP** | Every MCP server configured in any project's `.mcp.json` plus user-level servers from `~/.claude/settings.json` |
+| **CI / CD** | Every project that has a `.github/workflows/*.yml`, Vercel/Railway/Fly/Render/Netlify/Heroku/Docker hosting config, or Dependabot updates |
+
+The CI/CD tab parses workflows down to the **per-job** level: triggers, schedule crons, runs-on, and the deduped list of action `uses:` references for each job. It deliberately does **not** parse step `run:` scripts — those tend to be project-specific noise. Each row retains its source file path so a future template-builder feature can copy units verbatim across projects.
+
+User-level data (plugins, user-level hooks/MCP) lives only on `/config`. Per-project pages show only project-local config — see the [Project Config tab](#project-config-tab) below.
+
+## Project Config tab
+
+When a project has any project-local hooks (`.claude/settings.json`), MCP servers (`.mcp.json`), or CI/CD configuration, a **Config** tab appears on its detail page. The tab has four sections:
+
+- **Hooks** — events (PreToolUse / PostToolUse / etc.), matchers, and command previews; the `settings` / `settings.local` source is shown on the right.
+- **MCP Servers** — name, transport (stdio / http / sse), command + args (or URL), and the count of configured env keys (key names only — never values).
+- **GitHub Workflows** — file name, top-level workflow name, normalized triggers, cron schedules, and per-job rows with each job's `uses:` action references.
+- **Hosting & Automation** — host platform pills (Vercel, Railway, etc.), Vercel cron entries, Dependabot updates with their schedule interval.
+
+A small `CI` badge appears on the dashboard card whenever the project has at least one workflow file.
 
 ## Scan Roots
 

--- a/src/app/api/claude-config/route.ts
+++ b/src/app/api/claude-config/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCachedScan, setCachedScan } from "@/lib/cache";
+import { scanAllProjects } from "@/lib/scanner";
+import { getUserConfig } from "@/lib/userConfigCache";
+import {
+  CONFIG_TYPES,
+  CiCdInfo,
+  ConfigType,
+  HookEntry,
+  McpServer,
+  PluginEntry,
+  ProjectData,
+} from "@/lib/types";
+
+const CACHE_TTL_MS = 2 * 60 * 1000;
+
+interface HookRow extends HookEntry {
+  projectSlug?: string;
+  projectName?: string;
+}
+
+interface McpRow extends McpServer {
+  projectSlug?: string;
+  projectName?: string;
+}
+
+interface CicdRow {
+  projectSlug: string;
+  projectName: string;
+  cicd: CiCdInfo;
+}
+
+interface AggregatedPayload {
+  hooks: HookRow[];
+  plugins: PluginEntry[];
+  mcp: McpRow[];
+  cicd: CicdRow[];
+}
+
+const globalForCC = globalThis as unknown as {
+  __claudeConfigCache?: Map<string, { data: AggregatedPayload; cachedAt: number }>;
+};
+
+function getRouteCache(key: string): AggregatedPayload | null {
+  const cache = globalForCC.__claudeConfigCache;
+  if (!cache) return null;
+  const slot = cache.get(key);
+  if (!slot) return null;
+  if (Date.now() - slot.cachedAt < CACHE_TTL_MS) return slot.data;
+  cache.delete(key);
+  return null;
+}
+
+function setRouteCache(key: string, data: AggregatedPayload) {
+  let cache = globalForCC.__claudeConfigCache;
+  if (!cache) {
+    cache = new Map();
+    globalForCC.__claudeConfigCache = cache;
+  }
+  const cutoff = Date.now() - CACHE_TTL_MS;
+  for (const [k, slot] of cache) {
+    if (slot.cachedAt < cutoff) cache.delete(k);
+  }
+  cache.set(key, { data, cachedAt: Date.now() });
+}
+
+export function invalidateClaudeConfigRouteCache() {
+  globalForCC.__claudeConfigCache = new Map();
+}
+
+export async function GET(request: NextRequest) {
+  const typeParam = (request.nextUrl.searchParams.get("type") ?? "all").toLowerCase();
+  const type: ConfigType = (CONFIG_TYPES as readonly string[]).includes(typeParam)
+    ? (typeParam as ConfigType)
+    : "all";
+  const projectSlug = request.nextUrl.searchParams.get("project") ?? undefined;
+  const query = request.nextUrl.searchParams.get("q")?.toLowerCase() ?? undefined;
+
+  const cacheable = !query;
+  const cacheKey = `${type}|${projectSlug ?? ""}`;
+  if (cacheable) {
+    const cached = getRouteCache(cacheKey);
+    if (cached) return NextResponse.json(cached);
+  }
+
+  const [scan, userConfig] = await Promise.all([
+    (async () => {
+      let result = getCachedScan();
+      if (!result) {
+        result = await scanAllProjects();
+        setCachedScan(result);
+      }
+      return result;
+    })(),
+    getUserConfig(),
+  ]);
+
+  const allProjects = scan.projects;
+  const projects = projectSlug
+    ? allProjects.filter((p) => p.slug === projectSlug)
+    : allProjects;
+  const includeUserScope = !projectSlug;
+
+  const payload: AggregatedPayload = {
+    hooks: [],
+    plugins: [],
+    mcp: [],
+    cicd: [],
+  };
+
+  if (type === "hooks" || type === "all") {
+    payload.hooks = collectHooks(projects);
+    if (includeUserScope) {
+      payload.hooks.push(...userConfig.hooks.entries.map((e) => ({ ...e })));
+    }
+  }
+
+  if (type === "plugins" || type === "all") {
+    payload.plugins = userConfig.plugins.plugins;
+  }
+
+  if (type === "mcp" || type === "all") {
+    payload.mcp = collectMcp(projects);
+    if (includeUserScope) {
+      payload.mcp.push(...userConfig.mcpServers.servers.map((s) => ({ ...s })));
+    }
+  }
+
+  if (type === "cicd" || type === "all") {
+    payload.cicd = collectCicd(projects);
+  }
+
+  if (query) {
+    applyQuery(payload, query);
+    return NextResponse.json(payload);
+  }
+
+  setRouteCache(cacheKey, payload);
+  return NextResponse.json(payload);
+}
+
+function collectHooks(projects: ProjectData[]): HookRow[] {
+  const rows: HookRow[] = [];
+  for (const p of projects) {
+    if (!p.hooks) continue;
+    for (const e of p.hooks.entries) {
+      rows.push({ ...e, projectSlug: p.slug, projectName: p.name });
+    }
+  }
+  return rows;
+}
+
+function collectMcp(projects: ProjectData[]): McpRow[] {
+  const rows: McpRow[] = [];
+  for (const p of projects) {
+    if (!p.mcpServers) continue;
+    for (const s of p.mcpServers.servers) {
+      rows.push({ ...s, projectSlug: p.slug, projectName: p.name });
+    }
+  }
+  return rows;
+}
+
+function collectCicd(projects: ProjectData[]): CicdRow[] {
+  const rows: CicdRow[] = [];
+  for (const p of projects) {
+    if (!p.cicd) continue;
+    rows.push({ projectSlug: p.slug, projectName: p.name, cicd: p.cicd });
+  }
+  return rows;
+}
+
+function applyQuery(payload: AggregatedPayload, q: string): void {
+  payload.hooks = payload.hooks.filter((h) =>
+    [h.event, h.matcher, h.projectName, h.projectSlug, h.commands.map((c) => c.command).join(" ")]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase()
+      .includes(q)
+  );
+
+  payload.plugins = payload.plugins.filter((p) =>
+    [p.name, p.marketplace, p.version].filter(Boolean).join(" ").toLowerCase().includes(q)
+  );
+
+  payload.mcp = payload.mcp.filter((m) =>
+    [m.name, m.command, m.url, m.transport, m.projectName, m.projectSlug]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase()
+      .includes(q)
+  );
+
+  payload.cicd = payload.cicd.filter((c) => {
+    const text = [
+      c.projectName,
+      c.projectSlug,
+      ...c.cicd.workflows.map((w) => w.name ?? w.file),
+      ...c.cicd.workflows.flatMap((w) => w.jobs.flatMap((j) => j.actionUses)),
+      ...c.cicd.hosting.map((h) => h.platform),
+      ...c.cicd.dependabot.map((d) => d.ecosystem),
+    ]
+      .join(" ")
+      .toLowerCase();
+    return text.includes(q);
+  });
+}

--- a/src/app/api/claude-config/user/route.ts
+++ b/src/app/api/claude-config/user/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { getUserConfig } from "@/lib/userConfigCache";
+
+export async function GET() {
+  const data = await getUserConfig();
+  return NextResponse.json(data);
+}

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { readConfig, writeConfig } from "@/lib/config";
 import { invalidateCache } from "@/lib/cache";
+import { invalidateClaudeConfigRouteCache } from "@/app/api/claude-config/route";
 import { ProjectStatus, MinderConfig } from "@/lib/types";
 
 // Derived from the MinderConfig union types — update both together if options change
@@ -73,6 +74,7 @@ export async function PATCH(request: NextRequest) {
 
   await writeConfig(config);
   invalidateCache();
+  invalidateClaudeConfigRouteCache();
   return NextResponse.json({ ok: true, config });
 }
 
@@ -90,6 +92,7 @@ export async function PUT(request: NextRequest) {
     config.statuses[body.slug] = body.status as ProjectStatus;
     await writeConfig(config);
     invalidateCache();
+  invalidateClaudeConfigRouteCache();
     return NextResponse.json({ ok: true });
   }
 
@@ -100,6 +103,7 @@ export async function PUT(request: NextRequest) {
     }
     await writeConfig(config);
     invalidateCache();
+  invalidateClaudeConfigRouteCache();
     return NextResponse.json({ ok: true });
   }
 
@@ -108,6 +112,7 @@ export async function PUT(request: NextRequest) {
     config.hidden = config.hidden.filter((h) => h !== body.dirName);
     await writeConfig(config);
     invalidateCache();
+  invalidateClaudeConfigRouteCache();
     return NextResponse.json({ ok: true });
   }
 
@@ -123,6 +128,7 @@ export async function PUT(request: NextRequest) {
     }
     await writeConfig(config);
     invalidateCache();
+  invalidateClaudeConfigRouteCache();
     return NextResponse.json({ ok: true });
   }
 
@@ -131,6 +137,7 @@ export async function PUT(request: NextRequest) {
     config.hidden = body.hidden;
     await writeConfig(config);
     invalidateCache();
+  invalidateClaudeConfigRouteCache();
     return NextResponse.json({ ok: true });
   }
 

--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -4,12 +4,16 @@ import { invalidateCache, setCachedScan } from "@/lib/cache";
 import { invalidateCatalogCache } from "@/lib/indexer/catalog";
 import { invalidateAgentsRouteCache } from "@/app/api/agents/route";
 import { invalidateSkillsRouteCache } from "@/app/api/skills/route";
+import { invalidateClaudeConfigRouteCache } from "@/app/api/claude-config/route";
+import { invalidateUserConfigCache } from "@/lib/userConfigCache";
 
 export async function POST() {
   invalidateCache();
   invalidateCatalogCache();
   invalidateAgentsRouteCache();
   invalidateSkillsRouteCache();
+  invalidateClaudeConfigRouteCache();
+  invalidateUserConfigCache();
   const result = await scanAllProjects();
   setCachedScan(result);
   return NextResponse.json(result);

--- a/src/app/config/page.tsx
+++ b/src/app/config/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { ConfigDashboard } from "@/components/ConfigDashboard";
+import { ConfigBrowser } from "@/components/ConfigBrowser";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function ConfigPage() {
   useDocumentTitle("Config");
-  return <ConfigDashboard />;
+  return <ConfigBrowser />;
 }

--- a/src/components/ConfigBrowser.tsx
+++ b/src/components/ConfigBrowser.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Settings, Search, Webhook, Server, Workflow as WorkflowIcon, Cloud, Box, Sliders } from "lucide-react";
+import Link from "next/link";
+import { useConfig, type HookRow, type McpRow, type CicdRow } from "@/hooks/useConfig";
+import type { ConfigType, PluginEntry, Workflow } from "@/lib/types";
+import { ConfigDashboard } from "./ConfigDashboard";
+import { Pill, inlineCode, mutedMono, commandPreview, fileBasename, type PillTone } from "./config/primitives";
+
+type TabKey = ConfigType | "settings";
+
+const TABS: { key: TabKey; label: string; icon: typeof Webhook }[] = [
+  { key: "settings", label: "Settings",   icon: Sliders },
+  { key: "hooks",    label: "Hooks",      icon: Webhook },
+  { key: "plugins",  label: "Plugins",    icon: Box },
+  { key: "mcp",      label: "MCP",        icon: Server },
+  { key: "cicd",     label: "CI / CD",    icon: WorkflowIcon },
+];
+
+export function ConfigBrowser() {
+  const [activeTab, setActiveTab] = useState<TabKey>("settings");
+  const [rawQuery, setRawQuery] = useState("");
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(rawQuery), 300);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  const catalogType: ConfigType | undefined =
+    activeTab === "settings" ? undefined : activeTab;
+  const { data, loading } = useConfig(catalogType, undefined, query || undefined);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <Settings style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
+        <h1
+          style={{
+            fontSize: "0.72rem",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--text-secondary)",
+            fontFamily: "var(--font-body)",
+            margin: 0,
+          }}
+        >
+          Config
+        </h1>
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "var(--text-muted)" }}>
+          hooks · plugins · MCP · CI/CD
+        </span>
+      </header>
+
+      <nav style={{ display: "flex", gap: "2px", borderBottom: "1px solid var(--border-subtle)" }}>
+        {TABS.map((t) => {
+          const Icon = t.icon;
+          const active = activeTab === t.key;
+          const count = countFor(t.key, data);
+          return (
+            <button
+              key={t.key}
+              onClick={() => setActiveTab(t.key)}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "6px",
+                padding: "8px 14px",
+                fontSize: "0.72rem",
+                fontFamily: "var(--font-body)",
+                fontWeight: active ? 600 : 400,
+                color: active ? "var(--text-primary)" : "var(--text-secondary)",
+                background: "transparent",
+                border: "none",
+                borderBottom: active ? "2px solid var(--accent)" : "2px solid transparent",
+                cursor: "pointer",
+                marginBottom: "-1px",
+              }}
+            >
+              <Icon style={{ width: "12px", height: "12px" }} />
+              {t.label}
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.6rem", color: "var(--text-muted)" }}>
+                {count}
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+
+      {activeTab !== "settings" && (
+      <div style={{ position: "relative", maxWidth: "320px" }}>
+        <Search
+          style={{
+            position: "absolute",
+            left: "9px",
+            top: "50%",
+            transform: "translateY(-50%)",
+            width: "13px",
+            height: "13px",
+            color: "var(--text-muted)",
+            pointerEvents: "none",
+          }}
+        />
+        <input
+          type="text"
+          placeholder={`Search ${activeTab}…`}
+          value={rawQuery}
+          onChange={(e) => setRawQuery(e.target.value)}
+          style={{
+            width: "100%",
+            padding: "5px 9px 5px 28px",
+            fontSize: "0.72rem",
+            fontFamily: "var(--font-body)",
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius)",
+            color: "var(--text-primary)",
+            outline: "none",
+            boxSizing: "border-box",
+          }}
+        />
+      </div>
+      )}
+
+      {activeTab !== "settings" && loading ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {[...Array(6)].map((_, i) => (
+            <div
+              key={i}
+              style={{
+                height: "32px",
+                background: "var(--bg-surface)",
+                borderRadius: "var(--radius)",
+                opacity: 0.5,
+              }}
+            />
+          ))}
+        </div>
+      ) : (
+        <ActiveSection type={activeTab} data={data} />
+      )}
+    </div>
+  );
+}
+
+function countFor(type: TabKey, data: ReturnType<typeof useConfig>["data"]): number {
+  switch (type) {
+    case "hooks":   return data.hooks.length;
+    case "plugins": return data.plugins.length;
+    case "mcp":     return data.mcp.length;
+    case "cicd":    return data.cicd.reduce((acc, c) => acc + c.cicd.workflows.length, 0);
+    default:        return 0;
+  }
+}
+
+function ActiveSection({
+  type,
+  data,
+}: {
+  type: TabKey;
+  data: ReturnType<typeof useConfig>["data"];
+}) {
+  if (type === "settings") return <ConfigDashboard />;
+  if (type === "hooks") return <HooksList rows={data.hooks} />;
+  if (type === "plugins") return <PluginsList rows={data.plugins} />;
+  if (type === "mcp") return <McpList rows={data.mcp} />;
+  return <CicdList rows={data.cicd} />;
+}
+
+// ─── Lists ───────────────────────────────────────────────────────────────────
+
+function HooksList({ rows }: { rows: HookRow[] }) {
+  if (rows.length === 0) return <Empty label="No hooks configured." />;
+  return (
+    <div>
+      {rows.map((h, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            padding: "7px 0",
+            borderBottom: "1px solid var(--border-subtle)",
+          }}
+        >
+          <Pill tone="info">{h.event}</Pill>
+          <span style={{ flex: 1, minWidth: 0, fontSize: "0.72rem", display: "inline-flex", gap: "6px", alignItems: "center", overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
+            {h.matcher && <code style={inlineCode}>{h.matcher}</code>}
+            <span style={{ color: "var(--text-secondary)", overflow: "hidden", textOverflow: "ellipsis" }}>
+              {commandPreview(h.commands[0]?.command, h.commands.length)}
+            </span>
+          </span>
+          <SourceBadge projectSlug={h.projectSlug} projectName={h.projectName} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PluginsList({ rows }: { rows: PluginEntry[] }) {
+  if (rows.length === 0) return <Empty label="No plugins installed." />;
+  return (
+    <div>
+      {rows.map((p) => {
+        const status: "enabled" | "disabled" | "blocked" = p.blocked
+          ? "blocked"
+          : p.enabled
+          ? "enabled"
+          : "disabled";
+        return (
+          <div
+            key={`${p.name}@${p.marketplace}`}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              padding: "7px 0",
+              borderBottom: "1px solid var(--border-subtle)",
+            }}
+          >
+            <span style={{ flex: 1, minWidth: 0, fontSize: "0.78rem", fontWeight: 600, color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {p.name}
+            </span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.6rem", color: "var(--text-muted)" }}>
+              {p.marketplace}
+            </span>
+            {p.version && (
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.6rem", color: "var(--text-muted)" }}>
+                v{p.version}
+              </span>
+            )}
+            <StatusPill status={status} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function McpList({ rows }: { rows: McpRow[] }) {
+  if (rows.length === 0) return <Empty label="No MCP servers configured." />;
+  return (
+    <div>
+      {rows.map((m, i) => (
+        <div
+          key={`${m.name}-${i}`}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            padding: "7px 0",
+            borderBottom: "1px solid var(--border-subtle)",
+          }}
+        >
+          <span style={{ fontSize: "0.78rem", fontWeight: 600, color: "var(--text-primary)" }}>
+            {m.name}
+          </span>
+          <Pill>{m.transport}</Pill>
+          <span style={{ flex: 1, minWidth: 0, fontSize: "0.68rem", color: "var(--text-secondary)", fontFamily: "var(--font-mono)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {m.command ? `${m.command}${m.args ? " " + m.args.join(" ") : ""}` : m.url ?? ""}
+          </span>
+          {m.envKeys && m.envKeys.length > 0 && (
+            <span style={mutedMono} title={`env: ${m.envKeys.join(", ")}`}>
+              env {m.envKeys.length}
+            </span>
+          )}
+          <SourceBadge projectSlug={m.projectSlug} projectName={m.projectName} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CicdList({ rows }: { rows: CicdRow[] }) {
+  if (rows.length === 0) return <Empty label="No CI/CD configuration detected." />;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      {rows.map((row) => (
+        <div
+          key={row.projectSlug}
+          style={{
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius)",
+            padding: "12px 14px",
+            background: "var(--bg-surface)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <Link
+              href={`/project/${row.projectSlug}`}
+              style={{ fontSize: "0.78rem", fontWeight: 600, color: "var(--text-primary)", textDecoration: "none" }}
+            >
+              {row.projectName}
+            </Link>
+            <span style={mutedMono}>
+              {row.cicd.workflows.length} workflow{row.cicd.workflows.length === 1 ? "" : "s"} ·{" "}
+              {row.cicd.hosting.length} host{row.cicd.hosting.length === 1 ? "" : "s"} ·{" "}
+              {row.cicd.dependabot.length} dependabot
+            </span>
+          </div>
+
+          {row.cicd.hosting.length > 0 && (
+            <div style={{ display: "flex", gap: "4px", flexWrap: "wrap" }}>
+              {row.cicd.hosting.map((h) => (
+                <Pill key={`${h.platform}:${h.sourcePath}`} tone="info">
+                  <Cloud style={{ width: "9px", height: "9px", marginRight: "3px" }} />
+                  {h.platform}
+                </Pill>
+              ))}
+            </div>
+          )}
+
+          {row.cicd.workflows.map((w) => (
+            <WorkflowMini key={w.file} workflow={w} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function WorkflowMini({ workflow: w }: { workflow: Workflow }) {
+  const allUses = Array.from(new Set(w.jobs.flatMap((j) => j.actionUses)));
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "3px", borderTop: "1px solid var(--border-subtle)", paddingTop: "8px" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "6px", flexWrap: "wrap" }}>
+        <code style={inlineCode}>{fileBasename(w.file)}</code>
+        {w.name && <span style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}>{w.name}</span>}
+        {w.triggers.map((t) => (
+          <Pill key={t}>{t}</Pill>
+        ))}
+        {w.cron.map((c) => (
+          <code key={c} style={inlineCode}>{c}</code>
+        ))}
+      </div>
+      {allUses.length > 0 && (
+        <div style={{ display: "flex", gap: "4px", flexWrap: "wrap" }}>
+          {allUses.slice(0, 8).map((u) => (
+            <code key={u} style={inlineCode}>{u}</code>
+          ))}
+          {allUses.length > 8 && <span style={mutedMono}>+{allUses.length - 8}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function SourceBadge({ projectSlug, projectName }: { projectSlug?: string; projectName?: string }) {
+  if (!projectSlug || !projectName) {
+    return (
+      <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.6rem", color: "var(--text-muted)", border: "1px solid var(--border-subtle)", borderRadius: "3px", padding: "1px 5px" }}>
+        user
+      </span>
+    );
+  }
+  return (
+    <Link
+      href={`/project/${projectSlug}`}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6rem",
+        color: "var(--info)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "3px",
+        padding: "1px 5px",
+        textDecoration: "none",
+      }}
+      title={`project: ${projectName}`}
+    >
+      {projectName}
+    </Link>
+  );
+}
+
+function StatusPill({ status }: { status: "enabled" | "disabled" | "blocked" }) {
+  const tone: PillTone =
+    status === "enabled" ? "info" : status === "blocked" ? "warn" : "default";
+  return <Pill tone={tone}>{status}</Pill>;
+}
+
+function Empty({ label }: { label: string }) {
+  return (
+    <div style={{ padding: "40px 0", textAlign: "center", color: "var(--text-muted)", fontSize: "0.78rem" }}>
+      {label}
+    </div>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -57,6 +57,7 @@ export function ProjectCard({ project, onArchive, compact = false, pinned = fals
   })();
 
   const worktreeCount = (project.worktrees ?? []).length;
+  const workflowCount = project.cicd?.workflows.length ?? 0;
   const sessionStatus = project.claude?.mostRecentSessionStatus;
   const sessionId = project.claude?.mostRecentSessionId;
   const sessionBadge = sessionStatus && sessionStatus !== "idle"
@@ -402,6 +403,23 @@ export function ProjectCard({ project, onArchive, compact = false, pinned = fals
                   }}
                 >
                   wt {worktreeCount}
+                </span>
+              )}
+              {workflowCount > 0 && (
+                <span
+                  title={pluralize(workflowCount, "workflow")}
+                  style={{
+                    fontSize: "0.6rem",
+                    fontFamily: "var(--font-mono)",
+                    color: "var(--info)",
+                    border: "1px solid var(--border-subtle)",
+                    background: "var(--bg-elevated)",
+                    padding: "1px 5px",
+                    borderRadius: "3px",
+                    letterSpacing: "0.04em",
+                  }}
+                >
+                  CI
                 </span>
               )}
             </div>

--- a/src/components/ProjectConfigTab.tsx
+++ b/src/components/ProjectConfigTab.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import type {
+  CiCdInfo,
+  DependabotUpdate,
+  HostingTarget,
+  HooksInfo,
+  McpServersInfo,
+  ProjectData,
+  VercelCron,
+  Workflow,
+  WorkflowJob,
+} from "@/lib/types";
+import { Settings, Webhook, Server, Workflow as WorkflowIcon, Cloud } from "lucide-react";
+import {
+  Pill,
+  inlineCode,
+  mutedMono,
+  metaText,
+  commandPreview,
+  fileBasename,
+} from "./config/primitives";
+
+interface Props {
+  project: ProjectData;
+}
+
+export function ProjectConfigTab({ project }: Props) {
+  const { hooks, mcpServers, cicd } = project;
+  const empty = !hooks && !mcpServers && !cicd;
+
+  if (empty) {
+    return (
+      <div
+        style={{
+          padding: "32px 0",
+          textAlign: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "8px",
+        }}
+      >
+        <Settings style={{ width: "24px", height: "24px", color: "var(--text-muted)", opacity: 0.3 }} />
+        <p style={{ fontSize: "0.78rem", color: "var(--text-muted)" }}>
+          No project-local Claude or CI/CD config detected.
+        </p>
+        <p style={{ fontSize: "0.68rem", color: "var(--text-muted)", margin: 0 }}>
+          User-level plugins and hooks live on{" "}
+          <a href="/config" style={{ color: "var(--info)" }}>/config</a>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      {hooks && hooks.entries.length > 0 && <HooksSection hooks={hooks} />}
+      {mcpServers && mcpServers.servers.length > 0 && <McpSection servers={mcpServers} />}
+      {cicd && cicd.workflows.length > 0 && <WorkflowsSection workflows={cicd.workflows} />}
+      {cicd && hasHostingOrAutomation(cicd) && <HostingSection cicd={cicd} />}
+    </div>
+  );
+}
+
+function hasHostingOrAutomation(cicd: CiCdInfo): boolean {
+  return cicd.hosting.length > 0 || cicd.vercelCrons.length > 0 || cicd.dependabot.length > 0;
+}
+
+// ─── Sections ────────────────────────────────────────────────────────────────
+
+function HooksSection({ hooks }: { hooks: HooksInfo }) {
+  return (
+    <Section icon={<Webhook style={iconStyle} />} label="Hooks" count={hooks.entries.length}>
+      {hooks.entries.map((h, i) => (
+        <Row
+          key={i}
+          left={<Pill tone="info">{h.event}</Pill>}
+          middle={
+            <span style={metaText} title={h.commands.map((c) => c.command).join("\n")}>
+              {h.matcher && <code style={inlineCode}>{h.matcher}</code>}
+              {h.matcher && h.commands.length > 0 && " · "}
+              {commandPreview(h.commands[0]?.command, h.commands.length)}
+            </span>
+          }
+          right={
+            <span style={mutedMono}>{h.source === "local" ? "settings.local" : "settings"}</span>
+          }
+        />
+      ))}
+    </Section>
+  );
+}
+
+function McpSection({ servers }: { servers: McpServersInfo }) {
+  return (
+    <Section icon={<Server style={iconStyle} />} label="MCP Servers" count={servers.servers.length}>
+      {servers.servers.map((s) => (
+        <Row
+          key={s.name}
+          left={
+            <span style={{ fontSize: "0.78rem", fontWeight: 600, color: "var(--text-primary)" }}>
+              {s.name}
+            </span>
+          }
+          middle={
+            <span style={metaText} title={s.command ?? s.url ?? ""}>
+              <Pill>{s.transport}</Pill>
+              {s.command && <code style={inlineCode}>{s.command}{s.args && s.args.length > 0 ? ` ${s.args.join(" ")}` : ""}</code>}
+              {s.url && <code style={inlineCode}>{s.url}</code>}
+            </span>
+          }
+          right={
+            s.envKeys && s.envKeys.length > 0 ? (
+              <span style={mutedMono} title={`env: ${s.envKeys.join(", ")}`}>
+                env {s.envKeys.length}
+              </span>
+            ) : null
+          }
+        />
+      ))}
+    </Section>
+  );
+}
+
+function WorkflowsSection({ workflows }: { workflows: Workflow[] }) {
+  return (
+    <Section
+      icon={<WorkflowIcon style={iconStyle} />}
+      label="GitHub Workflows"
+      count={workflows.length}
+    >
+      {workflows.map((w) => (
+        <div
+          key={w.file}
+          style={{
+            padding: "7px 0",
+            borderBottom: "1px solid var(--border-subtle)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "4px",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+            <span style={{ fontSize: "0.78rem", fontWeight: 600, color: "var(--text-primary)" }}>
+              {w.name ?? fileBasename(w.file)}
+            </span>
+            {!w.parseOk && <Pill tone="warn">parse failed</Pill>}
+            {w.triggers.map((t) => (
+              <Pill key={t}>{t}</Pill>
+            ))}
+            {w.cron.map((c) => (
+              <code key={c} style={inlineCode}>{c}</code>
+            ))}
+          </div>
+          {w.jobs.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: "2px", paddingLeft: "2px" }}>
+              {w.jobs.map((j) => (
+                <JobRow key={j.id} job={j} />
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </Section>
+  );
+}
+
+function JobRow({ job }: { job: WorkflowJob }) {
+  const usesText = job.actionUses.length > 0 ? job.actionUses.join(", ") : null;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "6px", flexWrap: "wrap" }}>
+      <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--text-secondary)" }}>
+        {job.name ?? job.id}
+      </span>
+      {job.runsOn && <span style={mutedMono}>{job.runsOn}</span>}
+      {job.uses && <code style={inlineCode}>{job.uses}</code>}
+      {usesText && (
+        <span style={mutedMono} title={usesText}>
+          {job.actionUses.length} action{job.actionUses.length === 1 ? "" : "s"}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function HostingSection({ cicd }: { cicd: CiCdInfo }) {
+  return (
+    <Section
+      icon={<Cloud style={iconStyle} />}
+      label="Hosting & Automation"
+      count={cicd.hosting.length + cicd.vercelCrons.length + cicd.dependabot.length}
+    >
+      {cicd.hosting.map((h) => (
+        <HostingRow key={`${h.platform}:${h.sourcePath}`} target={h} />
+      ))}
+      {cicd.vercelCrons.map((c, i) => (
+        <VercelCronRow key={i} cron={c} />
+      ))}
+      {cicd.dependabot.map((d, i) => (
+        <DependabotRow key={i} update={d} />
+      ))}
+    </Section>
+  );
+}
+
+function HostingRow({ target }: { target: HostingTarget }) {
+  const detailLines = target.detail
+    ? Object.entries(target.detail).map(([k, v]) => `${k}=${formatDetailValue(v)}`)
+    : [];
+
+  return (
+    <Row
+      left={<Pill tone="info">{target.platform}</Pill>}
+      middle={
+        <span style={metaText}>
+          <code style={inlineCode}>{fileBasename(target.sourcePath)}</code>
+          {detailLines.length > 0 && (
+            <span style={{ marginLeft: "6px", color: "var(--text-secondary)" }}>
+              {detailLines.join(" · ")}
+            </span>
+          )}
+        </span>
+      }
+      right={null}
+    />
+  );
+}
+
+function VercelCronRow({ cron }: { cron: VercelCron }) {
+  return (
+    <Row
+      left={<Pill tone="info">cron</Pill>}
+      middle={
+        <span style={metaText}>
+          <code style={inlineCode}>{cron.schedule}</code>
+          <span style={{ marginLeft: "6px", color: "var(--text-secondary)" }}>{cron.path}</span>
+        </span>
+      }
+      right={<span style={mutedMono}>vercel.json</span>}
+    />
+  );
+}
+
+function DependabotRow({ update }: { update: DependabotUpdate }) {
+  return (
+    <Row
+      left={<Pill>dependabot</Pill>}
+      middle={
+        <span style={metaText}>
+          <code style={inlineCode}>{update.ecosystem}</code>
+          {update.directory && (
+            <span style={{ marginLeft: "6px", color: "var(--text-secondary)" }}>{update.directory}</span>
+          )}
+        </span>
+      }
+      right={update.schedule ? <span style={mutedMono}>{update.schedule}</span> : null}
+    />
+  );
+}
+
+// ─── Layout primitives ───────────────────────────────────────────────────────
+
+function Section({
+  icon,
+  label,
+  count,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={{ marginTop: "16px" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          marginBottom: "6px",
+          fontSize: "0.6rem",
+          fontWeight: 700,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-body)",
+        }}
+      >
+        {icon}
+        <span>{label}</span>
+        <span style={{ fontWeight: 400 }}>({count})</span>
+      </div>
+      <div>{children}</div>
+    </section>
+  );
+}
+
+function Row({
+  left,
+  middle,
+  right,
+}: {
+  left: React.ReactNode;
+  middle: React.ReactNode;
+  right: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "7px 0",
+        borderBottom: "1px solid var(--border-subtle)",
+      }}
+    >
+      <span style={{ flexShrink: 0 }}>{left}</span>
+      <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {middle}
+      </span>
+      {right && <span style={{ flexShrink: 0 }}>{right}</span>}
+    </div>
+  );
+}
+
+const iconStyle: React.CSSProperties = {
+  width: "12px",
+  height: "12px",
+  color: "var(--text-muted)",
+};
+
+function formatDetailValue(v: string | number | boolean | string[]): string {
+  if (Array.isArray(v)) return v.join(", ");
+  return String(v);
+}

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -15,6 +15,7 @@ import { MarkdownContent } from "./MarkdownContent";
 import { MemoryTab } from "./MemoryTab";
 import { ProjectAgentsTab } from "./ProjectAgentsTab";
 import { ProjectSkillsTab } from "./ProjectSkillsTab";
+import { ProjectConfigTab } from "./ProjectConfigTab";
 import {
   ArrowLeft,
   ExternalLink,
@@ -32,7 +33,7 @@ import { formatDistanceToNow } from "date-fns";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-type TabKey = "overview" | "context" | "todos" | "sessions" | "manual-steps" | "insights" | "memory" | "agents" | "skills";
+type TabKey = "overview" | "context" | "todos" | "sessions" | "manual-steps" | "insights" | "memory" | "agents" | "skills" | "config";
 
 interface ProjectDetailProps {
   project: ProjectData;
@@ -102,6 +103,7 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
     project.worktrees?.some((wt) => (wt.insights?.total ?? 0) > 0)
   );
   const hasSessions = !!(project.claude && project.claude.sessionCount > 0);
+  const hasConfig = !!(project.hooks || project.mcpServers || project.cicd);
 
   const tabs: { key: TabKey; label: string }[] = [
     { key: "overview",    label: "Overview" },
@@ -113,6 +115,7 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
     { key: "memory",      label: "Memory" },
     { key: "agents",      label: "Agents" },
     { key: "skills",      label: "Skills" },
+    ...(hasConfig       ? [{ key: "config"       as TabKey, label: "Config"       }] : []),
   ];
 
   const actionBtn = (label: string, icon: React.ReactNode, onClick: () => void, href?: string) => {
@@ -504,6 +507,11 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
           {/* ── SKILLS ───────────────────────────────────────────────── */}
           {activeTab === "skills" && (
             <ProjectSkillsTab slug={project.slug} />
+          )}
+
+          {/* ── CONFIG ───────────────────────────────────────────────── */}
+          {activeTab === "config" && (
+            <ProjectConfigTab project={project} />
           )}
         </div>
       </div>

--- a/src/components/SparklineList.tsx
+++ b/src/components/SparklineList.tsx
@@ -13,6 +13,59 @@ import { pluralize } from "@/lib/utils";
 type SortKey = "name" | "activity" | "lastSession" | "todos" | "branch";
 type SortDir = "asc" | "desc";
 
+function ColHeader({
+  label,
+  k,
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  label: string;
+  k: SortKey;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (k: SortKey) => void;
+}) {
+  const active = sortKey === k;
+  return (
+    <th
+      scope="col"
+      aria-sort={active ? (sortDir === "desc" ? "descending" : "ascending") : "none"}
+      style={{
+        padding: 0,
+        textAlign: "left",
+        borderBottom: "1px solid var(--border-subtle)",
+        background: "var(--bg-base)",
+      }}
+    >
+      <button
+        onClick={() => onSort(k)}
+        style={{
+          display: "block", width: "100%", textAlign: "left",
+          padding: "6px 10px",
+          fontSize: "0.65rem",
+          fontFamily: "var(--font-mono)",
+          fontWeight: active ? 600 : 500,
+          color: active ? "var(--info)" : "var(--text-muted)",
+          letterSpacing: "0.04em",
+          textTransform: "uppercase",
+          cursor: "pointer",
+          userSelect: "none",
+          whiteSpace: "nowrap",
+          background: "none", border: "none",
+        }}
+      >
+        {label}
+        {active && (
+          <span style={{ marginLeft: "3px", opacity: 0.7 }}>
+            {sortDir === "desc" ? "↓" : "↑"}
+          </span>
+        )}
+      </button>
+    </th>
+  );
+}
+
 interface SparklineListProps {
   projects: ProjectData[];
   activityData: Record<string, number[]>;
@@ -70,58 +123,17 @@ export function SparklineList({ projects, activityData, pinnedSlugs, onTogglePin
     return result;
   }, [projects, sortKey, sortDir, pinnedSlugs, sortKeys]);
 
-  const ColHeader = ({ label, k }: { label: string; k: SortKey }) => {
-    const active = sortKey === k;
-    return (
-      <th
-        scope="col"
-        aria-sort={active ? (sortDir === "desc" ? "descending" : "ascending") : "none"}
-        style={{
-          padding: 0,
-          textAlign: "left",
-          borderBottom: "1px solid var(--border-subtle)",
-          background: "var(--bg-base)",
-        }}
-      >
-        <button
-          onClick={() => toggleSort(k)}
-          style={{
-            display: "block", width: "100%", textAlign: "left",
-            padding: "6px 10px",
-            fontSize: "0.65rem",
-            fontFamily: "var(--font-mono)",
-            fontWeight: active ? 600 : 500,
-            color: active ? "var(--info)" : "var(--text-muted)",
-            letterSpacing: "0.04em",
-            textTransform: "uppercase",
-            cursor: "pointer",
-            userSelect: "none",
-            whiteSpace: "nowrap",
-            background: "none", border: "none",
-          }}
-        >
-          {label}
-          {active && (
-            <span style={{ marginLeft: "3px", opacity: 0.7 }}>
-              {sortDir === "desc" ? "↓" : "↑"}
-            </span>
-          )}
-        </button>
-      </th>
-    );
-  };
-
   return (
     <div style={{ width: "100%", overflowX: "auto" }}>
       <table style={{ width: "100%", borderCollapse: "collapse" }}>
         <thead>
           <tr>
             <th scope="col" style={{ width: "28px", borderBottom: "1px solid var(--border-subtle)", background: "var(--bg-base)", padding: "6px 4px 6px 10px", fontSize: "0.65rem", fontFamily: "var(--font-mono)", color: "var(--text-muted)", letterSpacing: "0.04em", textTransform: "uppercase" }}>Pin</th>
-            <ColHeader label="Project" k="name" />
-            <ColHeader label="14-day activity" k="activity" />
-            <ColHeader label="Last session" k="lastSession" />
-            <ColHeader label="Branch" k="branch" />
-            <ColHeader label="Todos" k="todos" />
+            <ColHeader label="Project"          k="name"        sortKey={sortKey} sortDir={sortDir} onSort={toggleSort} />
+            <ColHeader label="14-day activity"  k="activity"    sortKey={sortKey} sortDir={sortDir} onSort={toggleSort} />
+            <ColHeader label="Last session"     k="lastSession" sortKey={sortKey} sortDir={sortDir} onSort={toggleSort} />
+            <ColHeader label="Branch"           k="branch"      sortKey={sortKey} sortDir={sortDir} onSort={toggleSort} />
+            <ColHeader label="Todos"            k="todos"       sortKey={sortKey} sortDir={sortDir} onSort={toggleSort} />
             <th
               scope="col"
               style={{

--- a/src/components/config/primitives.tsx
+++ b/src/components/config/primitives.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export type PillTone = "default" | "info" | "warn";
+
+export function Pill({ children, tone = "default" }: { children: ReactNode; tone?: PillTone }) {
+  const color =
+    tone === "info" ? "var(--info)" : tone === "warn" ? "var(--accent)" : "var(--text-secondary)";
+  return (
+    <span
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6rem",
+        color,
+        background: "var(--bg-surface)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "3px",
+        padding: "1px 5px",
+        flexShrink: 0,
+        display: "inline-flex",
+        alignItems: "center",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export const inlineCode: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.65rem",
+  color: "var(--text-secondary)",
+  background: "var(--bg-elevated)",
+  border: "1px solid var(--border-subtle)",
+  borderRadius: "3px",
+  padding: "1px 5px",
+};
+
+export const mutedMono: React.CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.6rem",
+  color: "var(--text-muted)",
+};
+
+export const metaText: React.CSSProperties = {
+  fontSize: "0.72rem",
+  color: "var(--text-secondary)",
+  fontFamily: "var(--font-body)",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "6px",
+  flexWrap: "wrap",
+  minWidth: 0,
+};
+
+export function commandPreview(text: string | undefined, total: number, max = 80): string {
+  if (!text) return "";
+  const trimmed = text.length > max ? text.slice(0, max) + "…" : text;
+  return total > 1 ? `${trimmed}  (+${total - 1})` : trimmed;
+}
+
+export function fileBasename(p: string): string {
+  return p.split(/[\\/]/).pop() ?? p;
+}

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+  CiCdInfo,
+  ConfigType,
+  HookEntry,
+  McpServer,
+  PluginEntry,
+} from "@/lib/types";
+
+export type { ConfigType };
+
+export interface HookRow extends HookEntry {
+  projectSlug?: string;
+  projectName?: string;
+}
+
+export interface McpRow extends McpServer {
+  projectSlug?: string;
+  projectName?: string;
+}
+
+export interface CicdRow {
+  projectSlug: string;
+  projectName: string;
+  cicd: CiCdInfo;
+}
+
+export interface ConfigPayload {
+  hooks: HookRow[];
+  plugins: PluginEntry[];
+  mcp: McpRow[];
+  cicd: CicdRow[];
+}
+
+const empty: ConfigPayload = { hooks: [], plugins: [], mcp: [], cicd: [] };
+
+export function useConfig(
+  type: ConfigType | undefined = "all",
+  project?: string,
+  query?: string
+) {
+  const [data, setData] = useState<ConfigPayload>(empty);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    if (!type) {
+      setLoading(false);
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set("type", type);
+    if (project) params.set("project", project);
+    if (query) params.set("q", query);
+    try {
+      const res = await fetch(`/api/claude-config?${params.toString()}`);
+      if (res.ok) setData(await res.json());
+    } finally {
+      setLoading(false);
+    }
+  }, [type, project, query]);
+
+  useEffect(() => {
+    setLoading(true);
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, refresh };
+}

--- a/src/lib/scanner/cicd.ts
+++ b/src/lib/scanner/cicd.ts
@@ -1,0 +1,479 @@
+import { promises as fs } from "fs";
+import path from "path";
+import yaml from "js-yaml";
+import {
+  CiCdInfo,
+  DependabotUpdate,
+  HostingTarget,
+  VercelCron,
+  Workflow,
+  WorkflowJob,
+} from "../types";
+import { tryParseJsonc } from "./util/jsonc";
+
+/**
+ * Scan CI/CD-related config across the project.
+ *
+ * Parsing depth follows the "per-unit, semantic" rule from the design plan:
+ * each row should be a unit a future template-builder could pick up and
+ * drop into another project (a job, a cron, an ecosystem update block).
+ */
+export async function scanCiCd(
+  projectPath: string
+): Promise<CiCdInfo | undefined> {
+  const [workflows, dependabot, vercel, hostingOthers, dockerfile] =
+    await Promise.all([
+      scanWorkflows(projectPath),
+      scanDependabot(projectPath),
+      scanVercel(projectPath),
+      scanOtherHosting(projectPath),
+      scanDockerfile(projectPath),
+    ]);
+
+  const hosting: HostingTarget[] = [
+    ...vercel.hosting,
+    ...hostingOthers,
+    ...(dockerfile ? [dockerfile] : []),
+  ];
+
+  const empty =
+    workflows.length === 0 &&
+    dependabot.length === 0 &&
+    hosting.length === 0 &&
+    vercel.crons.length === 0;
+
+  if (empty) return undefined;
+
+  return {
+    workflows,
+    hosting,
+    vercelCrons: vercel.crons,
+    dependabot,
+  };
+}
+
+// ─── GitHub Actions workflows ────────────────────────────────────────────────
+
+async function scanWorkflows(projectPath: string): Promise<Workflow[]> {
+  const dir = path.join(projectPath, ".github", "workflows");
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const files = entries.filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+  const workflows = await Promise.all(
+    files.map(async (file): Promise<Workflow> => {
+      const filePath = path.join(dir, file);
+      const raw = await tryRead(filePath);
+      if (raw === null) {
+        return { file: filePath, triggers: [], cron: [], jobs: [], parseOk: false };
+      }
+      return parseWorkflow(raw, filePath);
+    })
+  );
+
+  workflows.sort((a, b) => a.file.localeCompare(b.file));
+  return workflows;
+}
+
+export function parseWorkflow(raw: string, filePath: string): Workflow {
+  let doc: unknown;
+  try {
+    doc = yaml.load(raw, { schema: yaml.DEFAULT_SCHEMA });
+  } catch {
+    return { file: filePath, triggers: [], cron: [], jobs: [], parseOk: false };
+  }
+  if (!doc || typeof doc !== "object") {
+    return { file: filePath, triggers: [], cron: [], jobs: [], parseOk: false };
+  }
+
+  // js-yaml parses `on:` as the boolean `true` (YAML 1.1 quirk). Look it up
+  // by both the key name and that quirk.
+  const docObj = doc as Record<string, unknown> & { true?: unknown };
+  const onValue = docObj.on ?? docObj.true;
+  const { triggers, cron } = normalizeTriggers(onValue);
+
+  const name = typeof docObj.name === "string" ? docObj.name : undefined;
+  const jobs = parseJobs(docObj.jobs);
+
+  return { file: filePath, name, triggers, cron, jobs, parseOk: true };
+}
+
+function normalizeTriggers(on: unknown): { triggers: string[]; cron: string[] } {
+  const triggers: string[] = [];
+  const cron: string[] = [];
+
+  if (typeof on === "string") {
+    triggers.push(on);
+  } else if (Array.isArray(on)) {
+    for (const t of on) {
+      if (typeof t === "string") triggers.push(t);
+    }
+  } else if (on && typeof on === "object") {
+    for (const [key, val] of Object.entries(on as Record<string, unknown>)) {
+      triggers.push(key);
+      if (key === "schedule" && Array.isArray(val)) {
+        for (const item of val) {
+          if (item && typeof item === "object") {
+            const c = (item as { cron?: unknown }).cron;
+            if (typeof c === "string") cron.push(c);
+          }
+        }
+      }
+    }
+  }
+
+  return { triggers: Array.from(new Set(triggers)), cron };
+}
+
+function parseJobs(value: unknown): WorkflowJob[] {
+  if (!value || typeof value !== "object") return [];
+  const out: WorkflowJob[] = [];
+
+  for (const [id, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object") continue;
+    const job = raw as {
+      name?: unknown;
+      "runs-on"?: unknown;
+      runs_on?: unknown;
+      uses?: unknown;
+      steps?: unknown;
+    };
+
+    const runsOn = pickRunsOn(job["runs-on"] ?? job.runs_on);
+    const actionUses = collectActionUses(job.steps);
+
+    out.push({
+      id,
+      name: typeof job.name === "string" ? job.name : undefined,
+      runsOn,
+      uses: typeof job.uses === "string" ? job.uses : undefined,
+      actionUses,
+    });
+  }
+
+  return out;
+}
+
+function pickRunsOn(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value.filter((v) => typeof v === "string").join(", ") || undefined;
+  }
+  return undefined;
+}
+
+function collectActionUses(steps: unknown): string[] {
+  if (!Array.isArray(steps)) return [];
+  const seen = new Set<string>();
+  for (const s of steps) {
+    if (!s || typeof s !== "object") continue;
+    const uses = (s as { uses?: unknown }).uses;
+    if (typeof uses === "string" && uses.length > 0) seen.add(uses);
+  }
+  return Array.from(seen);
+}
+
+// ─── Dependabot ──────────────────────────────────────────────────────────────
+
+async function scanDependabot(projectPath: string): Promise<DependabotUpdate[]> {
+  for (const candidate of [".github/dependabot.yml", ".github/dependabot.yaml"]) {
+    const filePath = path.join(projectPath, candidate);
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      return parseDependabot(raw, filePath);
+    } catch {
+      // Try next candidate.
+    }
+  }
+  return [];
+}
+
+export function parseDependabot(raw: string, filePath: string): DependabotUpdate[] {
+  let doc: unknown;
+  try {
+    doc = yaml.load(raw, { schema: yaml.DEFAULT_SCHEMA });
+  } catch {
+    return [];
+  }
+  const updates = (doc as { updates?: unknown })?.updates;
+  if (!Array.isArray(updates)) return [];
+
+  const out: DependabotUpdate[] = [];
+  for (const u of updates) {
+    if (!u || typeof u !== "object") continue;
+    const entry = u as {
+      "package-ecosystem"?: unknown;
+      directory?: unknown;
+      schedule?: unknown;
+    };
+    const ecosystem = entry["package-ecosystem"];
+    if (typeof ecosystem !== "string") continue;
+    const directory = typeof entry.directory === "string" ? entry.directory : undefined;
+    const interval = pickScheduleInterval(entry.schedule);
+    out.push({ ecosystem, directory, schedule: interval, sourcePath: filePath });
+  }
+  return out;
+}
+
+function pickScheduleInterval(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const v = (value as { interval?: unknown }).interval;
+  return typeof v === "string" ? v : undefined;
+}
+
+// ─── Vercel ──────────────────────────────────────────────────────────────────
+
+interface VercelScanResult {
+  crons: VercelCron[];
+  hosting: HostingTarget[];
+}
+
+async function scanVercel(projectPath: string): Promise<VercelScanResult> {
+  const jsonPath = path.join(projectPath, "vercel.json");
+  const tsPath = path.join(projectPath, "vercel.ts");
+
+  const [jsonRaw, tsRaw] = await Promise.all([tryRead(jsonPath), tryRead(tsPath)]);
+  const result: VercelScanResult = { crons: [], hosting: [] };
+
+  if (jsonRaw !== null) {
+    const doc = tryParseJsonc<{
+      crons?: unknown;
+      framework?: unknown;
+      buildCommand?: unknown;
+    }>(jsonRaw);
+    if (doc) {
+      const crons = parseVercelCrons(doc.crons, jsonPath);
+      result.crons.push(...crons);
+
+      const detail: Record<string, string | number | boolean | string[]> = {};
+      if (typeof doc.framework === "string") detail.framework = doc.framework;
+      if (typeof doc.buildCommand === "string") detail.buildCommand = doc.buildCommand;
+      if (crons.length > 0) detail.crons = crons.length;
+
+      result.hosting.push({
+        platform: "vercel",
+        sourcePath: jsonPath,
+        detail: Object.keys(detail).length > 0 ? detail : undefined,
+      });
+    }
+  }
+
+  if (tsRaw !== null && !result.hosting.some((h) => h.platform === "vercel")) {
+    result.hosting.push({ platform: "vercel", sourcePath: tsPath });
+  }
+
+  return result;
+}
+
+function parseVercelCrons(value: unknown, sourcePath: string): VercelCron[] {
+  if (!Array.isArray(value)) return [];
+  const out: VercelCron[] = [];
+  for (const c of value) {
+    if (!c || typeof c !== "object") continue;
+    const entry = c as { path?: unknown; schedule?: unknown };
+    if (typeof entry.path !== "string" || typeof entry.schedule !== "string") continue;
+    out.push({ path: entry.path, schedule: entry.schedule, sourcePath });
+  }
+  return out;
+}
+
+// ─── Other hosting targets ───────────────────────────────────────────────────
+
+async function scanOtherHosting(projectPath: string): Promise<HostingTarget[]> {
+  const railwayTomlPath = path.join(projectPath, "railway.toml");
+  const railwayJsonPath = path.join(projectPath, "railway.json");
+  const flyPath         = path.join(projectPath, "fly.toml");
+  const renderPath      = path.join(projectPath, "render.yaml");
+  const netlifyPath     = path.join(projectPath, "netlify.toml");
+  const procfilePath    = path.join(projectPath, "Procfile");
+  const appJsonPath     = path.join(projectPath, "app.json");
+
+  const [railwayToml, railwayJson, fly, render, netlify, procfile, appJson] = await Promise.all([
+    tryRead(railwayTomlPath),
+    tryRead(railwayJsonPath),
+    tryRead(flyPath),
+    tryRead(renderPath),
+    tryRead(netlifyPath),
+    tryRead(procfilePath),
+    tryRead(appJsonPath),
+  ]);
+
+  const out: HostingTarget[] = [];
+
+  if (railwayToml !== null) {
+    out.push({
+      platform: "railway",
+      sourcePath: railwayTomlPath,
+      detail: parseTomlScalars(railwayToml, ["app", "name"]),
+    });
+  } else if (railwayJson !== null) {
+    out.push({
+      platform: "railway",
+      sourcePath: railwayJsonPath,
+      detail: parseJsonScalars(railwayJson, ["name", "build", "deploy"]),
+    });
+  }
+
+  if (fly !== null) {
+    out.push({
+      platform: "fly",
+      sourcePath: flyPath,
+      detail: parseTomlScalars(fly, ["app", "primary_region"]),
+    });
+  }
+
+  if (render !== null) {
+    out.push({
+      platform: "render",
+      sourcePath: renderPath,
+      detail: parseRenderDetail(render),
+    });
+  }
+
+  if (netlify !== null) {
+    out.push({
+      platform: "netlify",
+      sourcePath: netlifyPath,
+      detail: parseNetlifyDetail(netlify),
+    });
+  }
+
+  if (procfile !== null || appJson !== null) {
+    const detail: Record<string, string | number | boolean | string[]> = {};
+    if (procfile !== null) {
+      detail.processes = parseProcfile(procfile);
+    }
+    if (appJson !== null) {
+      const doc = tryParseJsonc<{ name?: unknown; description?: unknown }>(appJson);
+      if (typeof doc?.name === "string") detail.name = doc.name;
+      if (typeof doc?.description === "string") detail.description = doc.description;
+    }
+    out.push({
+      platform: "heroku",
+      sourcePath: procfile !== null ? procfilePath : appJsonPath,
+      detail: Object.keys(detail).length > 0 ? detail : undefined,
+    });
+  }
+
+  return out;
+}
+
+function parseTomlScalars(
+  raw: string,
+  keys: string[]
+): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    if (/^\s*\[.+\]\s*$/.test(line)) break;
+    for (const k of keys) {
+      const matched = line.match(new RegExp(`^\\s*${escapeRegex(k)}\\s*=\\s*"([^"]*)"`));
+      if (matched) out[k] = matched[1];
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function parseJsonScalars(
+  raw: string,
+  keys: string[]
+): Record<string, string | number | boolean | string[]> | undefined {
+  const doc = tryParseJsonc<Record<string, unknown>>(raw);
+  if (!doc) return undefined;
+  const out: Record<string, string | number | boolean | string[]> = {};
+  for (const k of keys) {
+    const v = doc[k];
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function parseRenderDetail(
+  raw: string
+): Record<string, string | number | boolean | string[]> | undefined {
+  let doc: { services?: Array<{ name?: unknown }> };
+  try {
+    doc = yaml.load(raw, { schema: yaml.DEFAULT_SCHEMA }) as typeof doc;
+  } catch {
+    return undefined;
+  }
+  const services = Array.isArray(doc?.services) ? doc.services : [];
+  const names: string[] = [];
+  for (const s of services) {
+    if (s && typeof s.name === "string") names.push(s.name);
+  }
+  return names.length > 0 ? { services: names } : undefined;
+}
+
+function parseNetlifyDetail(raw: string): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  let inBuild = false;
+
+  for (const line of raw.split(/\r?\n/)) {
+    const sect = line.match(/^\s*\[(.+)\]\s*$/);
+    if (sect) {
+      inBuild = sect[1].trim() === "build";
+      continue;
+    }
+    if (!inBuild) continue;
+
+    const cmd = line.match(/^\s*command\s*=\s*"([^"]*)"/);
+    const pub = line.match(/^\s*publish\s*=\s*"([^"]*)"/);
+    if (cmd) out.command = cmd[1];
+    if (pub) out.publish = pub[1];
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function parseProcfile(raw: string): string[] {
+  const out: string[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const m = line.match(/^([a-zA-Z0-9_]+):\s*\S/);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+// ─── Dockerfile ──────────────────────────────────────────────────────────────
+
+async function scanDockerfile(projectPath: string): Promise<HostingTarget | null> {
+  const filePath = path.join(projectPath, "Dockerfile");
+  const raw = await tryRead(filePath);
+  if (raw === null) return null;
+  const baseImage = parseFirstFrom(raw);
+  return {
+    platform: "docker",
+    sourcePath: filePath,
+    detail: baseImage ? { baseImage } : undefined,
+  };
+}
+
+function parseFirstFrom(raw: string): string | undefined {
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const m = trimmed.match(/^FROM\s+(\S+)/i);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Read a file as utf-8, returning `null` on any error (ENOENT, permissions, etc). */
+async function tryRead(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/lib/scanner/claudeHooks.ts
+++ b/src/lib/scanner/claudeHooks.ts
@@ -1,0 +1,82 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { HookCommand, HookEntry, HookSource, HooksInfo } from "../types";
+import { tryParseJsonc } from "./util/jsonc";
+
+/**
+ * Reads `.claude/settings.json` and `.claude/settings.local.json` and
+ * extracts hook entries (PreToolUse, PostToolUse, SessionStart, etc.).
+ * Each entry retains its source file path so a future template-builder
+ * can copy units across projects.
+ */
+export async function scanClaudeHooks(
+  projectPath: string
+): Promise<HooksInfo | undefined> {
+  const sources: { file: string; source: HookSource }[] = [
+    { file: ".claude/settings.json",       source: "project" },
+    { file: ".claude/settings.local.json", source: "local"   },
+  ];
+
+  const entries: HookEntry[] = [];
+
+  for (const { file, source } of sources) {
+    const absolute = path.join(projectPath, file);
+    try {
+      const raw = await fs.readFile(absolute, "utf-8");
+      const doc = tryParseJsonc<Record<string, unknown>>(raw);
+      if (!doc || typeof doc !== "object") continue;
+
+      const hooks = (doc as { hooks?: unknown }).hooks;
+      entries.push(...extractHookEntries(hooks, source, absolute));
+    } catch {
+      // File doesn't exist or couldn't be read — skip silently.
+    }
+  }
+
+  if (entries.length === 0) return undefined;
+  return { entries };
+}
+
+export function extractHookEntries(
+  hooks: unknown,
+  source: HookSource,
+  sourcePath: string
+): HookEntry[] {
+  const out: HookEntry[] = [];
+  if (!hooks || typeof hooks !== "object") return out;
+
+  for (const [event, group] of Object.entries(hooks as Record<string, unknown>)) {
+    if (!Array.isArray(group)) continue;
+
+    for (const entry of group) {
+      if (!entry || typeof entry !== "object") continue;
+      const e = entry as { matcher?: unknown; hooks?: unknown };
+
+      const matcher = typeof e.matcher === "string" ? e.matcher : undefined;
+      const commands = normalizeCommands(e.hooks);
+      if (commands.length === 0) continue;
+
+      out.push({ event, matcher, commands, source, sourcePath });
+    }
+  }
+
+  return out;
+}
+
+function normalizeCommands(value: unknown): HookCommand[] {
+  if (!Array.isArray(value)) return [];
+  const out: HookCommand[] = [];
+
+  for (const cmd of value) {
+    if (!cmd || typeof cmd !== "object") continue;
+    const c = cmd as { type?: unknown; command?: unknown; timeout?: unknown };
+    if (typeof c.command !== "string" || c.command.length === 0) continue;
+    out.push({
+      type: "command",
+      command: c.command,
+      timeout: typeof c.timeout === "number" ? c.timeout : undefined,
+    });
+  }
+
+  return out;
+}

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -11,6 +11,9 @@ import { scanTodoMd } from "./todoMd";
 import { scanClaudeSessions } from "./claudeSessions";
 import { scanManualStepsMd } from "./manualStepsMd";
 import { scanInsightsMd } from "./insightsMd";
+import { scanClaudeHooks } from "./claudeHooks";
+import { scanMcpServers } from "./mcpServers";
+import { scanCiCd } from "./cicd";
 import { attachWorktreeOverlays } from "./worktrees";
 
 function toSlug(dirName: string): string {
@@ -33,18 +36,33 @@ async function scanProject(dirName: string, devRoot: string): Promise<ProjectDat
 
   const slug = toSlug(dirName);
 
-  const [pkgResult, envResult, dockerResult, gitResult, claudeMd, todos, claudeSessions, manualSteps, insights] =
-    await Promise.all([
-      scanPackageJson(projectPath),
-      scanEnvFiles(projectPath),
-      scanDockerCompose(projectPath),
-      scanGit(projectPath),
-      scanClaudeMd(projectPath),
-      scanTodoMd(projectPath),
-      scanClaudeSessions(projectPath),
-      scanManualStepsMd(projectPath),
-      scanInsightsMd(projectPath),
-    ]);
+  const [
+    pkgResult,
+    envResult,
+    dockerResult,
+    gitResult,
+    claudeMd,
+    todos,
+    claudeSessions,
+    manualSteps,
+    insights,
+    hooks,
+    mcpServers,
+    cicd,
+  ] = await Promise.all([
+    scanPackageJson(projectPath),
+    scanEnvFiles(projectPath),
+    scanDockerCompose(projectPath),
+    scanGit(projectPath),
+    scanClaudeMd(projectPath),
+    scanTodoMd(projectPath),
+    scanClaudeSessions(projectPath),
+    scanManualStepsMd(projectPath),
+    scanInsightsMd(projectPath),
+    scanClaudeHooks(projectPath),
+    scanMcpServers(projectPath),
+    scanCiCd(projectPath),
+  ]);
 
   // Determine DB port from env or docker
   let dbPort: number | undefined;
@@ -94,6 +112,9 @@ async function scanProject(dirName: string, devRoot: string): Promise<ProjectDat
     todos,
     manualSteps,
     insights,
+    hooks,
+    mcpServers,
+    cicd,
     lastActivity,
     scannedAt: new Date().toISOString(),
   };

--- a/src/lib/scanner/mcpServers.ts
+++ b/src/lib/scanner/mcpServers.ts
@@ -1,0 +1,78 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { McpServer, McpServersInfo, McpSource, McpTransport } from "../types";
+import { tryParseJsonc } from "./util/jsonc";
+
+/** Read project-level `.mcp.json` and return server entries. */
+export async function scanMcpServers(
+  projectPath: string
+): Promise<McpServersInfo | undefined> {
+  const file = path.join(projectPath, ".mcp.json");
+  try {
+    const raw = await fs.readFile(file, "utf-8");
+    const doc = tryParseJsonc<{ mcpServers?: Record<string, unknown> }>(raw);
+    if (!doc?.mcpServers) return undefined;
+
+    const servers = parseMcpServers(doc.mcpServers, "project", file);
+    if (servers.length === 0) return undefined;
+    return { servers };
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseMcpServers(
+  map: unknown,
+  source: McpSource,
+  sourcePath: string
+): McpServer[] {
+  if (!map || typeof map !== "object") return [];
+  const out: McpServer[] = [];
+
+  for (const [name, raw] of Object.entries(map as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object") continue;
+    const entry = raw as {
+      command?: unknown;
+      args?: unknown;
+      url?: unknown;
+      type?: unknown;
+      env?: unknown;
+    };
+
+    const command = typeof entry.command === "string" ? entry.command : undefined;
+    const url = typeof entry.url === "string" ? entry.url : undefined;
+    const declared =
+      typeof entry.type === "string" ? entry.type.toLowerCase() : "";
+
+    let transport: McpTransport = "unknown";
+    if (declared === "stdio" || declared === "http" || declared === "sse") {
+      transport = declared;
+    } else if (command) {
+      transport = "stdio";
+    } else if (url) {
+      transport = "http";
+    }
+
+    const args = Array.isArray(entry.args)
+      ? (entry.args.filter((a) => typeof a === "string") as string[])
+      : undefined;
+
+    const envKeys =
+      entry.env && typeof entry.env === "object"
+        ? Object.keys(entry.env as Record<string, unknown>)
+        : undefined;
+
+    out.push({
+      name,
+      transport,
+      command,
+      args,
+      url,
+      envKeys: envKeys && envKeys.length > 0 ? envKeys : undefined,
+      source,
+      sourcePath,
+    });
+  }
+
+  return out;
+}

--- a/src/lib/scanner/util/jsonc.ts
+++ b/src/lib/scanner/util/jsonc.ts
@@ -22,15 +22,21 @@ export function tryParseJsonc<T = unknown>(raw: string): T | null {
  * preserving the position of each character inside string literals so that
  * `//` or `/*` inside a quoted value is not mistaken for a comment.
  *
- * Also removes a single trailing comma before `}` / `]`.
+ * Also removes structural trailing commas before `}` / `]`. Commas appearing
+ * inside string literals (e.g. `",}"`) are never touched.
  */
 export function stripJsonComments(raw: string): string {
-  let out = "";
+  const buf: string[] = [];
   let i = 0;
   let inString = false;
   let stringQuote = "";
   let inLineComment = false;
   let inBlockComment = false;
+  // Index in `buf` of the most recently emitted structural comma — i.e. a
+  // comma that was outside any string/comment. -1 when no such comma is
+  // pending. Used to retroactively drop the comma if the next non-whitespace
+  // structural token turns out to be `}` or `]`.
+  let pendingCommaIdx = -1;
 
   while (i < raw.length) {
     const ch = raw[i];
@@ -39,7 +45,7 @@ export function stripJsonComments(raw: string): string {
     if (inLineComment) {
       if (ch === "\n") {
         inLineComment = false;
-        out += ch;
+        buf.push(ch);
       }
       i++;
       continue;
@@ -57,14 +63,12 @@ export function stripJsonComments(raw: string): string {
 
     if (inString) {
       if (ch === "\\" && i + 1 < raw.length) {
-        out += ch + next;
+        buf.push(ch, next);
         i += 2;
         continue;
       }
-      if (ch === stringQuote) {
-        inString = false;
-      }
-      out += ch;
+      if (ch === stringQuote) inString = false;
+      buf.push(ch);
       i++;
       continue;
     }
@@ -72,7 +76,8 @@ export function stripJsonComments(raw: string): string {
     if (ch === '"' || ch === "'") {
       inString = true;
       stringQuote = ch;
-      out += ch;
+      pendingCommaIdx = -1;
+      buf.push(ch);
       i++;
       continue;
     }
@@ -88,9 +93,30 @@ export function stripJsonComments(raw: string): string {
       continue;
     }
 
-    out += ch;
+    if (ch === ",") {
+      pendingCommaIdx = buf.length;
+      buf.push(ch);
+      i++;
+      continue;
+    }
+
+    if (ch === "}" || ch === "]") {
+      if (pendingCommaIdx !== -1) {
+        buf[pendingCommaIdx] = "";
+        pendingCommaIdx = -1;
+      }
+      buf.push(ch);
+      i++;
+      continue;
+    }
+
+    if (ch !== " " && ch !== "\t" && ch !== "\n" && ch !== "\r") {
+      pendingCommaIdx = -1;
+    }
+
+    buf.push(ch);
     i++;
   }
 
-  return out.replace(/,(\s*[}\]])/g, "$1");
+  return buf.join("");
 }

--- a/src/lib/scanner/util/jsonc.ts
+++ b/src/lib/scanner/util/jsonc.ts
@@ -1,0 +1,96 @@
+/**
+ * Parse JSON, tolerating `// line` and `/* block *\/` comments and trailing commas.
+ *
+ * Vercel and some `.mcp.json` files allow comments. We avoid pulling in an
+ * external JSONC parser by trying strict `JSON.parse` first and stripping
+ * comments only on failure.
+ */
+export function tryParseJsonc<T = unknown>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    try {
+      return JSON.parse(stripJsonComments(raw)) as T;
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Strip `//` line comments and `/* *\/` block comments from a JSON string,
+ * preserving the position of each character inside string literals so that
+ * `//` or `/*` inside a quoted value is not mistaken for a comment.
+ *
+ * Also removes a single trailing comma before `}` / `]`.
+ */
+export function stripJsonComments(raw: string): string {
+  let out = "";
+  let i = 0;
+  let inString = false;
+  let stringQuote = "";
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  while (i < raw.length) {
+    const ch = raw[i];
+    const next = raw[i + 1];
+
+    if (inLineComment) {
+      if (ch === "\n") {
+        inLineComment = false;
+        out += ch;
+      }
+      i++;
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (ch === "*" && next === "/") {
+        inBlockComment = false;
+        i += 2;
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    if (inString) {
+      if (ch === "\\" && i + 1 < raw.length) {
+        out += ch + next;
+        i += 2;
+        continue;
+      }
+      if (ch === stringQuote) {
+        inString = false;
+      }
+      out += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      stringQuote = ch;
+      out += ch;
+      i++;
+      continue;
+    }
+
+    if (ch === "/" && next === "/") {
+      inLineComment = true;
+      i += 2;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inBlockComment = true;
+      i += 2;
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out.replace(/,(\s*[}\]])/g, "$1");
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,13 @@ export interface ProjectData {
   // Worktree overlays
   worktrees?: WorktreeOverlay[];
 
+  // Claude config (project-local)
+  hooks?: HooksInfo;
+  mcpServers?: McpServersInfo;
+
+  // CI/CD
+  cicd?: CiCdInfo;
+
   // Timestamps
   lastActivity?: string;
   scannedAt: string;
@@ -289,6 +296,138 @@ export interface SessionDetail extends SessionSummary {
   fileOperations: FileOperation[];
   subagents: SubagentInfo[];
 }
+
+// ─── Claude config: hooks, MCP servers, plugins ──────────────────────────────
+
+export type HookSource = "project" | "local" | "user";
+
+export interface HookCommand {
+  type: "command";
+  command: string;
+  timeout?: number;
+}
+
+export interface HookEntry {
+  /** PreToolUse | PostToolUse | SessionStart | UserPromptSubmit | Stop | etc. */
+  event: string;
+  /** Tool/event matcher (e.g. "Edit|Write", "Bash"). Optional. */
+  matcher?: string;
+  commands: HookCommand[];
+  source: HookSource;
+  /** Absolute file path the entry came from — used for the future template-builder. */
+  sourcePath: string;
+}
+
+export interface HooksInfo {
+  entries: HookEntry[];
+}
+
+export type McpTransport = "stdio" | "http" | "sse" | "unknown";
+export type McpSource = "project" | "user";
+
+export interface McpServer {
+  name: string;
+  transport: McpTransport;
+  command?: string;
+  args?: string[];
+  url?: string;
+  /** Env variable KEY NAMES only — never values (avoid leaking secrets). */
+  envKeys?: string[];
+  source: McpSource;
+  sourcePath: string;
+}
+
+export interface McpServersInfo {
+  servers: McpServer[];
+}
+
+export interface PluginEntry {
+  name: string;
+  marketplace: string;
+  enabled: boolean;
+  blocked: boolean;
+  version?: string;
+  installedAt?: string;
+  lastUpdated?: string;
+  installPath?: string;
+  gitCommitSha?: string;
+  pluginRepoUrl?: string;
+}
+
+export interface PluginsInfo {
+  plugins: PluginEntry[];
+}
+
+// ─── CI/CD ───────────────────────────────────────────────────────────────────
+
+export interface WorkflowJob {
+  id: string;
+  name?: string;
+  runsOn?: string;
+  /** Reusable-workflow reference (`jobs.<id>.uses`). */
+  uses?: string;
+  /** Deduped `uses:` references from steps (e.g. "actions/checkout@v4"). */
+  actionUses: string[];
+}
+
+export interface Workflow {
+  /** Absolute path to the workflow file. */
+  file: string;
+  name?: string;
+  /** Normalized triggers: push | pull_request | schedule | workflow_dispatch | ... */
+  triggers: string[];
+  /** Cron expressions from `on.schedule[].cron`. */
+  cron: string[];
+  jobs: WorkflowJob[];
+  /** False if YAML parsing failed; the entry still surfaces by file name. */
+  parseOk: boolean;
+}
+
+export type HostingPlatform =
+  | "vercel"
+  | "railway"
+  | "fly"
+  | "render"
+  | "netlify"
+  | "heroku"
+  | "docker";
+
+export interface HostingTarget {
+  platform: HostingPlatform;
+  sourcePath: string;
+  detail?: Record<string, string | number | boolean | string[]>;
+}
+
+export interface VercelCron {
+  path: string;
+  schedule: string;
+  sourcePath: string;
+}
+
+export interface DependabotUpdate {
+  ecosystem: string;
+  directory?: string;
+  schedule?: string;
+  sourcePath: string;
+}
+
+export interface CiCdInfo {
+  workflows: Workflow[];
+  hosting: HostingTarget[];
+  vercelCrons: VercelCron[];
+  dependabot: DependabotUpdate[];
+}
+
+export interface UserConfig {
+  plugins: PluginsInfo;
+  hooks: HooksInfo;
+  mcpServers: McpServersInfo;
+}
+
+/** Catalog kinds surfaced by `/api/claude-config`. "all" returns every section. */
+export type ConfigType = "hooks" | "plugins" | "mcp" | "cicd" | "all";
+
+export const CONFIG_TYPES: readonly ConfigType[] = ["hooks", "plugins", "mcp", "cicd", "all"];
 
 export interface ScanResult {
   projects: ProjectData[];

--- a/src/lib/userConfigCache.ts
+++ b/src/lib/userConfigCache.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { extractHookEntries } from "./scanner/claudeHooks";
+import { parseMcpServers } from "./scanner/mcpServers";
+import { tryParseJsonc } from "./scanner/util/jsonc";
+import { loadInstalledPlugins } from "./indexer/walkPlugins";
+import {
+  HookEntry,
+  McpServer,
+  PluginEntry,
+  PluginsInfo,
+  UserConfig,
+} from "./types";
+
+const CACHE_TTL_MS = 5 * 60_000; // 5 minutes
+
+interface CacheSlot {
+  data: UserConfig;
+  cachedAt: number;
+}
+
+const globalForUC = globalThis as unknown as {
+  __userConfigCache?: CacheSlot;
+};
+
+export function invalidateUserConfigCache(): void {
+  globalForUC.__userConfigCache = undefined;
+}
+
+export async function getUserConfig(): Promise<UserConfig> {
+  const slot = globalForUC.__userConfigCache;
+  if (slot && Date.now() - slot.cachedAt < CACHE_TTL_MS) {
+    return slot.data;
+  }
+  const data = await readUserConfig();
+  globalForUC.__userConfigCache = { data, cachedAt: Date.now() };
+  return data;
+}
+
+async function readUserConfig(): Promise<UserConfig> {
+  const claudeDir = path.join(os.homedir(), ".claude");
+  const settingsPath = path.join(claudeDir, "settings.json");
+
+  const settings = await readSettings(settingsPath);
+  const plugins = await readPluginsInfo(claudeDir, settings);
+
+  const hookEntries: HookEntry[] = settings
+    ? extractHookEntries(settings.hooks, "user", settingsPath)
+    : [];
+
+  const mcpServers: McpServer[] = settings
+    ? parseMcpServers(settings.mcpServers, "user", settingsPath)
+    : [];
+
+  return {
+    plugins,
+    hooks: { entries: hookEntries },
+    mcpServers: { servers: mcpServers },
+  };
+}
+
+interface UserSettings {
+  hooks?: unknown;
+  mcpServers?: unknown;
+  enabledPlugins?: Record<string, unknown>;
+}
+
+async function readSettings(filePath: string): Promise<UserSettings | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    return tryParseJsonc<UserSettings>(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function readPluginsInfo(
+  claudeDir: string,
+  settings: UserSettings | null
+): Promise<PluginsInfo> {
+  const [installed, blocklist] = await Promise.all([
+    loadInstalledPlugins(),
+    readBlocklist(path.join(claudeDir, "plugins", "blocklist.json")),
+  ]);
+
+  const enabledMap = settings?.enabledPlugins ?? {};
+  const blockedSet = new Set(blocklist);
+
+  const installedKeys = new Set<string>();
+  const plugins: PluginEntry[] = [];
+
+  for (const ip of installed) {
+    const key = ip.marketplace ? `${ip.pluginName}@${ip.marketplace}` : ip.pluginName;
+    installedKeys.add(key);
+    plugins.push({
+      name: ip.pluginName,
+      marketplace: ip.marketplace,
+      enabled: enabledMap[key] === true,
+      blocked: blockedSet.has(key),
+      version: ip.version,
+      installedAt: ip.installedAt,
+      lastUpdated: ip.lastUpdated,
+      installPath: ip.installPath,
+      gitCommitSha: ip.gitCommitSha,
+      pluginRepoUrl: ip.pluginRepoUrl,
+    });
+  }
+
+  // Surface plugins that appear in `enabledPlugins` but not in installed_plugins.json
+  // (e.g. from another scope) so the user still sees them.
+  for (const [key, value] of Object.entries(enabledMap)) {
+    if (installedKeys.has(key)) continue;
+    const lastAt = key.lastIndexOf("@");
+    const name = lastAt > 0 ? key.slice(0, lastAt) : key;
+    const marketplace = lastAt > 0 ? key.slice(lastAt + 1) : "";
+    plugins.push({
+      name,
+      marketplace,
+      enabled: value === true,
+      blocked: blockedSet.has(key),
+    });
+  }
+
+  plugins.sort((a, b) => a.name.localeCompare(b.name));
+  return { plugins };
+}
+
+async function readBlocklist(filePath: string): Promise<string[]> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const doc = tryParseJsonc<{ plugins?: Array<{ plugin?: unknown }> }>(raw);
+    if (!doc?.plugins) return [];
+    return doc.plugins
+      .map((p) => p.plugin)
+      .filter((p): p is string => typeof p === "string");
+  } catch {
+    return [];
+  }
+}
+

--- a/tests/cicd.test.ts
+++ b/tests/cicd.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { parseDependabot, parseWorkflow } from "@/lib/scanner/cicd";
+
+describe("parseWorkflow", () => {
+  it("normalizes string-form `on:` to a single trigger", () => {
+    const yaml = `
+name: simple
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`;
+    const wf = parseWorkflow(yaml, "/repo/.github/workflows/simple.yml");
+    expect(wf.parseOk).toBe(true);
+    expect(wf.name).toBe("simple");
+    expect(wf.triggers).toEqual(["push"]);
+    expect(wf.jobs).toHaveLength(1);
+    expect(wf.jobs[0].id).toBe("build");
+    expect(wf.jobs[0].runsOn).toBe("ubuntu-latest");
+    expect(wf.jobs[0].actionUses).toEqual(["actions/checkout@v4"]);
+  });
+
+  it("normalizes array-form `on:` to multiple triggers", () => {
+    const yaml = `
+name: arr
+on: [push, pull_request]
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps: []
+`;
+    const wf = parseWorkflow(yaml, "/x.yml");
+    expect(wf.triggers.sort()).toEqual(["pull_request", "push"]);
+  });
+
+  it("normalizes object-form `on:` and extracts cron schedules", () => {
+    const yaml = `
+name: scheduled
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * *"
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps: []
+`;
+    const wf = parseWorkflow(yaml, "/x.yml");
+    expect(wf.triggers.sort()).toEqual(["push", "schedule", "workflow_dispatch"]);
+    expect(wf.cron).toEqual(["0 0 * * *", "*/15 * * * *"]);
+  });
+
+  it("dedupes action `uses:` references and skips run: scripts", () => {
+    const yaml = `
+name: dedup
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - run: npm test
+`;
+    const wf = parseWorkflow(yaml, "/x.yml");
+    expect(wf.jobs[0].actionUses).toEqual([
+      "actions/checkout@v4",
+      "actions/setup-node@v4",
+    ]);
+  });
+
+  it("preserves reusable-workflow references on jobs.<id>.uses", () => {
+    const yaml = `
+name: reuse
+on: push
+jobs:
+  call:
+    uses: org/repo/.github/workflows/shared.yml@main
+`;
+    const wf = parseWorkflow(yaml, "/x.yml");
+    expect(wf.jobs[0].uses).toBe("org/repo/.github/workflows/shared.yml@main");
+  });
+
+  it("returns parseOk:false on malformed YAML without throwing", () => {
+    const yaml = "::: not yaml :::";
+    const wf = parseWorkflow(yaml, "/broken.yml");
+    expect(wf.parseOk).toBe(false);
+    expect(wf.file).toBe("/broken.yml");
+    expect(wf.jobs).toEqual([]);
+  });
+
+  it("handles multi-runner runs-on as comma-joined string", () => {
+    const yaml = `
+name: arr-runs-on
+on: push
+jobs:
+  build:
+    runs-on: [self-hosted, linux]
+    steps: []
+`;
+    const wf = parseWorkflow(yaml, "/x.yml");
+    expect(wf.jobs[0].runsOn).toBe("self-hosted, linux");
+  });
+});
+
+describe("parseDependabot", () => {
+  it("emits one entry per `updates[]` block", () => {
+    const yaml = `
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+`;
+    const result = parseDependabot(yaml, "/repo/.github/dependabot.yml");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      ecosystem: "npm",
+      directory: "/",
+      schedule: "weekly",
+      sourcePath: "/repo/.github/dependabot.yml",
+    });
+    expect(result[1].ecosystem).toBe("github-actions");
+    expect(result[1].schedule).toBe("monthly");
+  });
+
+  it("returns empty array when updates is missing", () => {
+    expect(parseDependabot("version: 2\n", "/x")).toEqual([]);
+  });
+
+  it("ignores entries without a string ecosystem", () => {
+    const yaml = `
+version: 2
+updates:
+  - directory: "/"
+  - package-ecosystem: "npm"
+    directory: "/"
+`;
+    const result = parseDependabot(yaml, "/x");
+    expect(result).toHaveLength(1);
+    expect(result[0].ecosystem).toBe("npm");
+  });
+
+  it("returns empty when YAML is malformed", () => {
+    expect(parseDependabot("::: not yaml :::", "/x")).toEqual([]);
+  });
+});

--- a/tests/claudeHooks.test.ts
+++ b/tests/claudeHooks.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { extractHookEntries, scanClaudeHooks } from "@/lib/scanner/claudeHooks";
+
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+import { promises as fs } from "fs";
+const mockReadFile = vi.mocked(fs.readFile);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("extractHookEntries", () => {
+  it("returns empty when input is not an object", () => {
+    expect(extractHookEntries(null,      "project", "/x")).toEqual([]);
+    expect(extractHookEntries(undefined, "project", "/x")).toEqual([]);
+    expect(extractHookEntries("string",  "project", "/x")).toEqual([]);
+    expect(extractHookEntries(42,        "project", "/x")).toEqual([]);
+  });
+
+  it("parses event groups with matchers and command lists", () => {
+    const hooks = {
+      PostToolUse: [
+        {
+          matcher: "Edit|Write",
+          hooks: [
+            { type: "command", command: "npm run lint" },
+            { type: "command", command: "npm test", timeout: 60 },
+          ],
+        },
+      ],
+      SessionStart: [
+        { hooks: [{ type: "command", command: "echo hi" }] },
+      ],
+    };
+
+    const result = extractHookEntries(hooks, "project", "/proj/.claude/settings.json");
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      event: "PostToolUse",
+      matcher: "Edit|Write",
+      source: "project",
+      sourcePath: "/proj/.claude/settings.json",
+    });
+    expect(result[0].commands).toHaveLength(2);
+    expect(result[0].commands[1].timeout).toBe(60);
+    expect(result[1].event).toBe("SessionStart");
+    expect(result[1].matcher).toBeUndefined();
+  });
+
+  it("skips entries with no commands", () => {
+    const hooks = {
+      PreToolUse: [{ matcher: "Bash", hooks: [] }],
+    };
+    expect(extractHookEntries(hooks, "local", "/x")).toEqual([]);
+  });
+
+  it("skips malformed command shapes", () => {
+    const hooks = {
+      PostToolUse: [
+        {
+          matcher: "Bash",
+          hooks: [
+            { type: "command" },                 // missing command string
+            { command: "" },                     // empty command
+            "not an object",                     // wrong shape
+            { type: "command", command: "good" },
+          ],
+        },
+      ],
+    };
+    const result = extractHookEntries(hooks, "project", "/x");
+    expect(result).toHaveLength(1);
+    expect(result[0].commands).toHaveLength(1);
+    expect(result[0].commands[0].command).toBe("good");
+  });
+
+  it("preserves matcher globs as opaque strings", () => {
+    const hooks = { PreToolUse: [{ matcher: "Bash(*)", hooks: [{ type: "command", command: "x" }] }] };
+    const result = extractHookEntries(hooks, "project", "/x");
+    expect(result[0].matcher).toBe("Bash(*)");
+  });
+});
+
+describe("scanClaudeHooks", () => {
+  it("returns undefined when both files are missing", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    const result = await scanClaudeHooks("C:\\dev\\fake");
+    expect(result).toBeUndefined();
+  });
+
+  it("merges hooks from settings.json and settings.local.json with correct sources", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      const pathStr = typeof p === "string" ? p : p.toString();
+      if (pathStr.endsWith("settings.json")) {
+        return JSON.stringify({
+          hooks: { PostToolUse: [{ matcher: "Edit", hooks: [{ type: "command", command: "lint" }] }] },
+        });
+      }
+      if (pathStr.endsWith("settings.local.json")) {
+        return JSON.stringify({
+          hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "audit" }] }] },
+        });
+      }
+      throw new Error("ENOENT");
+    });
+
+    const result = await scanClaudeHooks("C:\\dev\\proj");
+    expect(result).toBeDefined();
+    expect(result!.entries).toHaveLength(2);
+    const sources = result!.entries.map((e) => e.source);
+    expect(sources).toContain("project");
+    expect(sources).toContain("local");
+  });
+
+  it("tolerates JSONC line comments in settings files", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      const pathStr = typeof p === "string" ? p : p.toString();
+      if (pathStr.endsWith("settings.local.json")) {
+        return `{
+          // this is a comment
+          "hooks": {
+            "PostToolUse": [
+              { "matcher": "Edit", "hooks": [{ "type": "command", "command": "x" }] }
+            ]
+          }
+        }`;
+      }
+      throw new Error("ENOENT");
+    });
+
+    const result = await scanClaudeHooks("C:\\dev\\proj");
+    expect(result?.entries).toHaveLength(1);
+  });
+
+  it("returns undefined when files exist but contain no hooks key", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      const pathStr = typeof p === "string" ? p : p.toString();
+      if (pathStr.endsWith(".json")) return JSON.stringify({ permissions: {} });
+      throw new Error("ENOENT");
+    });
+    const result = await scanClaudeHooks("C:\\dev\\proj");
+    expect(result).toBeUndefined();
+  });
+});

--- a/tests/jsonc.test.ts
+++ b/tests/jsonc.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { stripJsonComments, tryParseJsonc } from "@/lib/scanner/util/jsonc";
+
+describe("stripJsonComments", () => {
+  it("removes // line comments", () => {
+    const result = stripJsonComments(`{
+      // comment
+      "a": 1
+    }`);
+    expect(JSON.parse(result)).toEqual({ a: 1 });
+  });
+
+  it("removes /* block */ comments", () => {
+    const result = stripJsonComments(`{ /* explanation */ "a": 1 }`);
+    expect(JSON.parse(result)).toEqual({ a: 1 });
+  });
+
+  it("removes structural trailing commas before } and ]", () => {
+    expect(JSON.parse(stripJsonComments(`{ "a": 1, }`))).toEqual({ a: 1 });
+    expect(JSON.parse(stripJsonComments(`[1, 2, 3,]`))).toEqual([1, 2, 3]);
+  });
+
+  it("preserves commas inside string literals", () => {
+    // Comma followed by `}` inside a quoted value must NOT be stripped.
+    const raw = `{ "command": ",}" }`;
+    const result = stripJsonComments(raw);
+    expect(JSON.parse(result)).toEqual({ command: ",}" });
+  });
+
+  it("preserves `//` and `/*` inside string literals", () => {
+    const raw = `{ "url": "http://example.com/api", "comment": "/* not a real comment */" }`;
+    expect(JSON.parse(stripJsonComments(raw))).toEqual({
+      url: "http://example.com/api",
+      comment: "/* not a real comment */",
+    });
+  });
+
+  it("handles escaped quotes in strings without breaking state", () => {
+    const raw = `{ "msg": "she said \\"hi,\\"", "n": 1, }`;
+    expect(JSON.parse(stripJsonComments(raw))).toEqual({ msg: 'she said "hi,"', n: 1 });
+  });
+});
+
+describe("tryParseJsonc", () => {
+  it("parses strict JSON without invoking the comment-stripper", () => {
+    expect(tryParseJsonc(`{"a":1}`)).toEqual({ a: 1 });
+  });
+
+  it("falls back to JSONC parsing only when strict parse fails", () => {
+    expect(tryParseJsonc(`{ /* x */ "a": 1, }`)).toEqual({ a: 1 });
+  });
+
+  it("returns null when both passes fail", () => {
+    expect(tryParseJsonc(`{ "a":`)).toBeNull();
+  });
+});

--- a/tests/mcpServers.test.ts
+++ b/tests/mcpServers.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { parseMcpServers, scanMcpServers } from "@/lib/scanner/mcpServers";
+
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+import { promises as fs } from "fs";
+const mockReadFile = vi.mocked(fs.readFile);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("parseMcpServers", () => {
+  it("returns empty for non-objects", () => {
+    expect(parseMcpServers(null,  "project", "/x")).toEqual([]);
+    expect(parseMcpServers([],    "project", "/x")).toEqual([]);
+    expect(parseMcpServers("str", "project", "/x")).toEqual([]);
+  });
+
+  it("infers stdio transport when command is present", () => {
+    const result = parseMcpServers(
+      { foo: { command: "node", args: ["server.js"] } },
+      "project",
+      "/proj/.mcp.json"
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "foo",
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      source: "project",
+      sourcePath: "/proj/.mcp.json",
+    });
+  });
+
+  it("infers http transport when only url is present", () => {
+    const result = parseMcpServers(
+      { foo: { url: "https://example.com/mcp" } },
+      "project",
+      "/x"
+    );
+    expect(result[0].transport).toBe("http");
+  });
+
+  it("respects explicit `type` over inference", () => {
+    const result = parseMcpServers(
+      { foo: { url: "https://example.com", type: "sse" } },
+      "project",
+      "/x"
+    );
+    expect(result[0].transport).toBe("sse");
+  });
+
+  it("surfaces env KEY NAMES only — never values", () => {
+    const result = parseMcpServers(
+      { db: { command: "x", env: { POSTGRES_CONNECTION_STRING: "secret-value", DEBUG: "1" } } },
+      "project",
+      "/x"
+    );
+    expect(result[0].envKeys).toEqual(["POSTGRES_CONNECTION_STRING", "DEBUG"]);
+    // The McpServer type does not include env values; check the serialized output:
+    expect(JSON.stringify(result[0])).not.toContain("secret-value");
+  });
+
+  it("omits envKeys when env is empty or missing", () => {
+    const result = parseMcpServers(
+      { foo: { command: "x" }, bar: { command: "y", env: {} } },
+      "project",
+      "/x"
+    );
+    expect(result[0].envKeys).toBeUndefined();
+    expect(result[1].envKeys).toBeUndefined();
+  });
+
+  it("uses 'unknown' transport when neither command, url, nor type indicate one", () => {
+    const result = parseMcpServers({ foo: {} }, "project", "/x");
+    expect(result[0].transport).toBe("unknown");
+  });
+});
+
+describe("scanMcpServers", () => {
+  it("returns undefined when .mcp.json is missing", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    expect(await scanMcpServers("C:\\dev\\fake")).toBeUndefined();
+  });
+
+  it("parses a valid project-level .mcp.json", async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      mcpServers: {
+        postgres: { command: "cmd", args: ["/c", "npx", "pg-server"], env: { CONN: "x" } },
+      },
+    }));
+    const result = await scanMcpServers("C:\\dev\\proj");
+    expect(result?.servers).toHaveLength(1);
+    expect(result!.servers[0].name).toBe("postgres");
+    expect(result!.servers[0].source).toBe("project");
+    expect(result!.servers[0].envKeys).toEqual(["CONN"]);
+  });
+
+  it("tolerates `//` comments in .mcp.json", async () => {
+    mockReadFile.mockResolvedValue(`{
+      // comment
+      "mcpServers": { "x": { "command": "node" } }
+    }`);
+    const result = await scanMcpServers("C:\\dev\\proj");
+    expect(result?.servers).toHaveLength(1);
+  });
+
+  it("returns undefined when mcpServers is empty or absent", async () => {
+    mockReadFile.mockResolvedValue("{}");
+    expect(await scanMcpServers("C:\\dev\\proj")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Three new scanner modules** (`claudeHooks`, `mcpServers`, `cicd`) attach project-local config to `ProjectData`. CI/CD parsing is per-unit semantic — each row is a thing a future template-builder could lift across projects: workflow jobs with deduped action `uses:` references, Vercel crons, Dependabot ecosystem blocks, and multi-host detection across Vercel, Railway, Fly, Render, Netlify, Heroku, and Docker. Every unit retains its source path.
- **`userConfigCache` singleton** (5-min TTL, modeled on `gitStatusCache`) reads `~/.claude/settings.json` + `installed_plugins.json` + `blocklist.json` once per process; reuses the existing `loadInstalledPlugins()` helper.
- **`/config` rebuilt as a 5-tab shell** (Settings | Hooks | Plugins | MCP | CI/CD). Settings preserves the existing MinderConfig editor; the four catalog tabs surface cross-project rows with project-source badges. Includes a search box, route-level 2-min cache, and JSONC-tolerant `.mcp.json` / `vercel.json` parsing.
- **Project Config tab** on the detail page (gated on `hooks || mcpServers || cicd`); shows project-local data only — user-level lives on `/config`.
- **`CI` chip on dashboard cards** when a project has any `.github/workflows/*.yml`.
- **Two new API routes**: `GET /api/claude-config?type=hooks|plugins|mcp|cicd|all&project=&q=` and `GET /api/claude-config/user`.
- **Simplify pass landed in the same commit**: shared UI primitives (`src/components/config/primitives.tsx`), single source of truth for `ConfigType` in `src/lib/types.ts`, parallelized hosting + workflow reads (drops 7+ `fs.access` TOCTOU pre-checks per project), shared parsed settings between user-config readers, route-cache hygiene (skip on query, sweep stale entries on write).

Designed to feed a future **template-builder feature** that mines existing projects for reusable hook/MCP/job units and composes them into new project scaffolds. Per-unit `sourcePath` retention is the scaffolding for that.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — all 333 tests pass (31 files; 3 new test files for the new scanners)
- [x] `GET /api/claude-config/user` returns 42 plugins (21 enabled / 21 disabled / 1 blocked) joined from real `installed_plugins.json` + `enabledPlugins` map
- [x] `GET /api/claude-config?type=cicd&project=project-minder` correctly normalizes object-form `on:` to `["pull_request","push"]`, dedupes step `uses:` to `["actions/checkout@v4","actions/setup-node@v4"]`
- [x] `GET /api/projects/project-minder` includes `mcpServers.servers[0]` for the postgres MCP with `envKeys: ["POSTGRES_CONNECTION_STRING"]` (key name only, no secret value)
- [x] `/config` and `/project/project-minder` both return HTTP 200
- [ ] **Browser walkthrough deferred** — please confirm: (a) Config tab renders all four sections legibly on `/project/project-minder`, (b) the 5-tab shell at `/config` switches cleanly and the Settings tab still works after refactor, (c) the `CI` chip lays out next to the worktree badge without wrap regression at standard card widths, (d) long workflow `uses:` lists overflow correctly in `ConfigBrowser`.

## Follow-ups (already appended to TODO.md)

- Template-builder MVP: cross-project dedupe of hook/MCP/job units; "copy this unit to project X" action.
- Card `CI` chip → deep-link to `/config?type=cicd&project=<slug>` (URL params not yet wired).
- `local` ProvenanceBadge variant to distinguish `.claude/settings.local.json` hooks from `.claude/settings.json`.
- Surfacing plugin-bundled hooks/MCP from `~/.claude/plugins/cache/...` (deferred — weaker signal than user/project-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)