### PR TITLE
perf(p1): server consolidation — mtime cache, atomic writes, ETag/304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Performance
+- **P1 server consolidation.** The big WARM-path win — `/api/usage` warm dropped from 2.27 s to 14 ms (−99 %), `/api/sessions` warm from 211 ms to 44 ms, and three routes now support 304 short-circuits via `If-None-Match`. Cross-page navigations re-using cached data drop to ≤ 110 ms.
+  - **`FileCache<T>` mtime primitive (`src/lib/usage/cache.ts`)** — generic per-file cache keyed on `mtimeMs + size` with single-flight dedup on cold-path concurrency and LRU eviction. Replaces the prior 2-min TTL that re-parsed the entire 1.1 GB JSONL corpus on every miss.
+  - **Parser refactored to use FileCache** — `parseAllSessions()` now stat-sweeps the JSONL tree and only re-parses files whose mtime/size changed since the last call. First-call cost is unchanged; subsequent calls are stat-bounded.
+  - **Atomic file writes (`src/lib/atomicWrite.ts`)** — promoted the existing tmp+rename pattern to a top-level helper with shared `withFileLock`. Applied to `.minder.json`, `CLAUDE.md`, `.claude/settings.json`, `INSIGHTS.md`, `MANUAL_STEPS.md`, `TODO.md` writers. Prevents corruption when HMR or process exit interrupts a write mid-flush.
+  - **`mutateConfig()` helper** — read-modify-write cycles for `.minder.json` now run inside `withFileLock` so concurrent mutations from API handlers don't clobber each other's reads.
+  - **Scanner cache moved to `globalThis`** — survives HMR module reloads instead of being thrown away on every dev-server save.
+  - **ETag + `Cache-Control: private, max-age=0, stale-while-revalidate=60`** on `/api/sessions`, `/api/usage`, `/api/stats`. ETag inputs are mtime-derived so 304 round-trips are sub-100 ms.
+  - **Plain `Cache-Control: private, max-age=120`** on `/api/agents`, `/api/skills` — matches their existing 2-min TTL semantics. ETag deferred until the agent/skill catalog walk is mtime-cached (P1.5 / P2).
+
 ### Added
 - **Template Mode V5.5 — UI surface for user-scope apply.** The `/config` browser now exposes `↗ copy to project` buttons for all user-scope artifacts:
   - **Hooks**: user-scope hook rows (those with `source === "user"`) now show the apply button (previously hidden by the `projectSlug &&` guard). Clicking opens the conflict-policy popover with `source: { kind: "user" }` so the apply layer routes through `getUserConfig()`.

--- a/docs/perf/baseline-2026-04.md
+++ b/docs/perf/baseline-2026-04.md
@@ -274,6 +274,64 @@ Deferred to P0.5 (low-priority — no measured CLS issue, can copy SessionsBrows
 
 ---
 
+## After P1 — 2026-04-30
+
+P1 = server consolidation. New `FileCache<T>` mtime primitive in `src/lib/usage/cache.ts`, parser switched from 2-min TTL to mtime-driven cache, single-flight dedup for cold-path concurrency, `writeFileAtomic` + `withFileLock` extracted to top-level `src/lib/atomicWrite.ts` and applied across config/setup/insight/manual-step writers, scanner cache moved to `globalThis`, ETag + `Cache-Control` headers on `/api/sessions`, `/api/usage`, `/api/stats`, plain `Cache-Control` on `/api/agents`, `/api/skills`.
+
+### API timings — cold (after `rm -rf .next` + restart, disk caches present)
+
+| Route | Baseline cold | P1 cold | Δ |
+|---|---|---|---|
+| `/api/sessions` | 7.97 s | ~10.0 s | +25 % (one-time per restart) |
+| `/api/usage?period=month` | 6.90 s | ~10.4 s | +51 % (one-time per restart) |
+| `/api/stats` | n/a | 0.40 s | new |
+| `/api/agents` | n/a | 1.66 s | new |
+| `/api/skills` | n/a | 0.36 s | new |
+
+Cold path is slightly worse on `/api/sessions` and `/api/usage` because the new in-process FileCache is empty after restart and has to stat 3,211 files plus parse changed ones. The on-disk `claudeStatsCache` is still warm, so parse work itself is bounded — most of the 10 s is fs.stat round-trips. P2 (SQLite) eliminates this cost by persisting parsed state across restarts.
+
+### API timings — warm (in-process FileCache populated)
+
+| Route | Baseline warm | P1 warm | Δ |
+|---|---|---|---|
+| `/api/sessions` | 0.21 s | **0.044 s** | **−79 %** |
+| `/api/usage?period=month` | 2.27 s | **0.014 s** | **−99.4 %** |
+| `/api/stats` | n/a | 0.098 s | new |
+| `/api/agents` | n/a | 0.018 s | new |
+| `/api/skills` | n/a | 0.020 s | new |
+
+The 99.4 % reduction on `/api/usage` is the headline P1 win: prior to P1, every 2-min TTL miss re-parsed 1.1 GB. With mtime caching, only files that actually changed since the last sweep get re-parsed, and a stat-only sweep is ≤ 20 ms.
+
+### API timings — 304 round-trip (with `If-None-Match`)
+
+| Route | Time | Status |
+|---|---|---|
+| `/api/sessions` | 0.011 s | 304 |
+| `/api/usage?period=month` | 0.016 s | 304 |
+| `/api/stats` | 0.094 s | 304 |
+
+Browsers will use these headers automatically across cross-page navigations: clicking from `/sessions` → `/usage` → `/stats` → back will short-circuit to 304s instead of full payload re-fetches as long as the underlying JSONL/scan state hasn't changed.
+
+### Verification
+
+- `npm run typecheck` — clean.
+- `npm test` — **545/545 passing** including new `tests/fileCache.test.ts` (7 tests covering single-flight dedup, mtime/size invalidation, LRU eviction, max-mtime reporting).
+- `npm run build` — clean (one pre-existing NFT warning unchanged from baseline).
+- `curl -H 'If-None-Match: <etag>'` round-trip → 304 with same ETag, < 110 ms across all three routes.
+- ETag inputs: max JSONL mtime + query params (`/api/usage`), in-route cache `cachedAt` + filter (`/api/sessions`), max(scan timestamp, JSONL mtime) (`/api/stats`).
+
+### Why /api/agents and /api/skills don't get an ETag yet
+
+Both routes depend on TWO file sources: the JSONL corpus (covered by `getJsonlMaxMtime()`) and the agent/skill catalog directories walked by `loadCatalog`. The catalog walk isn't mtime-cached yet — that lands as part of P1.5 (or naturally with P2's SQLite indexer). For now, both routes get plain `Cache-Control: private, max-age=120` matching their existing 2-min in-process TTLs, so browsers dedupe back-to-back navigations without us claiming a freshness signal we can't enforce.
+
+### What didn't change in P1 (intentionally deferred)
+
+- **Streaming session detail** — `/api/sessions/[sessionId]` still loads the full file. Becomes trivial once P2's SQLite holds turn metadata + byte offsets.
+- **Single shared façade `src/lib/data/index.ts`** — would be churn without the SQLite backend behind it. Lands naturally with P2.
+- **`loadCatalog` mtime-cache** — see above. Cheap once we touch the indexer for SQLite.
+
+---
+
 ## How to recapture after each phase
 
 After landing each phase (P0/P1/P2/P3), append a new section to this file titled `## After P<n> — <date>` with the same tables filled in fresh, then add a final `### Delta vs baseline` subsection with percentage changes. Do not edit the baseline tables above — they are frozen as the reference point.

--- a/src/app/api/agents/route.ts
+++ b/src/app/api/agents/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { loadCatalog } from "@/lib/indexer/catalog";
 import { buildAgentAliasMap } from "@/lib/indexer/canonicalize";
 import { parseAllSessions } from "@/lib/usage/parser";
@@ -6,6 +6,7 @@ import { groupAgentCalls } from "@/lib/usage/agentParser";
 import { getCachedScan } from "@/lib/cache";
 import { pathToUsageSlug } from "@/lib/usage/slug";
 import { skillUpdateCache } from "@/lib/skillUpdateCache";
+import { jsonWithCacheControl } from "@/lib/httpCache";
 import type { QueueItem } from "@/lib/skillUpdateCache";
 import type { AgentStats } from "@/lib/usage/types";
 import type { AgentEntry } from "@/lib/indexer/types";
@@ -65,7 +66,7 @@ export async function GET(request: NextRequest) {
   const cached = getRouteCache(cacheKey);
   if (cached) {
     skillUpdateCache.enqueue(buildUpdateItems(cached));
-    return NextResponse.json(cached);
+    return jsonWithCacheControl(cached);
   }
 
   const [catalog, sessionMap] = await Promise.all([
@@ -146,5 +147,5 @@ export async function GET(request: NextRequest) {
   setRouteCache(cacheKey, result);
   skillUpdateCache.enqueue(buildUpdateItems(result));
 
-  return NextResponse.json(result);
+  return jsonWithCacheControl(result);
 }

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { readConfig, writeConfig } from "@/lib/config";
+import { readConfig, mutateConfig } from "@/lib/config";
 import { invalidateCache } from "@/lib/cache";
 import { invalidateClaudeConfigRouteCache } from "@/app/api/claude-config/route";
 import { ProjectStatus, MinderConfig } from "@/lib/types";
@@ -9,10 +9,20 @@ const VALID_DEFAULT_SORTS: MinderConfig["defaultSort"][] = ["activity", "name", 
 const VALID_STATUS_FILTERS: MinderConfig["defaultStatusFilter"][] = ["all", "active", "paused", "archived"];
 const VALID_VIEW_MODES: MinderConfig["viewMode"][] = ["full", "compact", "list"];
 
+function invalidateAll() {
+  invalidateCache();
+  invalidateClaudeConfigRouteCache();
+}
+
+// Validate first, mutate second. We can't validate inside `mutateConfig` because
+// it always writes — a half-mutated config caused by mid-validation failure
+// would be persisted. So we build a list of patch closures up front; only if
+// every validation passes do we hand them to `mutateConfig` to apply atomically.
+type Patch = (config: MinderConfig) => void;
+
 export async function PATCH(request: NextRequest) {
   const body = await request.json();
-  const config = await readConfig();
-  let changed = false;
+  const patches: Patch[] = [];
 
   if (Array.isArray(body.devRoots)) {
     if (body.devRoots.some((r: unknown) => typeof r !== "string")) {
@@ -22,9 +32,10 @@ export async function PATCH(request: NextRequest) {
     if (roots.length === 0) {
       return NextResponse.json({ error: "devRoots must not be empty" }, { status: 400 });
     }
-    config.devRoots = roots;
-    config.devRoot = roots[0]; // keep legacy field in sync
-    changed = true;
+    patches.push((c) => {
+      c.devRoots = roots;
+      c.devRoot = roots[0];
+    });
   }
 
   if (typeof body.scanBatchSize === "number") {
@@ -32,49 +43,45 @@ export async function PATCH(request: NextRequest) {
     if (size < 1 || size > 50) {
       return NextResponse.json({ error: "scanBatchSize must be 1–50" }, { status: 400 });
     }
-    config.scanBatchSize = size;
-    changed = true;
+    patches.push((c) => { c.scanBatchSize = size; });
   }
 
   if (body.defaultSort !== undefined) {
     if (!VALID_DEFAULT_SORTS.includes(body.defaultSort)) {
       return NextResponse.json({ error: "Invalid defaultSort" }, { status: 400 });
     }
-    config.defaultSort = body.defaultSort;
-    changed = true;
+    patches.push((c) => { c.defaultSort = body.defaultSort; });
   }
 
   if (body.defaultStatusFilter !== undefined) {
     if (!VALID_STATUS_FILTERS.includes(body.defaultStatusFilter)) {
       return NextResponse.json({ error: "Invalid defaultStatusFilter" }, { status: 400 });
     }
-    config.defaultStatusFilter = body.defaultStatusFilter;
-    changed = true;
+    patches.push((c) => { c.defaultStatusFilter = body.defaultStatusFilter; });
   }
 
   if (body.viewMode !== undefined) {
     if (!VALID_VIEW_MODES.includes(body.viewMode)) {
       return NextResponse.json({ error: "Invalid viewMode" }, { status: 400 });
     }
-    config.viewMode = body.viewMode;
-    changed = true;
+    patches.push((c) => { c.viewMode = body.viewMode; });
   }
 
   if (body.pinnedSlugs !== undefined) {
     if (!Array.isArray(body.pinnedSlugs) || body.pinnedSlugs.some((s: unknown) => typeof s !== "string")) {
       return NextResponse.json({ error: "pinnedSlugs must be an array of strings" }, { status: 400 });
     }
-    config.pinnedSlugs = body.pinnedSlugs as string[];
-    changed = true;
+    patches.push((c) => { c.pinnedSlugs = body.pinnedSlugs as string[]; });
   }
 
-  if (!changed) {
+  if (patches.length === 0) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
   }
 
-  await writeConfig(config);
-  invalidateCache();
-  invalidateClaudeConfigRouteCache();
+  const config = await mutateConfig((c) => {
+    for (const patch of patches) patch(c);
+  });
+  invalidateAll();
   return NextResponse.json({ ok: true, config });
 }
 
@@ -85,34 +92,33 @@ export async function GET() {
 
 export async function PUT(request: NextRequest) {
   const body = await request.json();
-  const config = await readConfig();
 
   // Update status
   if (body.slug && body.status) {
-    config.statuses[body.slug] = body.status as ProjectStatus;
-    await writeConfig(config);
-    invalidateCache();
-  invalidateClaudeConfigRouteCache();
+    await mutateConfig((config) => {
+      config.statuses[body.slug] = body.status as ProjectStatus;
+    });
+    invalidateAll();
     return NextResponse.json({ ok: true });
   }
 
   // Hide a project (by directory name)
   if (body.action === "hide" && body.dirName) {
-    if (!config.hidden.includes(body.dirName)) {
-      config.hidden.push(body.dirName);
-    }
-    await writeConfig(config);
-    invalidateCache();
-  invalidateClaudeConfigRouteCache();
+    await mutateConfig((config) => {
+      if (!config.hidden.includes(body.dirName)) {
+        config.hidden.push(body.dirName);
+      }
+    });
+    invalidateAll();
     return NextResponse.json({ ok: true });
   }
 
   // Unhide a project
   if (body.action === "unhide" && body.dirName) {
-    config.hidden = config.hidden.filter((h) => h !== body.dirName);
-    await writeConfig(config);
-    invalidateCache();
-  invalidateClaudeConfigRouteCache();
+    await mutateConfig((config) => {
+      config.hidden = config.hidden.filter((h) => h !== body.dirName);
+    });
+    invalidateAll();
     return NextResponse.json({ ok: true });
   }
 
@@ -120,24 +126,26 @@ export async function PUT(request: NextRequest) {
   if (body.slug && body.port !== undefined) {
     const port = parseInt(body.port, 10);
     if (port > 0 && port <= 65535) {
-      config.portOverrides[body.slug] = port;
+      await mutateConfig((config) => {
+        config.portOverrides[body.slug] = port;
+      });
     } else if (body.port === null || body.port === 0) {
-      delete config.portOverrides[body.slug];
+      await mutateConfig((config) => {
+        delete config.portOverrides[body.slug];
+      });
     } else {
       return NextResponse.json({ error: "Invalid port" }, { status: 400 });
     }
-    await writeConfig(config);
-    invalidateCache();
-  invalidateClaudeConfigRouteCache();
+    invalidateAll();
     return NextResponse.json({ ok: true });
   }
 
   // Bulk update hidden list
   if (body.hidden && Array.isArray(body.hidden)) {
-    config.hidden = body.hidden;
-    await writeConfig(config);
-    invalidateCache();
-  invalidateClaudeConfigRouteCache();
+    await mutateConfig((config) => {
+      config.hidden = body.hidden;
+    });
+    invalidateAll();
     return NextResponse.json({ ok: true });
   }
 

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -5,10 +5,32 @@ import { computeETag, ifNoneMatch, jsonWithETag } from "@/lib/httpCache";
 
 const CACHE_TTL = 30_000; // 30s — kept short so live status badges on the dashboard are timely
 
+interface SessionsCacheSlot {
+  sessions: SessionSummary[];
+  cachedAt: number;
+  // Content-derived watermark: max(endTime, startTime) across the cached
+  // session set. Captured at refresh time and used as the ETag input so the
+  // ETag only rotates when the underlying session content actually changed,
+  // not on every CACHE_TTL boundary. Matches the semantics already in place
+  // for /api/usage and /api/stats.
+  maxSessionMs: number;
+}
+
 // globalThis singleton — survives Next.js module reloads
 const globalForSessions = globalThis as unknown as {
-  __sessionsCache?: { sessions: SessionSummary[]; cachedAt: number };
+  __sessionsCache?: SessionsCacheSlot;
 };
+
+function deriveMaxSessionMs(sessions: SessionSummary[]): number {
+  let max = 0;
+  for (const s of sessions) {
+    const ts = s.endTime ?? s.startTime;
+    if (!ts) continue;
+    const ms = new Date(ts).getTime();
+    if (Number.isFinite(ms) && ms > max) max = ms;
+  }
+  return max;
+}
 
 export async function GET(request: NextRequest) {
   const project = request.nextUrl.searchParams.get("project");
@@ -19,18 +41,17 @@ export async function GET(request: NextRequest) {
   let cache = globalForSessions.__sessionsCache;
   if (!cache || Date.now() - cache.cachedAt > CACHE_TTL) {
     const sessions = await scanAllSessions();
-    cache = { sessions, cachedAt: Date.now() };
+    cache = {
+      sessions,
+      cachedAt: Date.now(),
+      maxSessionMs: deriveMaxSessionMs(sessions),
+    };
     globalForSessions.__sessionsCache = cache;
   }
 
-  // ETag uses the cache's `cachedAt` as the freshness signal — it rotates
-  // every CACHE_TTL window. Within a window, all repeat calls match the same
-  // ETag and return 304. We don't need to stat individual JSONL files here
-  // because scanAllSessions already does that internally and only produces a
-  // new SessionSummary[] when something changed.
   const etag = computeETag({
     salt: "sessions-v1",
-    maxMtimeMs: cache.cachedAt,
+    maxMtimeMs: cache.maxSessionMs,
     parts: [project ?? "", cache.sessions.length],
   });
 

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { scanAllSessions } from "@/lib/scanner/claudeConversations";
 import { SessionSummary } from "@/lib/types";
+import { computeETag, ifNoneMatch, jsonWithETag } from "@/lib/httpCache";
 
 const CACHE_TTL = 30_000; // 30s — kept short so live status badges on the dashboard are timely
 
@@ -12,6 +13,9 @@ const globalForSessions = globalThis as unknown as {
 export async function GET(request: NextRequest) {
   const project = request.nextUrl.searchParams.get("project");
 
+  // Refresh the in-route cache when stale. scanAllSessions itself is mtime-cached
+  // via claudeStatsCache on disk, so a refresh that finds no JSONL changes is
+  // already cheap — we just don't want to re-do the per-call work.
   let cache = globalForSessions.__sessionsCache;
   if (!cache || Date.now() - cache.cachedAt > CACHE_TTL) {
     const sessions = await scanAllSessions();
@@ -19,10 +23,24 @@ export async function GET(request: NextRequest) {
     globalForSessions.__sessionsCache = cache;
   }
 
+  // ETag uses the cache's `cachedAt` as the freshness signal — it rotates
+  // every CACHE_TTL window. Within a window, all repeat calls match the same
+  // ETag and return 304. We don't need to stat individual JSONL files here
+  // because scanAllSessions already does that internally and only produces a
+  // new SessionSummary[] when something changed.
+  const etag = computeETag({
+    salt: "sessions-v1",
+    maxMtimeMs: cache.cachedAt,
+    parts: [project ?? "", cache.sessions.length],
+  });
+
+  const notModified = ifNoneMatch(request, etag);
+  if (notModified) return notModified;
+
   let results = cache.sessions;
   if (project) {
     results = results.filter((s) => s.projectSlug === project || s.projectName.includes(project));
   }
 
-  return NextResponse.json(results);
+  return jsonWithETag(results, etag);
 }

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -49,9 +49,22 @@ export async function GET(request: NextRequest) {
     globalForSessions.__sessionsCache = cache;
   }
 
+  // ETag inputs include both `cachedAt` and `maxSessionMs` deliberately. There
+  // are two failure modes to dodge here:
+  //   - Rotate-too-often (ETag = cachedAt only): clients lose 304s every 30 s
+  //     even when nothing actually changed.
+  //   - Rotate-too-rarely (ETag = maxSessionMs only): SessionSummary contains
+  //     time-dependent fields (`isActive`, `status`) that scanAllSessions
+  //     recomputes on every refresh based on the current clock. Two sessions
+  //     could "go inactive" across cache rebuilds without any JSONL editing,
+  //     and a content-only ETag would 304 conditional clients into displaying
+  //     stale activity badges indefinitely.
+  // Combining both means the ETag is stable WITHIN a 30 s window (304s work
+  // for back-to-back navigations) but rotates ACROSS windows so any
+  // time-driven status flip surfaces on the next refresh.
   const etag = computeETag({
     salt: "sessions-v1",
-    maxMtimeMs: cache.maxSessionMs,
+    maxMtimeMs: Math.max(cache.maxSessionMs, cache.cachedAt),
     parts: [project ?? "", cache.sessions.length],
   });
 

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { loadCatalog } from "@/lib/indexer/catalog";
 import { buildSkillAliasMap } from "@/lib/indexer/canonicalize";
 import { parseAllSessions } from "@/lib/usage/parser";
@@ -6,6 +6,7 @@ import { groupSkillCalls } from "@/lib/usage/skillParser";
 import { getCachedScan } from "@/lib/cache";
 import { pathToUsageSlug } from "@/lib/usage/slug";
 import { skillUpdateCache } from "@/lib/skillUpdateCache";
+import { jsonWithCacheControl } from "@/lib/httpCache";
 import type { QueueItem } from "@/lib/skillUpdateCache";
 import type { SkillStats } from "@/lib/usage/types";
 import type { SkillEntry } from "@/lib/indexer/types";
@@ -65,7 +66,7 @@ export async function GET(request: NextRequest) {
   const cached = getRouteCache(cacheKey);
   if (cached) {
     skillUpdateCache.enqueue(buildUpdateItems(cached));
-    return NextResponse.json(cached);
+    return jsonWithCacheControl(cached);
   }
 
   const [catalog, sessionMap] = await Promise.all([
@@ -145,5 +146,5 @@ export async function GET(request: NextRequest) {
   setRouteCache(cacheKey, result);
   skillUpdateCache.enqueue(buildUpdateItems(result));
 
-  return NextResponse.json(result);
+  return jsonWithCacheControl(result);
 }

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,33 +1,52 @@
-import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { scanAllProjects } from "@/lib/scanner";
 import { getCachedScan, setCachedScan } from "@/lib/cache";
 import { computeStats } from "@/lib/stats";
 import { scanClaudeConversationsForProjects } from "@/lib/scanner/claudeConversations";
+import { getJsonlMaxMtime, parseAllSessions } from "@/lib/usage/parser";
+import { computeETag, ifNoneMatch, jsonWithETag } from "@/lib/httpCache";
 import { ClaudeUsageStats } from "@/lib/types";
 
 const CLAUDE_USAGE_TTL = 10 * 60_000; // 10 minutes
 
-// globalThis singleton — survives Next.js module reloads
+// globalThis singleton — survives Next.js module reloads. The slot includes
+// the max JSONL mtime captured at refresh time so the ETag describes the
+// bytes we serve, not the current filesystem state.
 const globalForStats = globalThis as unknown as {
-  __claudeUsageCache?: { usage: ClaudeUsageStats; cachedAt: number };
+  __claudeUsageCache?: { usage: ClaudeUsageStats; cachedAt: number; maxMtime: number };
 };
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   let result = getCachedScan();
   if (!result) {
     result = await scanAllProjects();
     setCachedScan(result);
   }
 
-  // Fetch Claude usage stats scoped to scanned projects only
   let cache = globalForStats.__claudeUsageCache;
   if (!cache || Date.now() - cache.cachedAt > CLAUDE_USAGE_TTL) {
     const projectPaths = result.projects.map((p) => p.path);
+    // parseAllSessions populates the FileCache so getJsonlMaxMtime() reflects
+    // every JSONL we just considered. Snapshot it into the cache slot.
+    await parseAllSessions();
     const usage = await scanClaudeConversationsForProjects(projectPaths);
-    cache = { usage, cachedAt: Date.now() };
+    cache = {
+      usage,
+      cachedAt: Date.now(),
+      maxMtime: getJsonlMaxMtime(),
+    };
     globalForStats.__claudeUsageCache = cache;
   }
 
+  // ETag combines scan freshness + JSONL freshness as captured at last refresh.
+  const etag = computeETag({
+    salt: "stats-v1",
+    maxMtimeMs: Math.max(cache.maxMtime, new Date(result.scannedAt).getTime()),
+  });
+
+  const notModified = ifNoneMatch(request, etag);
+  if (notModified) return notModified;
+
   const stats = computeStats(result.projects, result.hiddenCount, cache.usage);
-  return NextResponse.json(stats);
+  return jsonWithETag(stats, etag);
 }

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -1,12 +1,24 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { generateUsageReport } from "@/lib/usage/aggregator";
 import { validatePeriod } from "@/lib/usage/constants";
+import { getJsonlMaxMtime } from "@/lib/usage/parser";
+import { computeETag, ifNoneMatch, jsonWithETag } from "@/lib/httpCache";
 import type { UsageReport } from "@/lib/usage/types";
 
 const CACHE_TTL = 2 * 60_000;
 
+interface UsageCacheSlot {
+  report: UsageReport;
+  cachedAt: number;
+  // Snapshot of `getJsonlMaxMtime()` at report-generation time. Used as the
+  // ETag input so the ETag describes the bytes we're about to serve, not the
+  // current filesystem state — otherwise a JSONL change inside the cache TTL
+  // window would rotate the ETag while the served bytes stayed identical.
+  maxMtime: number;
+}
+
 const globalForUsage = globalThis as unknown as {
-  __usageCache?: Map<string, { report: UsageReport; cachedAt: number }>;
+  __usageCache?: Map<string, UsageCacheSlot>;
 };
 
 if (!globalForUsage.__usageCache) {
@@ -21,13 +33,28 @@ export async function GET(request: NextRequest) {
   const cacheKey = `${safePeriod}:${project || "all"}`;
   const cache = globalForUsage.__usageCache!;
   const cached = cache.get(cacheKey);
+  const fresh = cached && Date.now() - cached.cachedAt < CACHE_TTL;
 
-  if (cached && Date.now() - cached.cachedAt < CACHE_TTL) {
-    return NextResponse.json(cached.report);
+  let slot: UsageCacheSlot;
+  if (fresh) {
+    slot = cached!;
+  } else {
+    const report = await generateUsageReport(safePeriod, project);
+    // Capture max mtime AFTER generateUsageReport — it calls parseAllSessions
+    // which populates the FileCache, so getJsonlMaxMtime() now reflects every
+    // input file we read for this report.
+    slot = { report, cachedAt: Date.now(), maxMtime: getJsonlMaxMtime() };
+    cache.set(cacheKey, slot);
   }
 
-  const report = await generateUsageReport(safePeriod, project);
-  cache.set(cacheKey, { report, cachedAt: Date.now() });
+  const etag = computeETag({
+    salt: "usage-v1",
+    maxMtimeMs: slot.maxMtime,
+    parts: [safePeriod, project ?? ""],
+  });
 
-  return NextResponse.json(report);
+  const notModified = ifNoneMatch(request, etag);
+  if (notModified) return notModified;
+
+  return jsonWithETag(slot.report, etag);
 }

--- a/src/lib/atomicWrite.ts
+++ b/src/lib/atomicWrite.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+// Atomic file write + per-file mutex. Used by every writer that touches a
+// long-lived file the user (or another reader) might be observing — config,
+// TODO.md, MANUAL_STEPS.md, INSIGHTS.md, .claude/settings.json, .mcp.json.
+//
+// Why the tmp+rename dance:
+// - A plain `fs.writeFile` can leave the file half-written if the process
+//   crashes (or HMR reloads) mid-flush. A reader that lands during that
+//   window sees a corrupted file. `rename` is atomic on Windows and POSIX,
+//   so a reader either sees the old file or the new file — never a partial.
+// - The tmp suffix includes pid + random bits so two concurrent writers in
+//   the same process don't fight over the same tmp path.
+//
+// Why withFileLock as well:
+// - rename atomicity protects byte-level integrity, not logical integrity.
+//   If two callers do read→modify→write on the same file in parallel, both
+//   read the same starting state and the second write clobbers the first's
+//   changes. Per-path mutex ensures read-modify-write cycles serialize.
+
+const fileLocks = new Map<string, Promise<unknown>>();
+
+export function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const normalized = path.resolve(filePath);
+  const prev = fileLocks.get(normalized) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  fileLocks.set(normalized, next);
+  next.finally(() => {
+    if (fileLocks.get(normalized) === next) {
+      fileLocks.delete(normalized);
+    }
+  });
+  return next;
+}
+
+export async function writeFileAtomic(
+  filePath: string,
+  content: string,
+  encoding: BufferEncoding = "utf-8"
+): Promise<void> {
+  const tmp =
+    filePath +
+    ".tmp." +
+    process.pid +
+    "." +
+    Math.random().toString(36).slice(2, 8);
+  try {
+    await fs.writeFile(tmp, content, encoding);
+    await fs.rename(tmp, filePath);
+  } catch (err) {
+    // If rename failed, the tmp file may still be there — best-effort cleanup.
+    try { await fs.unlink(tmp); } catch { /* ignore */ }
+    throw err;
+  }
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -2,22 +2,24 @@ import { ScanResult } from "./types";
 
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
-let cachedResult: ScanResult | null = null;
-let cachedAt: number = 0;
+// Stored on globalThis so the cache survives Next.js HMR module reloads —
+// previously each reload reset the cache and forced a full project rescan.
+const g = globalThis as unknown as {
+  __scanCache?: { result: ScanResult; cachedAt: number };
+};
 
 export function getCachedScan(): ScanResult | null {
-  if (cachedResult && Date.now() - cachedAt < CACHE_TTL) {
-    return cachedResult;
+  const cache = g.__scanCache;
+  if (cache && Date.now() - cache.cachedAt < CACHE_TTL) {
+    return cache.result;
   }
   return null;
 }
 
 export function setCachedScan(result: ScanResult): void {
-  cachedResult = result;
-  cachedAt = Date.now();
+  g.__scanCache = { result, cachedAt: Date.now() };
 }
 
 export function invalidateCache(): void {
-  cachedResult = null;
-  cachedAt = 0;
+  g.__scanCache = undefined;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import { MinderConfig, ProjectStatus } from "./types";
 import { getDefaultDevRoot } from "./platform";
+import { writeFileAtomic, withFileLock } from "./atomicWrite";
 
 const CONFIG_PATH = path.join(process.cwd(), ".minder.json");
 
@@ -31,7 +32,7 @@ export async function readConfig(): Promise<MinderConfig> {
 }
 
 export async function writeConfig(config: MinderConfig): Promise<void> {
-  await fs.writeFile(CONFIG_PATH, JSON.stringify(config, null, 2), "utf-8");
+  await writeFileAtomic(CONFIG_PATH, JSON.stringify(config, null, 2));
 }
 
 export async function getProjectStatus(slug: string): Promise<ProjectStatus> {
@@ -39,11 +40,33 @@ export async function getProjectStatus(slug: string): Promise<ProjectStatus> {
   return config.statuses[slug] || "active";
 }
 
+/**
+ * Read-modify-write helper. Use this for any in-place config mutation —
+ * locking the whole r/m/w cycle, not just the write, is what prevents lost
+ * updates when two concurrent mutations would otherwise read the same
+ * starting state and clobber each other.
+ *
+ * The mutator may either return a new MinderConfig or mutate the passed-in
+ * one and return void. Either way, the result (or the mutated input) is
+ * written back atomically.
+ */
+export async function mutateConfig(
+  fn: (config: MinderConfig) => Promise<MinderConfig | void> | MinderConfig | void
+): Promise<MinderConfig> {
+  return withFileLock(CONFIG_PATH, async () => {
+    const config = await readConfig();
+    const result = await fn(config);
+    const next = result ?? config;
+    await writeConfig(next);
+    return next;
+  });
+}
+
 export async function setProjectStatus(
   slug: string,
   status: ProjectStatus
 ): Promise<void> {
-  const config = await readConfig();
-  config.statuses[slug] = status;
-  await writeConfig(config);
+  await mutateConfig((config) => {
+    config.statuses[slug] = status;
+  });
 }

--- a/src/lib/httpCache.ts
+++ b/src/lib/httpCache.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+
+// Tiny ETag/Cache-Control helper for routes that derive their payload from
+// mtime-keyed file caches. The pattern:
+//   1. Build an ETag from the inputs that determine the response (max input
+//      mtime + query params + a route-specific salt).
+//   2. If the request's `If-None-Match` matches, return 304 with no body.
+//   3. Otherwise let the route compute the response and stamp it with the
+//      same ETag + a Cache-Control header.
+//
+// `stale-while-revalidate=60` lets the browser show last-known-good for up
+// to 60 s while a background revalidation request fetches the new ETag.
+// During SWR the route still runs, but the response usually short-circuits
+// to 304 so the cost is dominated by stat() not parse().
+
+const DEFAULT_CACHE_CONTROL = "private, max-age=0, stale-while-revalidate=60";
+
+export interface ETagInputs {
+  /** Largest mtime (ms since epoch) across the files this route consumes. */
+  maxMtimeMs: number;
+  /**
+   * Anything else that should cause the ETag to differ — query params, route
+   * variant, schema version. Stringified order doesn't matter as long as the
+   * same inputs always produce the same string.
+   */
+  parts?: Array<string | number | undefined>;
+  /** Route-specific salt so two routes with identical inputs don't collide. */
+  salt: string;
+}
+
+export function computeETag(inputs: ETagInputs): string {
+  const parts = (inputs.parts ?? []).map((p) => p ?? "").join("|");
+  const raw = `${inputs.salt}|${inputs.maxMtimeMs}|${parts}`;
+  // sha1 is fine here — this is a cache-bust key, not a security boundary.
+  // Quoted form per RFC 7232 §2.3.
+  const hash = crypto.createHash("sha1").update(raw).digest("hex").slice(0, 16);
+  return `"${hash}"`;
+}
+
+/** Returns a 304 response if the request's If-None-Match matches `etag`. */
+export function ifNoneMatch(request: NextRequest, etag: string): NextResponse | null {
+  const header = request.headers.get("if-none-match");
+  if (!header) return null;
+  // Allow `If-None-Match: *` (always match) and exact comma-separated lists.
+  if (header === "*" || header.split(",").some((v) => v.trim() === etag)) {
+    return new NextResponse(null, {
+      status: 304,
+      headers: {
+        ETag: etag,
+        "Cache-Control": DEFAULT_CACHE_CONTROL,
+      },
+    });
+  }
+  return null;
+}
+
+/**
+ * Stamp a JSON response with ETag + Cache-Control. Use this instead of
+ * `NextResponse.json(body)` so every response from a cached route has the
+ * same surface for browsers and intermediate caches.
+ */
+export function jsonWithETag(
+  body: unknown,
+  etag: string,
+  cacheControl: string = DEFAULT_CACHE_CONTROL
+): NextResponse {
+  const res = NextResponse.json(body);
+  res.headers.set("ETag", etag);
+  res.headers.set("Cache-Control", cacheControl);
+  return res;
+}
+
+/**
+ * Plain Cache-Control without ETag. Use for routes that don't yet have a
+ * reliable change signal (e.g. catalog routes that depend on multiple file
+ * sources we haven't mtime-cached yet) but still want browsers to dedupe
+ * back-to-back navigations. `max-age=120` matches the existing in-process
+ * 2-min TTLs those routes already use, so it doesn't change observable
+ * staleness — it just lets the client also remember.
+ */
+export function jsonWithCacheControl(
+  body: unknown,
+  cacheControl: string = "private, max-age=120"
+): NextResponse {
+  const res = NextResponse.json(body);
+  res.headers.set("Cache-Control", cacheControl);
+  return res;
+}

--- a/src/lib/manualStepsWriter.ts
+++ b/src/lib/manualStepsWriter.ts
@@ -1,41 +1,7 @@
 import { promises as fs } from "fs";
-import path from "path";
 import { parseManualStepsMd } from "./scanner/manualStepsMd";
 import { ManualStepsInfo } from "./types";
-
-/**
- * Per-file mutex to serialize read-modify-write cycles.
- * Prevents concurrent toggles from clobbering each other.
- */
-const fileLocks = new Map<string, Promise<unknown>>();
-
-function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
-  const normalized = path.resolve(filePath);
-  const prev = fileLocks.get(normalized) ?? Promise.resolve();
-  const next = prev.then(fn, fn); // run fn after previous completes (even if it failed)
-  fileLocks.set(normalized, next);
-  // Clean up the map entry once this operation finishes
-  next.finally(() => {
-    if (fileLocks.get(normalized) === next) {
-      fileLocks.delete(normalized);
-    }
-  });
-  return next;
-}
-
-/**
- * Atomic write: write to a temp file then rename.
- * On Windows, rename overwrites the target atomically at the FS level,
- * so concurrent readers never see partial content.
- */
-async function atomicWriteFile(
-  filePath: string,
-  content: string
-): Promise<void> {
-  const tmpPath = filePath + ".tmp." + process.pid;
-  await fs.writeFile(tmpPath, content, "utf-8");
-  await fs.rename(tmpPath, filePath);
-}
+import { writeFileAtomic, withFileLock } from "./atomicWrite";
 
 export async function toggleStepInFile(
   filePath: string,
@@ -66,7 +32,7 @@ export async function toggleStepInFile(
     }
 
     const newContent = lines.join("\n");
-    await atomicWriteFile(filePath, newContent);
+    await writeFileAtomic(filePath, newContent);
     return parseManualStepsMd(newContent);
   });
 }

--- a/src/lib/scanner/insightsMd.ts
+++ b/src/lib/scanner/insightsMd.ts
@@ -4,6 +4,7 @@ import os from "os";
 import crypto from "crypto";
 import { InsightEntry, InsightsInfo } from "../types";
 import { encodePath, toSlug } from "./claudeConversations";
+import { writeFileAtomic } from "../atomicWrite";
 
 // ─── Dedup ID ────────────────────────────────────────────────────────────────
 
@@ -209,7 +210,7 @@ export async function appendInsights(
   const finalContent =
     `# Insights\n\n` + formattedEntries.join("\n") + (existingBody ? `\n${existingBody}` : "");
 
-  await fs.writeFile(insightsMdPath, finalContent, "utf-8");
+  await writeFileAtomic(insightsMdPath, finalContent);
   return { count: newEntries.length, content: finalContent };
 }
 

--- a/src/lib/scanner/insightsMd.ts
+++ b/src/lib/scanner/insightsMd.ts
@@ -4,7 +4,7 @@ import os from "os";
 import crypto from "crypto";
 import { InsightEntry, InsightsInfo } from "../types";
 import { encodePath, toSlug } from "./claudeConversations";
-import { writeFileAtomic } from "../atomicWrite";
+import { writeFileAtomic, withFileLock } from "../atomicWrite";
 
 // ─── Dedup ID ────────────────────────────────────────────────────────────────
 
@@ -167,51 +167,58 @@ export async function appendInsights(
 
   const insightsMdPath = path.join(projectPath, "INSIGHTS.md");
 
-  let existingContent = "";
-  try {
-    existingContent = await fs.readFile(insightsMdPath, "utf-8");
-  } catch {
-    // File doesn't exist yet
-  }
+  // Lock the entire read→dedupe→write sequence. `writeFileAtomic` alone
+  // protects byte-level integrity, but two concurrent appendInsights calls
+  // (e.g. a background scan + a worktree-sync request) would each read the
+  // same starting state and the second writer would clobber the first's
+  // additions. Locking the whole RMW serializes them so both batches land.
+  return withFileLock(insightsMdPath, async () => {
+    let existingContent = "";
+    try {
+      existingContent = await fs.readFile(insightsMdPath, "utf-8");
+    } catch {
+      // File doesn't exist yet
+    }
 
-  const { knownIds } = parseInsightsMd(existingContent);
+    const { knownIds } = parseInsightsMd(existingContent);
 
-  const seen = new Set(knownIds);
-  const newEntries = entries.filter((e) => {
-    if (seen.has(e.id)) return false;
-    seen.add(e.id);
-    return true;
+    const seen = new Set(knownIds);
+    const newEntries = entries.filter((e) => {
+      if (seen.has(e.id)) return false;
+      seen.add(e.id);
+      return true;
+    });
+
+    if (newEntries.length === 0) return { count: 0, content: null };
+
+    newEntries.sort((a, b) => {
+      const dateA = new Date(a.date).getTime() || 0;
+      const dateB = new Date(b.date).getTime() || 0;
+      return dateB - dateA;
+    });
+
+    const formattedEntries = newEntries.map((e) => {
+      const d = e.date ? new Date(e.date) : null;
+      const dateStr = d && isFinite(d.getTime()) ? d.toISOString() : "unknown";
+      return (
+        `<!-- insight:${e.id} | session:${e.sessionId} | ${dateStr} -->\n` +
+        `## ★ Insight\n` +
+        `${e.content}\n` +
+        `\n` +
+        `---\n`
+      );
+    });
+
+    const existingBody = existingContent
+      .replace(/^#\s+Insights\s*(?:\r?\n)+/, "")
+      .trimStart();
+
+    const finalContent =
+      `# Insights\n\n` + formattedEntries.join("\n") + (existingBody ? `\n${existingBody}` : "");
+
+    await writeFileAtomic(insightsMdPath, finalContent);
+    return { count: newEntries.length, content: finalContent };
   });
-
-  if (newEntries.length === 0) return { count: 0, content: null };
-
-  newEntries.sort((a, b) => {
-    const dateA = new Date(a.date).getTime() || 0;
-    const dateB = new Date(b.date).getTime() || 0;
-    return dateB - dateA;
-  });
-
-  const formattedEntries = newEntries.map((e) => {
-    const d = e.date ? new Date(e.date) : null;
-    const dateStr = d && isFinite(d.getTime()) ? d.toISOString() : "unknown";
-    return (
-      `<!-- insight:${e.id} | session:${e.sessionId} | ${dateStr} -->\n` +
-      `## ★ Insight\n` +
-      `${e.content}\n` +
-      `\n` +
-      `---\n`
-    );
-  });
-
-  const existingBody = existingContent
-    .replace(/^#\s+Insights\s*(?:\r?\n)+/, "")
-    .trimStart();
-
-  const finalContent =
-    `# Insights\n\n` + formattedEntries.join("\n") + (existingBody ? `\n${existingBody}` : "");
-
-  await writeFileAtomic(insightsMdPath, finalContent);
-  return { count: newEntries.length, content: finalContent };
 }
 
 // ─── INSIGHTS.md Parser ───────────────────────────────────────────────────────

--- a/src/lib/setupApply.ts
+++ b/src/lib/setupApply.ts
@@ -13,6 +13,7 @@ import {
   HOOKS_VALIDATE_TODO,
   HOOKS_VALIDATE_MANUAL_STEPS,
 } from "./setup-content";
+import { writeFileAtomic } from "./atomicWrite";
 
 export type ApplyAction = "claude-md" | "hooks" | "both";
 export type ApplyStatus = "applied" | "already-present";
@@ -107,7 +108,7 @@ async function applyClaudeMd(projectPath: string): Promise<ClaudeMdResult> {
       await backupFile(claudeMdPath);
       content = existing.trimEnd() + "\n\n" + blocksToAdd.join("\n\n");
     }
-    await fs.writeFile(claudeMdPath, content, "utf-8");
+    await writeFileAtomic(claudeMdPath, content);
   }
 
   return {
@@ -144,7 +145,7 @@ async function writeScriptIdempotent(filePath: string, content: string): Promise
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
     // File doesn't exist — write it fresh
   }
-  await fs.writeFile(filePath, content, "utf-8");
+  await writeFileAtomic(filePath, content);
   return "applied";
 }
 
@@ -192,6 +193,6 @@ async function mergeSettingsJson(settingsPath: string): Promise<ApplyStatus> {
   if (!Array.isArray(settings.hooks.PreToolUse)) settings.hooks.PreToolUse = [];
   settings.hooks.PreToolUse.push({ ...DESIRED_HOOK_ENTRY, hooks: missingHooks });
 
-  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
+  await writeFileAtomic(settingsPath, JSON.stringify(settings, null, 2));
   return "applied";
 }

--- a/src/lib/template/atomicFs.ts
+++ b/src/lib/template/atomicFs.ts
@@ -1,34 +1,12 @@
 import { promises as fs } from "fs";
 import path from "path";
+import { writeFileAtomic, withFileLock as sharedWithFileLock } from "../atomicWrite";
 
-/**
- * Per-file mutex keyed on the resolved absolute path. Mirrors the pattern in
- * `manualStepsWriter.ts` — a separate Map here is fine because Template Mode
- * targets `.claude/settings.json` and `.mcp.json`, which manual steps never
- * touch. Sharing a Map across modules would only matter if they wrote the same
- * files, which they don't.
- */
-const fileLocks = new Map<string, Promise<unknown>>();
-
-export function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
-  const normalized = path.resolve(filePath);
-  const prev = fileLocks.get(normalized) ?? Promise.resolve();
-  const next = prev.then(fn, fn);
-  fileLocks.set(normalized, next);
-  next.finally(() => {
-    if (fileLocks.get(normalized) === next) {
-      fileLocks.delete(normalized);
-    }
-  });
-  return next;
-}
-
-/** Write to a temp sibling, then rename. Rename is atomic on Windows and POSIX. */
-export async function atomicWriteFile(filePath: string, content: string): Promise<void> {
-  const tmp = filePath + ".tmp." + process.pid + "." + Math.random().toString(36).slice(2, 8);
-  await fs.writeFile(tmp, content, "utf-8");
-  await fs.rename(tmp, filePath);
-}
+// Re-exported under the historic name `atomicWriteFile` so the template-mode
+// callers don't need to be touched. New call sites should import
+// `writeFileAtomic` from `@/lib/atomicWrite` directly.
+export const atomicWriteFile = writeFileAtomic;
+export const withFileLock = sharedWithFileLock;
 
 export async function ensureDir(dir: string): Promise<void> {
   await fs.mkdir(dir, { recursive: true });

--- a/src/lib/todoWriter.ts
+++ b/src/lib/todoWriter.ts
@@ -2,34 +2,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import { scanTodoMd } from "./scanner/todoMd";
 import { TodoInfo } from "./types";
-
-/**
- * Per-file mutex to serialize read-modify-write cycles.
- * Prevents concurrent appends from clobbering each other.
- */
-const fileLocks = new Map<string, Promise<unknown>>();
-
-function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
-  const normalized = path.resolve(filePath);
-  const prev = fileLocks.get(normalized) ?? Promise.resolve();
-  const next = prev.then(fn, fn);
-  fileLocks.set(normalized, next);
-  next.finally(() => {
-    if (fileLocks.get(normalized) === next) {
-      fileLocks.delete(normalized);
-    }
-  });
-  return next;
-}
-
-async function atomicWriteFile(
-  filePath: string,
-  content: string
-): Promise<void> {
-  const tmpPath = filePath + ".tmp." + process.pid;
-  await fs.writeFile(tmpPath, content, "utf-8");
-  await fs.rename(tmpPath, filePath);
-}
+import { writeFileAtomic, withFileLock } from "./atomicWrite";
 
 const MAX_TODO_LENGTH = 500;
 
@@ -92,7 +65,7 @@ export async function appendTodosToFile(
     const appended =
       base + sanitized.map((t) => `- [ ] ${t}`).join("\n") + "\n";
 
-    await atomicWriteFile(filePath, appended);
+    await writeFileAtomic(filePath, appended);
 
     const info = await scanTodoMd(projectPath);
     // scanTodoMd returns undefined only if zero items — after an append this
@@ -132,7 +105,7 @@ export async function toggleTodoInFile(
     }
 
     if (changed) {
-      await atomicWriteFile(filePath, lines.join("\n"));
+      await writeFileAtomic(filePath, lines.join("\n"));
     }
     const info = await scanTodoMd(projectPath);
     return info ?? { total: 0, completed: 0, pending: 0, items: [] };

--- a/src/lib/usage/cache.ts
+++ b/src/lib/usage/cache.ts
@@ -103,6 +103,22 @@ export class FileCache<T> {
   }
 
   /**
+   * Drop every cached slot whose path is not in `liveSet`. Callers that walk
+   * a known set of files (e.g. `readdir` of a session directory) can pass the
+   * set in to evict slots for files that disappeared since the last sweep.
+   *
+   * Without this, `maxMtimeMs()` keeps reflecting the mtime of a deleted file
+   * forever, which makes ETags stick to a value that no longer corresponds to
+   * any real input — clients would then get 304s after a session deletion
+   * even though the response body did change.
+   */
+  retainOnly(liveSet: Set<string>): void {
+    for (const path of this.slots.keys()) {
+      if (!liveSet.has(path)) this.slots.delete(path);
+    }
+  }
+
+  /**
    * Max mtime across all currently cached entries — exposed as a side-channel
    * so routes can compute an ETag without changing parser return signatures.
    */

--- a/src/lib/usage/cache.ts
+++ b/src/lib/usage/cache.ts
@@ -1,0 +1,132 @@
+import { promises as fs } from "fs";
+
+// Generic file-keyed cache: stores a parsed/derived value for an absolute file
+// path and only re-runs the factory when the file's mtime or size has changed.
+// This replaces TTL-based caches whose only job was "throw everything out
+// occasionally so we eventually pick up edits" — the filesystem already tells
+// us when a file changed, so we ask it directly.
+//
+// Design notes:
+// - mtime+size is the change-detection key. Resolution can be 1 s on some FS,
+//   but a same-second edit that produces an identical size is vanishingly rare
+//   for the append-only JSONL files this is built for.
+// - LRU eviction by `lastSeenAt`: with mtime caching, files that never change
+//   again sit in memory forever. We sweep on access once we exceed `maxEntries`
+//   so a long-running dev server doesn't grow unbounded.
+// - Single-flight on the per-file factory: if two callers request the same
+//   file simultaneously, only one factory call runs. Cold-path matters for
+//   `parseAllSessions()` which this caches — see usage in `parser.ts`.
+
+interface CacheSlot<T> {
+  mtimeMs: number;
+  size: number;
+  value: T;
+  lastSeenAt: number;
+}
+
+export interface FileCacheOptions {
+  /** Maximum entries before LRU eviction kicks in. Default: 5000. */
+  maxEntries?: number;
+}
+
+export class FileCache<T> {
+  private readonly slots = new Map<string, CacheSlot<T>>();
+  private readonly inFlight = new Map<string, Promise<T>>();
+  private readonly maxEntries: number;
+
+  constructor(opts: FileCacheOptions = {}) {
+    this.maxEntries = opts.maxEntries ?? 5000;
+  }
+
+  /** Number of cached entries (for tests and metrics). */
+  get size(): number {
+    return this.slots.size;
+  }
+
+  /**
+   * Returns the cached value if the file's mtime and size are unchanged,
+   * otherwise runs `factory(filePath)`, stores the result, and returns it.
+   * Returns `undefined` if the file can't be stat'd (deleted, permission, etc.)
+   * — the caller decides whether absence is fatal.
+   */
+  async getOrCompute(
+    filePath: string,
+    factory: (filePath: string) => Promise<T>
+  ): Promise<T | undefined> {
+    let stat;
+    try {
+      stat = await fs.stat(filePath);
+    } catch {
+      // File gone — drop any cached entry so we don't return stale data later.
+      this.slots.delete(filePath);
+      return undefined;
+    }
+
+    const mtimeMs = stat.mtimeMs;
+    const size = stat.size;
+    const now = Date.now();
+
+    const cached = this.slots.get(filePath);
+    if (cached && cached.mtimeMs === mtimeMs && cached.size === size) {
+      cached.lastSeenAt = now;
+      return cached.value;
+    }
+
+    // Coalesce concurrent requests for the same file. Without this, two callers
+    // that both miss the cache would each parse the file independently.
+    const existing = this.inFlight.get(filePath);
+    if (existing) return existing;
+
+    const promise = (async () => {
+      const value = await factory(filePath);
+      this.slots.set(filePath, { mtimeMs, size, value, lastSeenAt: Date.now() });
+      this.evictIfNeeded();
+      return value;
+    })();
+
+    this.inFlight.set(filePath, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inFlight.delete(filePath);
+    }
+  }
+
+  /** Drop a single entry. */
+  delete(filePath: string): void {
+    this.slots.delete(filePath);
+  }
+
+  /** Drop everything. */
+  clear(): void {
+    this.slots.clear();
+  }
+
+  /**
+   * Max mtime across all currently cached entries — exposed as a side-channel
+   * so routes can compute an ETag without changing parser return signatures.
+   */
+  maxMtimeMs(): number {
+    let max = 0;
+    for (const slot of this.slots.values()) {
+      if (slot.mtimeMs > max) max = slot.mtimeMs;
+    }
+    return max;
+  }
+
+  /**
+   * LRU eviction by lastSeenAt. We trim to 80% of capacity in a single sweep
+   * so we don't pay the sort cost on every insert near the boundary.
+   */
+  private evictIfNeeded(): void {
+    if (this.slots.size <= this.maxEntries) return;
+    const target = Math.floor(this.maxEntries * 0.8);
+    const entries = Array.from(this.slots.entries()).sort(
+      (a, b) => a[1].lastSeenAt - b[1].lastSeenAt
+    );
+    const toEvict = entries.length - target;
+    for (let i = 0; i < toEvict; i++) {
+      this.slots.delete(entries[i][0]);
+    }
+  }
+}

--- a/src/lib/usage/parser.ts
+++ b/src/lib/usage/parser.ts
@@ -6,13 +6,27 @@ import {
   type ConversationEntry,
 } from "@/lib/scanner/claudeConversations";
 import type { UsageTurn } from "./types";
+import { FileCache } from "./cache";
 
 const MAX_SESSION_FILE_SIZE = 50 * 1024 * 1024; // 50MB
-const CACHE_TTL_MS = 2 * 60 * 1000; // 2 minutes
 
+// Per-file mtime-keyed cache. Replaces the old 2-min TTL: with mtime caching,
+// we only re-parse files that actually changed since last seen. Memory ceiling
+// is bounded by FileCache's LRU sweep.
+//
+// Stored on globalThis so the cache survives Next.js HMR module reloads. Same
+// rationale as the existing globalThis caches in /api/sessions, /api/stats etc.
 const globalForParser = globalThis as unknown as {
-  __usageParserCache?: { data: Map<string, UsageTurn[]>; cachedAt: number };
+  __usageFileCache?: FileCache<UsageTurn[]>;
+  __usageAllSessionsInFlight?: Promise<Map<string, UsageTurn[]>>;
 };
+
+function getFileCache(): FileCache<UsageTurn[]> {
+  if (!globalForParser.__usageFileCache) {
+    globalForParser.__usageFileCache = new FileCache<UsageTurn[]>({ maxEntries: 5000 });
+  }
+  return globalForParser.__usageFileCache;
+}
 
 // ── Content extraction helpers ────────────────────────────────────────────────
 
@@ -166,33 +180,23 @@ export async function parseSessionTurns(
   return turns;
 }
 
-// ── All-sessions parser with caching ─────────────────────────────────────────
+// ── All-sessions parser with mtime caching ───────────────────────────────────
 
-export async function parseAllSessions(): Promise<Map<string, UsageTurn[]>> {
-  // Check cache
-  const cached = globalForParser.__usageParserCache;
-  if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS) {
-    return cached.data;
-  }
-
+async function buildAllSessions(): Promise<Map<string, UsageTurn[]>> {
   const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const cache = getFileCache();
 
   let subdirs: string[];
   try {
     const entries = await fs.readdir(projectsDir, { withFileTypes: true });
-    subdirs = entries
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name);
+    subdirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
   } catch {
-    // ~/.claude/projects doesn't exist yet
-    const empty = new Map<string, UsageTurn[]>();
-    globalForParser.__usageParserCache = { data: empty, cachedAt: Date.now() };
-    return empty;
+    return new Map();
   }
 
   const result = new Map<string, UsageTurn[]>();
 
-  // Process subdirectories in batches of 5
+  // Process subdirectories in batches of 5 to avoid overwhelming the FS.
   for (let i = 0; i < subdirs.length; i += 5) {
     const batch = subdirs.slice(i, i + 5);
     await Promise.all(
@@ -209,17 +213,27 @@ export async function parseAllSessions(): Promise<Map<string, UsageTurn[]>> {
         for (const file of files) {
           const filePath = path.join(dirPath, file);
 
-          // Check file size
-          try {
-            const stat = await fs.stat(filePath);
-            if (stat.size > MAX_SESSION_FILE_SIZE) continue;
-          } catch {
-            continue;
-          }
+          // FileCache stat's the file, returns the cached parse if mtime+size
+          // are unchanged, otherwise calls the factory. Skip oversized files
+          // before parsing — they're typically session-in-progress logs that
+          // we'll re-evaluate on the next sweep when they may have been rolled.
+          //
+          // The factory has its own try/catch because a file can disappear in
+          // the gap between the FileCache's outer stat and our second stat
+          // (log rotation, session pruning). Pre-P1 behavior was "one bad
+          // file doesn't kill the sweep" — keep it.
+          const turns = await cache.getOrCompute(filePath, async (fp) => {
+            try {
+              const stat = await fs.stat(fp);
+              if (stat.size > MAX_SESSION_FILE_SIZE) return [];
+              return await parseSessionTurns(fp, dirName);
+            } catch {
+              return [];
+            }
+          });
 
-          const sessionId = path.basename(file, ".jsonl");
-          const turns = await parseSessionTurns(filePath, dirName);
-          if (turns.length > 0) {
+          if (turns && turns.length > 0) {
+            const sessionId = path.basename(file, ".jsonl");
             result.set(sessionId, turns);
           }
         }
@@ -227,6 +241,32 @@ export async function parseAllSessions(): Promise<Map<string, UsageTurn[]>> {
     );
   }
 
-  globalForParser.__usageParserCache = { data: result, cachedAt: Date.now() };
   return result;
+}
+
+export async function parseAllSessions(): Promise<Map<string, UsageTurn[]>> {
+  // Single-flight: if pulse + dashboard mount fire in parallel on a cold
+  // server, only one of them does the 1.1 GB sweep — the rest await the
+  // same promise. After the first call settles, subsequent calls hit the
+  // FileCache directly and stat 3k files (cheap), no full re-parse.
+  if (globalForParser.__usageAllSessionsInFlight) {
+    return globalForParser.__usageAllSessionsInFlight;
+  }
+  const promise = buildAllSessions().finally(() => {
+    globalForParser.__usageAllSessionsInFlight = undefined;
+  });
+  globalForParser.__usageAllSessionsInFlight = promise;
+  return promise;
+}
+
+/**
+ * Max mtime across all currently cached JSONL files. Used as the input to
+ * route ETag computation — when no file has changed since the last response,
+ * the ETag is identical and the route can return 304.
+ *
+ * Note: this only reflects files that have been parsed at least once. Until
+ * the first `parseAllSessions()` call completes, it returns 0.
+ */
+export function getJsonlMaxMtime(): number {
+  return getFileCache().maxMtimeMs();
 }

--- a/src/lib/usage/parser.ts
+++ b/src/lib/usage/parser.ts
@@ -195,6 +195,12 @@ async function buildAllSessions(): Promise<Map<string, UsageTurn[]>> {
   }
 
   const result = new Map<string, UsageTurn[]>();
+  // Track every JSONL we observed during this sweep so we can evict slots for
+  // files that were deleted since the last call. Without this, `maxMtimeMs()`
+  // keeps reflecting a deleted file's mtime forever and ETags stick to a
+  // value that no longer matches reality — clients would get 304s after a
+  // session deletion even though the response body changed.
+  const liveSet = new Set<string>();
 
   // Process subdirectories in batches of 5 to avoid overwhelming the FS.
   for (let i = 0; i < subdirs.length; i += 5) {
@@ -212,6 +218,7 @@ async function buildAllSessions(): Promise<Map<string, UsageTurn[]>> {
 
         for (const file of files) {
           const filePath = path.join(dirPath, file);
+          liveSet.add(filePath);
 
           // FileCache stat's the file, returns the cached parse if mtime+size
           // are unchanged, otherwise calls the factory. Skip oversized files
@@ -241,6 +248,9 @@ async function buildAllSessions(): Promise<Map<string, UsageTurn[]>> {
     );
   }
 
+  // Evict slots for files that disappeared since the last sweep. This keeps
+  // `maxMtimeMs()` honest as a change signal for ETag computation.
+  cache.retainOnly(liveSet);
   return result;
 }
 

--- a/tests/fileCache.test.ts
+++ b/tests/fileCache.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FileCache } from "@/lib/usage/cache";
+
+vi.mock("fs", () => ({
+  promises: {
+    stat: vi.fn(),
+  },
+}));
+
+import { promises as fs } from "fs";
+const mockStat = vi.mocked(fs.stat);
+
+beforeEach(() => vi.clearAllMocks());
+
+function statResult(mtimeMs: number, size: number) {
+  return { mtimeMs, size } as unknown as Awaited<ReturnType<typeof fs.stat>>;
+}
+
+describe("FileCache", () => {
+  it("runs the factory once and caches the result while mtime/size are stable", async () => {
+    mockStat.mockResolvedValue(statResult(1000, 100));
+    const cache = new FileCache<string>();
+    const factory = vi.fn(async () => "parsed");
+
+    const a = await cache.getOrCompute("/x", factory);
+    const b = await cache.getOrCompute("/x", factory);
+
+    expect(a).toBe("parsed");
+    expect(b).toBe("parsed");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-runs the factory when mtime changes", async () => {
+    const cache = new FileCache<string>();
+    const factory = vi.fn(async () => "v" + factory.mock.calls.length);
+
+    mockStat.mockResolvedValueOnce(statResult(1000, 100));
+    await cache.getOrCompute("/x", factory);
+    mockStat.mockResolvedValueOnce(statResult(2000, 100));
+    const result = await cache.getOrCompute("/x", factory);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(result).toBe("v2");
+  });
+
+  it("re-runs the factory when size changes (mtime collision)", async () => {
+    const cache = new FileCache<string>();
+    const factory = vi.fn(async () => "v" + factory.mock.calls.length);
+
+    mockStat.mockResolvedValueOnce(statResult(1000, 100));
+    await cache.getOrCompute("/x", factory);
+    mockStat.mockResolvedValueOnce(statResult(1000, 200));
+    await cache.getOrCompute("/x", factory);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns undefined and drops the entry when stat fails", async () => {
+    const cache = new FileCache<string>();
+    const factory = vi.fn(async () => "v");
+
+    mockStat.mockResolvedValueOnce(statResult(1000, 100));
+    await cache.getOrCompute("/x", factory);
+    expect(cache.size).toBe(1);
+
+    mockStat.mockRejectedValueOnce(new Error("ENOENT"));
+    const result = await cache.getOrCompute("/x", factory);
+
+    expect(result).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("dedupes concurrent factory calls for the same file (single-flight)", async () => {
+    mockStat.mockResolvedValue(statResult(1000, 100));
+    const cache = new FileCache<string>();
+    let pending: ((v: string) => void) | null = null;
+    const factory = vi.fn(
+      () => new Promise<string>((resolve) => { pending = resolve; })
+    );
+
+    const p1 = cache.getOrCompute("/x", factory);
+    const p2 = cache.getOrCompute("/x", factory);
+
+    // Yield once so both calls reach the in-flight registration before resolve.
+    await Promise.resolve();
+    expect(pending).not.toBeNull();
+    pending!("parsed");
+
+    expect(await p1).toBe("parsed");
+    expect(await p2).toBe("parsed");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports max mtime across all entries", async () => {
+    const cache = new FileCache<string>();
+    mockStat.mockResolvedValueOnce(statResult(1000, 1));
+    await cache.getOrCompute("/a", async () => "a");
+    mockStat.mockResolvedValueOnce(statResult(3000, 1));
+    await cache.getOrCompute("/b", async () => "b");
+    mockStat.mockResolvedValueOnce(statResult(2000, 1));
+    await cache.getOrCompute("/c", async () => "c");
+
+    expect(cache.maxMtimeMs()).toBe(3000);
+  });
+
+  it("evicts least-recently-seen entries past maxEntries", async () => {
+    const cache = new FileCache<string>({ maxEntries: 3 });
+    // /a, /b, /c all inserted; touch /a to keep it fresh; insert /d to overflow.
+    for (const f of ["/a", "/b", "/c"]) {
+      mockStat.mockResolvedValueOnce(statResult(1000, 1));
+      await cache.getOrCompute(f, async () => f);
+    }
+    mockStat.mockResolvedValueOnce(statResult(1000, 1));
+    await cache.getOrCompute("/a", async () => "a"); // refreshes /a's lastSeenAt
+
+    mockStat.mockResolvedValueOnce(statResult(1000, 1));
+    await cache.getOrCompute("/d", async () => "d");
+
+    // floor(3 * 0.8) = 2. /a and /d should survive (most recent), /b/c evicted.
+    expect(cache.size).toBe(2);
+    expect(cache.maxMtimeMs()).toBeGreaterThan(0);
+  });
+});

--- a/tests/fileCache.test.ts
+++ b/tests/fileCache.test.ts
@@ -103,6 +103,23 @@ describe("FileCache", () => {
     expect(cache.maxMtimeMs()).toBe(3000);
   });
 
+  it("retainOnly drops slots not in the live set (deleted files)", async () => {
+    const cache = new FileCache<string>();
+    mockStat.mockResolvedValueOnce(statResult(1000, 1));
+    await cache.getOrCompute("/keep", async () => "k");
+    mockStat.mockResolvedValueOnce(statResult(9999, 1));
+    await cache.getOrCompute("/drop", async () => "d");
+
+    expect(cache.size).toBe(2);
+    expect(cache.maxMtimeMs()).toBe(9999);
+
+    cache.retainOnly(new Set(["/keep"]));
+
+    expect(cache.size).toBe(1);
+    // Deleted file's mtime no longer leaks into the freshness signal.
+    expect(cache.maxMtimeMs()).toBe(1000);
+  });
+
   it("evicts least-recently-seen entries past maxEntries", async () => {
     const cache = new FileCache<string>({ maxEntries: 3 });
     // /a, /b, /c all inserted; touch /a to keep it fresh; insert /d to overflow.

--- a/tests/insightsWriter.test.ts
+++ b/tests/insightsWriter.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { appendInsights } from "@/lib/insightsWriter";
 import { InsightEntry } from "@/lib/types";
 
-// Mock fs
+// Mock fs. `rename` is needed because the writer goes through writeFileAtomic
+// (tmp + rename); the test asserts on the temp-file write rather than the
+// rename target, since that's where the formatted content lands first.
 vi.mock("fs", () => ({
   promises: {
     readFile: vi.fn(),
     writeFile: vi.fn(),
+    rename: vi.fn(async () => undefined),
   },
 }));
 


### PR DESCRIPTION
## Summary

P1 of the [performance overhaul](docs/perf/baseline-2026-04.md). The big WARM-path win: `/api/usage` warm drops from 2.27 s to 14 ms (−99 %), `/api/sessions` warm from 211 ms to 44 ms, and three routes now short-circuit to sub-100 ms 304s when their inputs haven't changed. Cross-page navigations re-using cached data drop to ≤ 110 ms.

| Route | Baseline warm | P1 warm | P1 304 |
|---|---|---|---|
| `/api/sessions` | 211 ms | **44 ms** | 11 ms |
| `/api/usage?period=month` | 2.27 s | **14 ms** | 16 ms |
| `/api/stats` | n/a | 98 ms | 94 ms |
| `/api/agents` | n/a | 18 ms | (CC only) |
| `/api/skills` | n/a | 20 ms | (CC only) |

Cold path is roughly unchanged; first-call population of the in-process FileCache is bounded by stat round-trips on 3,211 files. P2 (SQLite indexer) is what makes cold persist across restarts.

## What changed

- **`FileCache<T>` mtime primitive** (`src/lib/usage/cache.ts`) — generic per-file cache keyed on `mtimeMs + size` with single-flight dedup and LRU eviction. 7 unit tests cover invalidation, single-flight, stat-failure cleanup, max-mtime reporting, eviction.
- **Parser switched to FileCache** — `parseAllSessions()` now only re-parses changed files. The factory has its own try/catch so one bad file (race with log rotation, etc.) doesn't kill the whole sweep.
- **`writeFileAtomic` + `withFileLock`** (`src/lib/atomicWrite.ts`) — promoted from the existing duplicate implementations in `template/atomicFs.ts`, `todoWriter.ts`, `manualStepsWriter.ts`. Now the single source of truth, applied to `.minder.json`, `CLAUDE.md`, `.claude/settings.json`, `INSIGHTS.md`, `MANUAL_STEPS.md`, `TODO.md`.
- **`mutateConfig()`** — read-modify-write of `.minder.json` now runs inside `withFileLock` so concurrent API mutations don't clobber each other. `/api/config` PATCH validation is front-loaded so a half-mutated config can never be persisted on validation failure.
- **Scanner cache moved to `globalThis`** — survives HMR module reloads.
- **`computeETag` / `ifNoneMatch` / `jsonWithETag` / `jsonWithCacheControl`** (`src/lib/httpCache.ts`) — small helpers; ETag inputs are snapshotted into cache slots at generation time so the ETag describes the bytes we serve, not the current FS state.
- **ETag + `Cache-Control: private, max-age=0, stale-while-revalidate=60`** on `/api/sessions`, `/api/usage`, `/api/stats`.
- **Plain `Cache-Control: max-age=120`** on `/api/agents`, `/api/skills`. ETag deferred until the catalog walk is mtime-cached (P1.5 / P2).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 545/545 passing including 7 new `FileCache` tests
- [x] `npm run build` clean (one pre-existing NFT warning unchanged)
- [x] Cold-path bench (full restart, fresh `.next`) recorded in `docs/perf/baseline-2026-04.md`
- [x] Warm-path bench shows 99% reduction on `/api/usage`
- [x] `If-None-Match` round-trip on all three ETag'd routes returns 304 with the same ETag, sub-100 ms
- [ ] Manual smoke of `/sessions`, `/usage`, `/stats`, `/agents`, `/skills` after merge — confirm pages render normally and badges update on file changes

## What didn't change in P1 (intentionally deferred)

- Streaming session detail (`/api/sessions/[sessionId]`) — needs P2 SQLite turn metadata + byte offsets to be cheap.
- Single shared façade `src/lib/data/index.ts` — would be churn without the SQLite backend behind it. Lands with P2.
- `loadCatalog` mtime-cache + agents/skills ETag — see above; cheap once we touch the indexer for P2.

## Migration / breaking changes

None. All API responses return identical bodies; only headers added. Existing `getCachedScan` / `setCachedScan` / `invalidateCache` signatures unchanged. Existing `setProjectStatus` / `writeConfig` signatures unchanged. The duplicate `atomicWriteFile` exports in `template/atomicFs.ts` are now thin re-exports of the top-level helper — no caller updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)