### PR TITLE
chore: silence Edge-runtime warnings via instrumentation-node split

### DIFF
--- a/instrumentation-node.ts
+++ b/instrumentation-node.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+// Node-runtime-only instrumentation. Imported via dynamic `await import()`
+// from `instrumentation.ts` after that file's `process.env.NEXT_RUNTIME`
+// gate. Splitting the Node logic here is the only way to keep Turbopack
+// from compiling the `@/lib/db/...` chain for the Edge runtime — every
+// module in that graph uses `fs`, `process.cwd()`, `child_process`, etc.
+// `'server-only'` at the top makes Turbopack refuse Edge compilation of
+// this file outright, severing the trace at the dynamic-import boundary.
+//
+// Three ingest modes, in priority order:
+//
+//   MINDER_INDEXER_WORKER=1  → start the worker_threads-hosted ingest
+//                              (P2a-2.4; phase 1 = trivial ping/pong stub).
+//   MINDER_INDEXER=1         → start the in-process chokidar watcher
+//                              (P2a-2.2 / 2.3 path; remains the default
+//                              and serves as the fallback if the worker
+//                              path turns out to be broken on a given
+//                              platform / Next.js version).
+//   neither                  → no-op. Dashboard runs on the file-parse
+//                              path. Ingest is strictly additive in P2a.
+
+export async function startIngest(): Promise<void> {
+  if (process.env.MINDER_INDEXER_WORKER === "1") {
+    try {
+      const { startWorker, stopWorker } = await import("@/lib/db/workerHost");
+      // awaitStart: false — return as soon as the worker is alive and
+      // the watcher module is loaded. The initial reconcile runs in
+      // the background; instrumentation doesn't block server startup
+      // on it.
+      //
+      // onStartFailure — if the async start handshake fails (worker
+      // is alive but the watcher inside it couldn't start, e.g. DB
+      // driver unavailable or watcher init throws), tear down the
+      // worker and switch to the in-process watcher so ingest doesn't
+      // silently stay off.
+      const status = await startWorker({
+        awaitStart: false,
+        onStartFailure: (err: Error) => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[ingest-worker] async start failed (${err.message}); switching to in-process watcher.`
+          );
+          void stopWorker().then(() => startInProcessWatcher());
+        },
+      });
+      if (status.running) {
+        // eslint-disable-next-line no-console
+        console.info(`[ingest-worker] spawned; entry=${status.workerEntry}`);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ingest-worker] failed to start: ${(err as Error).message}. ` +
+          `Falling back to in-process watcher (MINDER_INDEXER mode).`
+      );
+      // Tear down the worker host before handing off. Otherwise a
+      // pending crash-respawn (a non-zero pre-ready exit triggers the
+      // exit handler's respawn loop independently of the rejected
+      // startWorker promise) would run alongside the in-process
+      // watcher and we'd have two ingest pipelines fighting for the
+      // writer connection.
+      try {
+        const { stopWorker } = await import("@/lib/db/workerHost");
+        await stopWorker();
+      } catch {
+        /* swallow — best-effort teardown */
+      }
+      await startInProcessWatcher();
+    }
+    return;
+  }
+
+  if (process.env.MINDER_INDEXER === "1") {
+    await startInProcessWatcher();
+  }
+}
+
+async function startInProcessWatcher(): Promise<void> {
+  try {
+    const { startIngestWatcher } = await import("@/lib/db/ingestWatcher");
+    // Pass `bypassEnvFlag: true` because instrumentation.ts has
+    // already gated on the relevant env flags. The watcher's own
+    // NODE_ENV=test guard is also bypassed by this option, which is
+    // why we short-circuit on NODE_ENV=test in the parent
+    // `instrumentation.ts` instead — keeping defense-in-depth without
+    // double-gating the worker fallback path (where MINDER_INDEXER
+    // may not be set).
+    const status = await startIngestWatcher({ bypassEnvFlag: true });
+    if (status.running) {
+      // eslint-disable-next-line no-console
+      console.info(
+        `[ingest-watcher] started; initial reconcile took ${status.initialReconcileMs ?? "?"} ms`
+      );
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[ingest-watcher] failed to start: ${(err as Error).message}. ` +
+        `Dashboard continues on the file-parse path.`
+    );
+  }
+}

--- a/instrumentation-node.ts
+++ b/instrumentation-node.ts
@@ -79,13 +79,15 @@ export async function startIngest(): Promise<void> {
 async function startInProcessWatcher(): Promise<void> {
   try {
     const { startIngestWatcher } = await import("@/lib/db/ingestWatcher");
-    // Pass `bypassEnvFlag: true` because instrumentation.ts has
-    // already gated on the relevant env flags. The watcher's own
-    // NODE_ENV=test guard is also bypassed by this option, which is
-    // why we short-circuit on NODE_ENV=test in the parent
-    // `instrumentation.ts` instead — keeping defense-in-depth without
-    // double-gating the worker fallback path (where MINDER_INDEXER
-    // may not be set).
+    // Pass `bypassEnvFlag: true` because we only reach this function
+    // after the parent `instrumentation.ts` runtime/test gate passes
+    // AND `startIngest()` above has handled the `MINDER_INDEXER*` mode
+    // selection. Re-checking the env flag inside the watcher would
+    // (a) double-gate, and (b) wrongly skip the worker fallback path,
+    // where the user set `MINDER_INDEXER_WORKER=1` but not
+    // `MINDER_INDEXER=1`. The watcher's own NODE_ENV=test guard is
+    // also bypassed by this option — defense-in-depth lives at the
+    // top of `instrumentation.ts` instead.
     const status = await startIngestWatcher({ bypassEnvFlag: true });
     if (status.running) {
       // eslint-disable-next-line no-console

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,24 +1,15 @@
-// Next.js instrumentation hook. Runs once per server process at startup —
-// the canonical place for "things that should happen before any request."
+// Next.js instrumentation hook. Runs once per server process at startup
+// and is invoked by Next.js for **both** the Node and Edge runtimes
+// regardless of where our actual logic needs to run.
 //
-// Three ingest modes, in priority order:
-//
-//   MINDER_INDEXER_WORKER=1  → start the worker_threads-hosted ingest
-//                              (P2a-2.4; phase 1 = trivial ping/pong stub).
-//   MINDER_INDEXER=1         → start the in-process chokidar watcher
-//                              (P2a-2.2 / 2.3 path; remains the default
-//                              and serves as the fallback if the worker
-//                              path turns out to be broken on a given
-//                              platform / Next.js version).
-//   neither                  → no-op. Dashboard runs on the file-parse
-//                              path. Ingest is strictly additive in P2a.
-//
-// We dynamic-import both options because:
-//   1. Next.js calls `register` in both server runtimes; the modules are
-//      `server-only` and fail to bundle in edge.
-//   2. They import `better-sqlite3` (optional native binary) — keeping
-//      the cost out of the cold-start critical path on platforms where
-//      the binary isn't installed.
+// All Node-only work — the SQLite indexer worker, the chokidar watcher,
+// every `fs` / `process.cwd` / `child_process` call in their import
+// graph — lives in `instrumentation-node.ts`. That sibling file imports
+// `'server-only'` at the top, which Turbopack treats as a hard "do not
+// compile for the Edge runtime" signal. Coupled with our runtime gate
+// below, the Edge-runtime build never traces the Node module graph and
+// we don't get spammed with "Node.js API used in Edge Runtime"
+// warnings on every dev startup.
 
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
@@ -29,82 +20,6 @@ export async function register(): Promise<void> {
   // races against tmpHome fixtures.
   if (process.env.NODE_ENV === "test") return;
 
-  if (process.env.MINDER_INDEXER_WORKER === "1") {
-    try {
-      const { startWorker, stopWorker } = await import("@/lib/db/workerHost");
-      // awaitStart: false — return as soon as the worker is alive and
-      // the watcher module is loaded. The initial reconcile runs in
-      // the background; instrumentation doesn't block server startup
-      // on it.
-      //
-      // onStartFailure — if the async start handshake fails (worker
-      // is alive but the watcher inside it couldn't start, e.g. DB
-      // driver unavailable or watcher init throws), tear down the
-      // worker and switch to the in-process watcher so ingest doesn't
-      // silently stay off.
-      const status = await startWorker({
-        awaitStart: false,
-        onStartFailure: (err: Error) => {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[ingest-worker] async start failed (${err.message}); switching to in-process watcher.`
-          );
-          void stopWorker().then(() => startInProcessWatcher());
-        },
-      });
-      if (status.running) {
-        // eslint-disable-next-line no-console
-        console.info(`[ingest-worker] spawned; entry=${status.workerEntry}`);
-      }
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[ingest-worker] failed to start: ${(err as Error).message}. ` +
-          `Falling back to in-process watcher (MINDER_INDEXER mode).`
-      );
-      // Tear down the worker host before handing off. Otherwise a
-      // pending crash-respawn (a non-zero pre-ready exit triggers the
-      // exit handler's respawn loop independently of the rejected
-      // startWorker promise) would run alongside the in-process
-      // watcher and we'd have two ingest pipelines fighting for the
-      // writer connection.
-      try {
-        const { stopWorker } = await import("@/lib/db/workerHost");
-        await stopWorker();
-      } catch {
-        /* swallow — best-effort teardown */
-      }
-      await startInProcessWatcher();
-    }
-    return;
-  }
-
-  if (process.env.MINDER_INDEXER === "1") {
-    await startInProcessWatcher();
-  }
-}
-
-async function startInProcessWatcher(): Promise<void> {
-  try {
-    const { startIngestWatcher } = await import("@/lib/db/ingestWatcher");
-    // Pass `bypassEnvFlag: true` because instrumentation.ts has
-    // already gated on the relevant env flags. The watcher's own
-    // NODE_ENV=test guard is also bypassed by this option, which is
-    // why we short-circuit on NODE_ENV=test at the top of register()
-    // instead — keeping defense-in-depth without double-gating the
-    // worker fallback path (where MINDER_INDEXER may not be set).
-    const status = await startIngestWatcher({ bypassEnvFlag: true });
-    if (status.running) {
-      // eslint-disable-next-line no-console
-      console.info(
-        `[ingest-watcher] started; initial reconcile took ${status.initialReconcileMs ?? "?"} ms`
-      );
-    }
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[ingest-watcher] failed to start: ${(err as Error).message}. ` +
-        `Dashboard continues on the file-parse path.`
-    );
-  }
+  const { startIngest } = await import("./instrumentation-node");
+  await startIngest();
 }


### PR DESCRIPTION
## Summary

Removes the wall of `"Node.js API used in Edge Runtime"` warnings that appeared on every dev startup.

**Root cause:** `instrumentation.ts` is invoked by Next.js for **both** Node and Edge runtimes, and Turbopack statically traces the dynamic `await import("@/lib/db/ingestWatcher")` chain. That chain pulls in modules that use `fs`, `process.cwd()`, `child_process`, and `process.kill` — all illegal in Edge. The runtime gate (`if (process.env.NEXT_RUNTIME !== "nodejs") return`) already prevents anything from *running* in Edge, but the build-time trace is the source of the warning spam.

**Fix:** extract Node-only logic into `instrumentation-node.ts` with `'server-only'` at the top. `'server-only'` is Turbopack's "do not compile for Edge" sigil — it severs the trace at the dynamic-import boundary. `instrumentation.ts` shrinks to the runtime gate plus `await import('./instrumentation-node')`.

## Verification

`pnpm run dev` startup, side by side:

**Before** (~10 warnings, examples):
```
⚠ ./src/lib/db/migrations.ts:126:13
A Node.js API is used (process.cwd at line: 126) which is not supported in the Edge Runtime.
⚠ ./src/lib/atomicWrite.ts:1:1
A Node.js module is loaded ('fs' at line 1) which is not supported in the Edge Runtime.
⚠ ./src/lib/platform.ts:1:1
A Node.js module is loaded ('child_process' at line 1) which is not supported in the Edge Runtime.
[... 7 more ...]
```

**After:** zero warnings.

Worker indexer still spawns, `/api/usage` still works, the runtime gate still falls through cleanly when `NEXT_RUNTIME !== "nodejs"`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 614 pass, 1 skipped, 0 failed
- [x] `pnpm run dev` startup — zero Edge-runtime warnings (previously ~10)
- [x] Worker indexer spawns correctly (`[ingest-worker] spawned` in log)
- [x] `/api/usage?period=all` serves correctly through both gates (DB readiness + runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)