### PR TITLE
feat(wave5.2): /plans, /hooks, /plugins, /sql browsers — Cluster L

### DIFF
--- a/.github/scripts/pr-review-responder.mjs
+++ b/.github/scripts/pr-review-responder.mjs
@@ -323,8 +323,11 @@ function commitAndPush(actionable) {
 
   const sha = git('rev-parse', '--short', 'HEAD').trim();
   // NEVER --force — hard guardrail against overwriting shared history
-  spawnSync('git', ['push'],
+  const pushResult = spawnSync('git', ['push'],
     { encoding: 'utf-8', stdio: 'inherit', env: process.env });
+  if (pushResult.status !== 0) {
+    throw new Error(`git push failed with exit code ${pushResult.status ?? 'null'}`);
+  }
   console.log(`  Pushed ${sha}`);
   return sha;
 }

--- a/.github/scripts/pr-review-responder.mjs
+++ b/.github/scripts/pr-review-responder.mjs
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+// Autonomous PR review responder — invoked by .github/workflows/pr-review-responder.yml
+// Flow: fetch unresolved threads → classify P0/P1/P2 → fix P0/P1 → check → commit → reply
+//       on failure: debug loop up to MAX_DEBUG_PASSES, then escalate
+
+import { spawnSync } from 'child_process';
+import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const MAX_DEBUG_PASSES = 3;
+const CLAUDE_TIMEOUT_MS = 240_000;
+const { ANTHROPIC_API_KEY, PR_NUMBER, GITHUB_REPOSITORY } = process.env;
+
+if (!ANTHROPIC_API_KEY) die('ANTHROPIC_API_KEY not set');
+if (!PR_NUMBER)          die('PR_NUMBER not set');
+if (!GITHUB_REPOSITORY)  die('GITHUB_REPOSITORY not set');
+
+const [OWNER, REPO] = GITHUB_REPOSITORY.split('/');
+
+// Paths Claude Code must never modify — CI config integrity guardrail
+const PROTECTED = ['.github/workflows/', '.github/actions/', '.github/scripts/'];
+
+// CI check order matches .github/workflows/ci.yml exactly
+const CI_CHECKS = ['npm run lint', 'npm run typecheck', 'npm test', 'npm run build'];
+
+// ── Low-level helpers ─────────────────────────────────────────────────────────
+
+function die(msg) {
+  console.error(`\n💀 ${msg}`);
+  process.exit(1);
+}
+
+/**
+ * Run a git/shell command with explicit arg array (no shell injection risk).
+ * For internal commands only — never pass user-controlled PR content here.
+ */
+function git(...args) {
+  const result = spawnSync('git', args, {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+    env: process.env,
+  });
+  if (result.status !== 0) throw new Error(`git ${args.join(' ')}: ${result.stderr}`);
+  return result.stdout;
+}
+
+/** Run `claude -p <prompt>` in headless mode with permissions bypassed for CI. */
+function claudeCode(prompt) {
+  const result = spawnSync(
+    'claude',
+    ['-p', prompt, '--dangerously-skip-permissions', '--model', 'claude-sonnet-4-6'],
+    {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: CLAUDE_TIMEOUT_MS,
+      cwd: process.cwd(),
+      env: process.env,
+    }
+  );
+  if (result.status !== 0) {
+    console.warn(`  ⚠ claude exited ${result.status}: ${(result.stderr || '').slice(0, 400)}`);
+  }
+  return result;
+}
+
+/** Direct Anthropic API call — no SDK dep, uses Haiku for lightweight classification. */
+async function callAnthropic(prompt, model = 'claude-haiku-4-5-20251001', maxTokens = 300) {
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ model, max_tokens: maxTokens,
+      messages: [{ role: 'user', content: prompt }] }),
+  });
+  if (!resp.ok) die(`Anthropic API ${resp.status}: ${await resp.text()}`);
+  return (await resp.json()).content[0].text;
+}
+
+/** Thin wrapper around `gh api` with JSON body piped via stdin. */
+function ghApi(args, body) {
+  const result = spawnSync('gh', args, {
+    input: body ? JSON.stringify(body) : undefined,
+    encoding: 'utf-8',
+    stdio: body ? ['pipe', 'pipe', 'pipe'] : ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+  if (result.status !== 0) throw new Error(`gh ${args.join(' ')} → ${result.stderr}`);
+  return result.stdout ? JSON.parse(result.stdout) : null;
+}
+
+function postPRComment(body) {
+  spawnSync('gh', ['pr', 'comment', PR_NUMBER, '--body', body],
+    { encoding: 'utf-8', env: process.env });
+}
+
+// ── PR data (GraphQL for databaseId) ─────────────────────────────────────────
+
+function fetchPRData() {
+  // REST `gh pr view --json` doesn't always populate comment.databaseId (integer),
+  // which is required by POST /pulls/{n}/comments in_reply_to. Use GraphQL directly.
+  const query = `
+    query($owner:String!, $repo:String!, $pr:Int!) {
+      repository(owner:$owner, name:$repo) {
+        pullRequest(number:$pr) {
+          headRefName
+          headRepository { nameWithOwner }
+          reviewThreads(first:50) {
+            nodes {
+              id
+              isResolved
+              isOutdated
+              comments(first:5) {
+                nodes {
+                  id
+                  databaseId
+                  path
+                  line
+                  originalLine
+                  body
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result = spawnSync('gh', [
+    'api', 'graphql',
+    '-f', `query=${query}`,
+    '-f', `owner=${OWNER}`,
+    '-f', `repo=${REPO}`,
+    '-F', `pr=${PR_NUMBER}`,
+  ], { encoding: 'utf-8', env: process.env });
+
+  if (result.status !== 0) die(`GraphQL fetch failed: ${result.stderr}`);
+  return JSON.parse(result.stdout).data.repository.pullRequest;
+}
+
+function getUnresolvedThreads(pr) {
+  return (pr.reviewThreads?.nodes || []).filter(
+    t => !t.isResolved && !t.isOutdated && t.comments.nodes.length > 0
+  );
+}
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+async function classifyComments(threads) {
+  const results = [];
+
+  for (const thread of threads) {
+    const comment = thread.comments.nodes[0];
+
+    const text = await callAnthropic(`Classify this GitHub PR review comment. Reply with JSON only — no prose.
+
+File: ${comment.path || 'N/A'}
+Line: ${comment.originalLine || comment.line || 'N/A'}
+Comment: "${(comment.body || '').slice(0, 600)}"
+
+Priority levels:
+- P0: Bug, security flaw, data loss risk, or broken correctness
+- P1: Performance issue, best-practice violation, or significant maintainability problem
+- P2: Style nit, naming preference, minor formatting, or optional suggestion
+
+Reply: {"priority":"P0"|"P1"|"P2","rationale":"one sentence"}`);
+
+    let priority = 'P1';
+    let rationale = 'Defaulted to P1 (classification parse failed)';
+
+    try {
+      const parsed = JSON.parse(text.trim().replace(/^```json\n?/, '').replace(/\n?```$/, ''));
+      if (['P0', 'P1', 'P2'].includes(parsed.priority)) {
+        priority = parsed.priority;
+        rationale = parsed.rationale || '';
+      }
+    } catch (e) {
+      console.warn(`  Classification parse failed for thread ${thread.id}: ${e.message}`);
+    }
+
+    results.push({
+      thread,
+      comment,
+      threadId: thread.id,
+      databaseId: comment.databaseId,
+      file: comment.path || '',
+      line: comment.originalLine || comment.line || 0,
+      body: comment.body || '',
+      priority,
+      rationale,
+    });
+  }
+
+  return results;
+}
+
+// ── Fix prompts ───────────────────────────────────────────────────────────────
+
+function buildFixPrompt(item) {
+  let excerpt = '';
+  if (item.file && existsSync(item.file)) {
+    const lines = readFileSync(item.file, 'utf-8').split('\n');
+    const ln = Number(item.line);
+    const s = Math.max(0, ln - 15);
+    const e = Math.min(lines.length, ln + 15);
+    excerpt = lines.slice(s, e)
+      .map((l, i) => `${s + i + 1}${s + i + 1 === ln ? '◄' : ' '} ${l}`)
+      .join('\n');
+  }
+
+  return `You are a PR review bot. Fix ONLY the issue below. Do not refactor, rename, or modify anything else.
+
+[${item.priority}] ${item.file}:${item.line}
+Review comment: "${item.body}"
+Why this matters: ${item.rationale}
+
+${excerpt ? `Code context:\n\`\`\`\n${excerpt}\n\`\`\`` : ''}
+
+Steps:
+1. Read the file if you need more context
+2. Make the minimal targeted change to address the review comment
+3. Save the file
+4. NEVER modify any file under .github/ — hard guardrail`;
+}
+
+function buildDebugPrompt(checkResult, pass) {
+  return `You are fixing a CI failure after auto-applying PR review fixes. This is debug pass ${pass}.
+
+Failed command: ${checkResult.failedCmd}
+Output:
+\`\`\`
+${checkResult.output.slice(0, 4000)}
+\`\`\`
+
+Instructions:
+- Read failing source files for context
+- Make targeted corrections to resolve the failure
+- Do NOT touch any .github/ files or CI configuration
+- Do NOT make broad refactors — fix only what broke`;
+}
+
+// ── Guardrails ────────────────────────────────────────────────────────────────
+
+function getModifiedFiles() {
+  try {
+    return git('diff', '--name-only', 'HEAD').trim().split('\n').filter(Boolean);
+  } catch { return []; }
+}
+
+/**
+ * Reverts any modifications to protected CI config paths.
+ * Returns true if a violation was found and reverted.
+ */
+function enforceCIGuardrail() {
+  const modified = getModifiedFiles();
+  const violations = modified.filter(f => PROTECTED.some(p => f.startsWith(p)));
+  if (violations.length === 0) return false;
+  console.warn(`  🛡  Reverting unauthorized CI-config changes: ${violations.join(', ')}`);
+  spawnSync('git', ['checkout', '--', '.github/'],
+    { encoding: 'utf-8', stdio: 'pipe', env: process.env });
+  return true;
+}
+
+// ── Check runner ──────────────────────────────────────────────────────────────
+
+function runChecks() {
+  let allOutput = '';
+
+  for (const cmd of CI_CHECKS) {
+    process.stdout.write(`  ${cmd} ... `);
+    const [exe, ...args] = cmd.split(/\s+/);
+    const result = spawnSync(exe, args, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+      shell: false,
+      env: { ...process.env, CI: 'true', FORCE_COLOR: '0' },
+    });
+
+    allOutput += `$ ${cmd}\n${result.stdout || ''}${result.stderr || ''}\n\n`;
+
+    if (result.status !== 0) {
+      console.log('✗');
+      return { success: false, output: allOutput.slice(0, 8000), failedCmd: cmd };
+    }
+    console.log('✓');
+  }
+
+  return { success: true, output: allOutput };
+}
+
+// ── Commit & push ─────────────────────────────────────────────────────────────
+
+function commitAndPush(actionable) {
+  spawnSync('git', ['add', '-A'],
+    { encoding: 'utf-8', stdio: 'pipe', env: process.env });
+  // Belt-and-suspenders: unstage any .github/ files
+  spawnSync('git', ['restore', '--staged', '.github/'],
+    { encoding: 'utf-8', stdio: 'pipe', env: process.env });
+
+  const staged = git('diff', '--cached', '--name-only').trim();
+  if (!staged) {
+    console.log('  Nothing to commit (no files changed after guardrail).');
+    return null;
+  }
+
+  const refs = actionable
+    .map(i => `  [${i.priority}] ${i.file}:${i.line} — ${i.rationale}`)
+    .join('\n');
+  const msg = `fix(pr-review): address ${actionable.length} comment(s) on PR #${PR_NUMBER}\n\nAddressed:\n${refs}\n\nAutomated fix by PR Review Responder.`;
+
+  // Write to temp file — avoids any shell escaping issues with special chars in rationale
+  const msgFile = join(tmpdir(), `pr-bot-${Date.now()}.txt`);
+  writeFileSync(msgFile, msg, 'utf-8');
+  spawnSync('git', ['commit', '-F', msgFile],
+    { encoding: 'utf-8', stdio: 'inherit', env: process.env });
+
+  const sha = git('rev-parse', '--short', 'HEAD').trim();
+  // NEVER --force — hard guardrail against overwriting shared history
+  spawnSync('git', ['push'],
+    { encoding: 'utf-8', stdio: 'inherit', env: process.env });
+  console.log(`  Pushed ${sha}`);
+  return sha;
+}
+
+// ── Thread replies ────────────────────────────────────────────────────────────
+
+function replyToThread(item, sha) {
+  if (!item.databaseId) {
+    console.warn(`  No databaseId for ${item.file}:${item.line} — skipping reply`);
+    return;
+  }
+  const body = sha
+    ? `Fixed in ${sha} · **${item.priority}**: ${item.rationale}`
+    : `Auto-fix attempted but push failed · **${item.priority}**: ${item.rationale}`;
+  try {
+    ghApi(
+      ['api', `repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments`,
+       '--method', 'POST', '--input', '-'],
+      { body, in_reply_to: item.databaseId }
+    );
+  } catch (e) {
+    console.warn(`  Reply to ${item.databaseId} failed: ${e.message}`);
+  }
+}
+
+function resolveThread(threadId) {
+  const mutation = `mutation{resolveReviewThread(input:{threadId:"${threadId}"}){thread{isResolved}}}`;
+  spawnSync('gh', ['api', 'graphql', '-f', `query=${mutation}`],
+    { encoding: 'utf-8', env: process.env });
+}
+
+// ── Comment builders ──────────────────────────────────────────────────────────
+
+function commentTable(items) {
+  const rows = items.map(i =>
+    `| ${i.priority} | \`${i.file}:${i.line}\` | ${i.body.slice(0, 80).replace(/\|/g, '\\|')} | ${i.rationale} |`
+  ).join('\n');
+  return `| Priority | Location | Comment | Rationale |\n|----------|----------|---------|----------|\n${rows}`;
+}
+
+function escalationComment(actionable, p2, failure) {
+  return [
+    '## ❌ PR Review Responder — Escalation',
+    '',
+    `Automated fix failed after ${MAX_DEBUG_PASSES} debug pass(es). Manual review required.`,
+    '',
+    '### Last failing check',
+    '```',
+    (failure?.output || '').slice(0, 3500),
+    '```',
+    '',
+    '### Comments requiring attention',
+    commentTable([...actionable, ...p2]),
+  ].join('\n');
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`\n🤖  PR Review Responder — PR #${PR_NUMBER} @ ${GITHUB_REPOSITORY}\n`);
+
+  // ── Fetch PR ──────────────────────────────────────────────────────────────
+  const pr = fetchPRData();
+  console.log(`Branch: ${pr.headRefName}`);
+
+  // Block fork PRs — GITHUB_TOKEN cannot push to forks
+  if (pr.headRepository?.nameWithOwner !== GITHUB_REPOSITORY) {
+    postPRComment('⚠️ **PR Review Responder**: Cannot auto-fix fork PRs (no push access). Please apply fixes manually.');
+    return;
+  }
+
+  // ── Get unresolved threads ────────────────────────────────────────────────
+  const threads = getUnresolvedThreads(pr);
+  if (threads.length === 0) {
+    console.log('No unresolved review threads — nothing to do.');
+    return;
+  }
+  console.log(`${threads.length} unresolved thread(s).\n`);
+
+  // ── Classify ──────────────────────────────────────────────────────────────
+  console.log('Classifying comments (Haiku)...');
+  const classified = await classifyComments(threads);
+
+  const p0p1 = classified
+    .filter(c => c.priority !== 'P2')
+    .sort((a, b) => (a.priority === 'P0' ? -1 : b.priority === 'P0' ? 1 : 0));
+  const p2 = classified.filter(c => c.priority === 'P2');
+
+  classified.forEach(c => console.log(`  [${c.priority}] ${c.file}:${c.line} — ${c.rationale}`));
+
+  if (p0p1.length === 0) {
+    postPRComment(
+      '## ℹ️ PR Review Responder\n\nAll comments classified as **P2** (stylistic/optional). No automated fixes applied.\n\n' +
+      p2.map(c => `- \`${c.file}:${c.line}\` — ${c.rationale}`).join('\n')
+    );
+    return;
+  }
+
+  // ── Apply fixes once ──────────────────────────────────────────────────────
+  console.log('\nApplying fixes (Sonnet)...');
+  for (const item of p0p1) {
+    console.log(`\n  [${item.priority}] ${item.file}:${item.line}`);
+    claudeCode(buildFixPrompt(item));
+    // Guard immediately after each fix to catch stray .github/ writes
+    enforceCIGuardrail();
+  }
+
+  // Early-out: if guardrail reverted everything and no files changed, escalate
+  if (getModifiedFiles().length === 0) {
+    postPRComment(
+      '⚠️ **PR Review Responder**: Fixes produced no file changes (or all were blocked by CI-config guardrail). Manual review required.\n\n' +
+      commentTable(p0p1)
+    );
+    return;
+  }
+
+  // ── Check → debug loop ────────────────────────────────────────────────────
+  // Fixes are applied once above. Debug patches accumulate across passes — no reset between
+  // passes because the debug patch from pass N is meant to carry forward into pass N+1.
+  let lastFailure = null;
+
+  for (let pass = 1; pass <= MAX_DEBUG_PASSES; pass++) {
+    console.log(`\nCheck pass ${pass}/${MAX_DEBUG_PASSES}...`);
+    const result = runChecks();
+
+    if (result.success) {
+      // ── Green — commit, push, reply ──────────────────────────────────────
+      console.log('\nAll checks passed. Committing...');
+      const sha = commitAndPush(p0p1);
+
+      console.log('Replying to threads...');
+      for (const item of p0p1) {
+        replyToThread(item, sha);
+        resolveThread(item.threadId);
+      }
+
+      if (p2.length > 0) {
+        postPRComment(
+          `## ✅ PR Review Responder${sha ? ` — fixed in \`${sha}\`` : ''}\n\n` +
+          `P2 comments classified as stylistic — not auto-fixed:\n\n` +
+          p2.map(c => `- \`${c.file}:${c.line}\` — ${c.rationale}`).join('\n')
+        );
+      }
+
+      console.log(`\n✅ Done — ${p0p1.length} comment(s) addressed${sha ? ` in ${sha}` : ''}.`);
+      return;
+    }
+
+    // ── Red — debug or escalate ───────────────────────────────────────────
+    lastFailure = result;
+    console.log(`\n  ✗ ${result.failedCmd} failed on pass ${pass}`);
+
+    if (pass < MAX_DEBUG_PASSES) {
+      console.log('  Invoking Claude Code to debug...');
+      claudeCode(buildDebugPrompt(result, pass));
+      enforceCIGuardrail(); // guard after debug patch too
+    }
+  }
+
+  // ── Escalate ──────────────────────────────────────────────────────────────
+  console.log('\n🚨 Escalating after max debug passes...');
+  postPRComment(escalationComment(p0p1, p2, lastFailure));
+
+  // Leave workspace clean for any follow-up manual work
+  spawnSync('git', ['checkout', '.'], { stdio: 'pipe', env: process.env });
+  spawnSync('git', ['clean', '-fd'], { stdio: 'pipe', env: process.env });
+
+  process.exit(1);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           REVIEW_STATE: ${{ github.event.review.state }}
+          REVIEW_ASSOCIATION: ${{ github.event.review.author_association }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
           ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
@@ -39,7 +40,9 @@ jobs:
         run: |
           TRUSTED="OWNER COLLABORATOR MEMBER"
 
-          if [[ "$EVENT_NAME" == "pull_request_review" && "$REVIEW_STATE" == "changes_requested" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request_review" \
+            && "$REVIEW_STATE" == "changes_requested" \
+            && $(echo "$TRUSTED" | grep -cw "$REVIEW_ASSOCIATION") -gt 0 ]]; then
             echo "should_run=true"  >> "$GITHUB_OUTPUT"
             echo "pr_number=$PR_NUMBER_REVIEW" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/pr-review-responder.yml
+++ b/.github/workflows/pr-review-responder.yml
@@ -1,0 +1,111 @@
+name: Autonomous PR Review Responder
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+# Serialize per-PR to avoid concurrent fix races
+concurrency:
+  group: pr-review-responder-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Guard ─────────────────────────────────────────────────────────────────
+  # Filters to: changes_requested reviews, or /auto-fix from trusted collaborators
+  guard:
+    name: Evaluate trigger
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.eval.outputs.should_run }}
+      pr_number: ${{ steps.eval.outputs.pr_number }}
+    steps:
+      - name: Check conditions
+        id: eval
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
+          PR_NUMBER_REVIEW: ${{ github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          TRUSTED="OWNER COLLABORATOR MEMBER"
+
+          if [[ "$EVENT_NAME" == "pull_request_review" && "$REVIEW_STATE" == "changes_requested" ]]; then
+            echo "should_run=true"  >> "$GITHUB_OUTPUT"
+            echo "pr_number=$PR_NUMBER_REVIEW" >> "$GITHUB_OUTPUT"
+
+          elif [[ "$EVENT_NAME" == "issue_comment" \
+            && -n "$ISSUE_PR_URL" \
+            && $(echo "$TRUSTED" | grep -cw "$COMMENT_ASSOCIATION") -gt 0 \
+            && $(echo "$COMMENT_BODY" | grep -cF '/auto-fix') -gt 0 ]]; then
+            echo "should_run=true"  >> "$GITHUB_OUTPUT"
+            echo "pr_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Respond ───────────────────────────────────────────────────────────────
+  respond:
+    name: Fix review comments
+    needs: guard
+    if: needs.guard.outputs.should_run == 'true'
+    runs-on: ubuntu-latest   # matches CI workflow OS
+    timeout-minutes: 45
+
+    steps:
+      # Resolve PR head ref before checkout so we get the right branch+deps
+      - name: Resolve PR head ref
+        id: pr_ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.guard.outputs.pr_number }}
+        run: |
+          HEAD_REF=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json headRefName --jq '.headRefName')
+          echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr_ref.outputs.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'   # pin to match CI
+          cache: 'npm'
+
+      - name: Install project dependencies
+        run: npm ci
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Embed token in remote URL so push works without a PAT
+          git remote set-url origin \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+      - name: Run PR Review Responder
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.guard.outputs.pr_number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node .github/scripts/pr-review-responder.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 5.2 — Cluster L: four new top-level browsers.** TODOs #152, #154, #156, #237 from `~/.claude/plans/our-to-do-list-has-gentle-cookie.md`.
+  - **`/sql` — interactive SQL workbench** (#237). Read-only SELECT editor against `~/.minder/index.db`. Schema sidebar with expand/collapse and one-click template insert. Virtualized results table with truncation banner at 10,000 rows. CSV (RFC-4180) and JSON export. localStorage query history (max 20, dedup adjacent). Read-only enforcement by `stmt.readonly` bytecode introspection in `better-sqlite3` — catches `WITH … INSERT RETURNING` CTEs that pass a regex.
+  - **`/hooks` — cross-project hook coverage matrix** (#154). Coverage summary cards (project/local/user scope counts + unique event count); click a card to filter. Virtualised hook list reusing `Pill`, `LocalScopeBadge`, `SourceBadge`, `commandPreview`, and `ApplyUnitButton` from `ConfigBrowser`. 300ms-debounced search, source filter, sort by event or project. AppNav Hooks entry now points to `/hooks` instead of `/config?type=hooks`; the `/config` Hooks tab continues to exist for project deep-links.
+  - **`/plans` — plan catalog browser** (#152). Scans `~/.claude/plans/*.md` via new `claudePlans.ts` scanner. Extracts title from front-matter or first `# ` heading; tags from front-matter; related session IDs by UUID regex in body. Tag filter, 300ms-debounced search, sort by mtime/title. Expand row → full plan body + clickable related-session chips.
+  - **`/plugins` — installed-plugin catalog** (#156). New `pluginRollup.ts` JOIN helper: `loadInstalledPlugins()` × `loadCatalog()` × `getAgentUsage()` × `getSkillUsage()` × `readPluginScopeMcp()`. Per-plugin agent/skill/MCP counts + total invocations. 2-min cache. Expand row → links to `/agents?source=plugin`, `/skills?source=plugin`, `/config?type=mcp`. Status badge (enabled/disabled/blocked).
+  - **`src/lib/csv.ts`** — RFC-4180 CSV escaper (`escapeCell`, `toCsv`). Used by `/sql` export. Future CSV writers should use this rather than ad-hoc concatenation.
+  - **`src/lib/sqlSchemaSnapshot.ts`** — hardcoded schema-version-6 table/column list (13 tables + 2 FTS5 virtual). Validated by `tests/sqlSchemaSnapshot.test.ts` via live `PRAGMA table_info` when DB is available.
+  - **`PlanEntry`** type added to `src/lib/types.ts`.
+  - **Help docs** added for all four routes: `docs/help/{plans,hooks,plugins,sql}.md` + `public/help/` copies.
+  - **Tests** (44 new): `csv.test.ts` (18), `claudePlans.test.ts` (10), `pluginRollup.test.ts` (7), `sqlSchemaSnapshot.test.ts` (5 + 1 conditional live check). 1195 tests pass; typecheck clean.
+
+### Changed
+- AppNav **Hooks** entry now links to `/hooks` (top-level browser) instead of `/config?type=hooks`. The `/config` Hooks tab is unchanged.
+
+### Added
 - **Wave 5.1 — Catalog UX polish (Cluster K).** TODOs #34, #35, #37, #33 (badges + cost) from `~/.claude/plans/our-to-do-list-has-gentle-cookie.md`. No schema migration; no new third-party deps.
   - **Frontmatter lint warnings (#34).** `parseFrontmatter` now returns `warnings: string[]` capturing YAML parse errors and unclosed `---` blocks. `parseWarnings?: string[]` added to `CatalogEntryBase` (agents + skills) and `CommandEntry`. All walkers (`walkAgents`, `walkSkills`, `walkCommands`) propagate warnings from the parser. A small amber `!` chip (`CatalogLintChip.tsx`) renders in the badge cluster of each catalog row (agents, skills, commands); hovering shows the full warning text via native `title=""`.
   - **Copy-invocation button (#35).** New `CopyInvocationButton.tsx` (mirrors `code-block.tsx` icon-swap pattern, 1.8s revert). Agents copy `@<name>`, user-invocable skills copy `/<name>`, non-invocable skills copy `Skill: <name>`, commands copy `/<slug>`. MCP server rows in ConfigBrowser copy `mcp__<server>__` with a title hint to append the tool name. For agents and skills the button is placed inside `CatalogActionStrip`; for commands and MCP it is inline in the row.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,18 @@ Project: **Project Minder** — local-only dashboard that auto-scans `C:\dev\*` 
 - All pages are client components (`"use client"`) — data fetched via API routes
 - Keyboard shortcut: `/` focuses search bar
 
+## Git Workflow
+- NEVER push directly to main. Always create a feature branch (e.g., `wave3.3`), push to that branch, and open a PR.
+- Use squash-merge for PRs. Admin override is acceptable when CI passes but branch protection blocks (e.g., `gh pr merge --squash --admin`).
+- After merging, verify post-merge state with typecheck and full test suite.
+## Verification Gates
+Before committing or opening a PR, ALWAYS run: (1) `npm run typecheck`, (2) full test suite. Report exact pass counts (e.g., '934 tests passing'). Do not mark a task complete until both pass.
+
+## Context Management
+- For long sessions, prefer `Grep` and targeted `Read` with offset/limit over re-reading whole large files.
+- When observing another session's tool-output files, read incrementally and summarize early — do not accumulate full file contents in context.
+- If approaching context limits, checkpoint progress to a file before continuing.
+
 ## TODO
 - If I give you a TODO, save it to TODO.md in our repo.
 - Consider our TODO list when planning new features. If something on the list can be accomplished during a plan or implement run, suggest it.

--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -1,5 +1,64 @@
 # Insights
 
+<!-- insight:1373ca6b3ecc | session:4bb141a4-1a4c-4794-a32a-b6bb351076ba | 2026-05-06T11:46:38.999Z -->
+## ★ Insight
+The `SqlResultsTable` architecture issue is a classic virtualizer gotcha: splitting the header and body into separate `overflow: auto` containers means horizontal scrolling is independent. The fix is to make the header `position: sticky; top: 0` inside the same scroll container that the virtualizer uses — sticky elements scroll horizontally with the container but pin vertically.
+
+---
+
+<!-- insight:846879024d2a | session:4bb141a4-1a4c-4794-a32a-b6bb351076ba | 2026-05-06T02:20:08.156Z -->
+## ★ Insight
+The UUID regex `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` is high-precision enough for session cross-linking. Using the global flag `g` on the regex with `matchAll` is safer than `exec` in a loop — no risk of forgetting to reset `lastIndex`.
+
+---
+
+<!-- insight:a77c44eb2736 | session:4bb141a4-1a4c-4794-a32a-b6bb351076ba | 2026-05-06T02:17:46.784Z -->
+## ★ Insight
+RFC-4180 has only four escaping triggers: `,`, `"`, `\n`, `\r`. The critical one developers miss is that a `"` inside a quoted field must be doubled — `"` → `""` — NOT backslash-escaped.
+
+---
+
+<!-- insight:390f1b047ed9 | session:4bb141a4-1a4c-4794-a32a-b6bb351076ba | 2026-05-06T02:13:15.528Z -->
+## ★ Insight
+The build order follows a key principle: start with the highest-certainty, lowest-risk items. `csv.ts` is pure logic with zero dependencies — if tests pass, the foundation is solid before we touch the UI.
+
+---
+
+<!-- insight:08ed8f932f98 | session:4bb141a4-1a4c-4794-a32a-b6bb351076ba | 2026-05-06T01:47:19.453Z -->
+## ★ Insight
+- Cluster L is wider than other 5.x sessions because it stands up four new top-level pages, but each follows the established `*Browser.tsx` template. The leverage is high: scanner + API + browser is a known shape, and three of the four routes already have placeholder pages from Wave 1.
+- The `/sql` browser is the outlier — it's a power-user interface against SQLite, not another catalog. It needs its own validation strategy (SELECT-only via regex + `EXPLAIN`) that doesn't exist anywhere else in the codebase yet.
+- Wave 5.1's `walkPlugins.ts` semver dedup work is a building block for `/plugins`; we should reuse, not redo.
+
+---
+
+<!-- insight:825d4579e69b | session:2ec11a17-6d55-42e1-9319-38fa6b4917d9 | 2026-05-06T01:31:38.419Z -->
+## ★ Insight
+**Fix once, debug many times** — applying original fixes on every retry is counterproductive. Claude Code sees already-edited files and makes conflicting changes. The right shape is: apply fixes once, then run a debug-only loop that accumulates patches without resetting.
+**Haiku for classification, Sonnet for implementation** — classification is a simple routing decision (P0/P1/P2); Haiku handles it near-instantly at ~30× lower cost than Opus. Sonnet gets the file-editing task where reasoning quality matters.
+
+---
+
+<!-- insight:97b2af94b315 | session:2ec11a17-6d55-42e1-9319-38fa6b4917d9 | 2026-05-06T01:31:04.571Z -->
+## ★ Insight
+**Claude Code in headless CI hangs without `--dangerously-skip-permissions`** — every `applyFix` call would silently timeout waiting for a permission prompt that never comes.
+**Fetch-then-checkout order matters** — `npm ci` must run against the PR branch's deps, not the base branch. We use `gh pr view` to get the head ref *before* `checkout@v4`.
+**GraphQL over REST for review threads** — `gh pr view --json` gives REST-shape data where `databaseId` (the integer ID needed for reply-to) may be absent; the GraphQL API guarantees it.
+
+---
+
+<!-- insight:d36d395559bc | session:a923dbd6-5aa8-48a6-80f6-48e11bdecc25 | 2026-05-06T01:10:37.161Z -->
+## ★ Insight
+Vitest 4 moved pool-specific options (`execArgv`, `maxForks`, etc.) to the top-level `test` block — the old `poolOptions.forks.*` nesting was a Vitest 3 API. The `Object.assign` workaround avoided a TypeScript error but meant the option was silently ignored when Vitest 4 dropped the key. Using `execArgv` directly at `test` level is both correct for V4 and type-safe.
+
+---
+
+<!-- insight:67f41dfcc2ec | session:a923dbd6-5aa8-48a6-80f6-48e11bdecc25 | 2026-05-05T23:41:23.403Z -->
+## ★ Insight
+The recursive directory walker uses the same mocked `readdir` that always returns a directory-type dirent, creating an infinite recursion. This is a classic mock completeness bug: when you add a new module to an orchestrator, all tests that mock the orchestrator's dependencies must also mock the new one.
+
+---
+
 <!-- insight:ddbe99e4f51f | session:a923dbd6-5aa8-48a6-80f6-48e11bdecc25 | 2026-05-05T20:55:27.896Z -->
 ## ★ Insight
 The `globalThis` pattern solves a specific Next.js dev-mode problem: module-level singletons get re-initialized on HMR restarts, but `globalThis` survives them. The tradeoff is that tests running in the same Node.js process share the same `globalThis`, so caches must be explicitly reset in `beforeEach`. This is why the test fix is a `(globalThis as Record<string, unknown>).__agentCostCache = undefined` — casting through `Record<string, unknown>` avoids the typed interface that only `agentCost.ts` knows about.

--- a/MANUAL_STEPS.md
+++ b/MANUAL_STEPS.md
@@ -1,0 +1,95 @@
+## 2026-05-05 | pr-review-responder | GitHub Action secrets + permissions setup
+
+- [ ] Add `ANTHROPIC_API_KEY` to repository secrets
+  Settings → Secrets and variables → Actions → New repository secret
+  Name: `ANTHROPIC_API_KEY`, Value: your Anthropic API key
+  See: https://docs.anthropic.com/en/api/getting-started
+- [ ] Verify `GITHUB_TOKEN` has write permissions for `contents` and `pull-requests`
+  Settings → Actions → General → Workflow permissions → Read and write permissions
+  (Required for the bot to push commits and post PR comments)
+- [ ] Confirm fork PR protection is acceptable
+  The responder posts a comment on fork PRs instead of fixing — it cannot push to fork branches
+  with GITHUB_TOKEN. If you need fork support, create a dedicated PAT and add it as a secret.
+
+---
+
+## 2026-04-16 | repo-hardening | Enable branch protection + CI for public release
+
+- [ ] Apply `main-protection` ruleset in GitHub UI
+  Settings → Rules → Rulesets → New branch ruleset
+  Target: `refs/heads/main`, Enforcement: Active
+  Bypass list: add `joshuatownsend` with role `bypass` set to `always`
+  Rules: Restrict deletions ON, Block force pushes ON, Require linear history ON,
+         Require PR before merging ON (0 required approvals), Dismiss stale approvals ON,
+         Require conversation resolution ON
+- [ ] Set repo merge settings to squash-only
+  Settings → General → Pull Requests
+  Disable: Allow merge commits, Allow rebase merging
+  Enable: Allow squash merging (default message: "Pull request title and description")
+  Enable: Automatically delete head branches
+  Enable: Always suggest updating pull request branches
+- [ ] Turn on Dependabot alerts + security updates
+  Settings → Code security and analysis → Dependabot
+- [ ] Turn on Secret scanning + Push protection
+  Settings → Code security and analysis → Secret scanning
+- [ ] Enable Private vulnerability reporting
+  Settings → Code security and analysis → Private vulnerability reporting
+- [ ] Commit `.github/workflows/ci.yml` on a PR, confirm first CI run passes
+  The job is named `verify` — confirm it appears in the Checks tab
+- [ ] After first successful CI run, re-open the `main-protection` ruleset and add required status check
+  Require status checks to pass: ON
+  Require branches to be up to date: ON
+  Required check: `verify`
+- [ ] Run verification: try `git push --force-with-lease origin main` — should be rejected
+- [ ] Run verification: try pushing directly to main — should be rejected (PR required)
+- [ ] Run verification: open a PR that breaks a test, confirm CI blocks merge
+
+---
+
+## 2026-03-17 14:32 | notifications | Toast & OS Notification Setup
+
+- [x] Grant browser notification permission when prompted
+  Click "Allow" on the browser permission dialog
+- [x] Verify notification sound plays on new entry detection
+  Open DevTools console and check for audio errors
+- [x] Add notification.wav to public/sounds/
+  Already done during implementation
+
+---
+
+## 2026-03-17 15:10 | testing | Manual Steps Feature Verification
+
+- [x] Visit /manual-steps page and verify cross-project view
+  See: http://localhost:4100/manual-steps
+- [x] Click a project card with manual steps, check the new tab
+- [x] Toggle a checkbox and verify MANUAL_STEPS.md updates on disk
+- [x] Test real-time detection by appending a new entry to any MANUAL_STEPS.md
+
+---
+
+## 2026-04-16 | github-pages | Enable GitHub Pages from gh-pages branch
+
+- [x] Go to https://github.com/joshuatownsend/project-minder/settings/pages
+- [x] Under "Build and deployment" → Source, select "Deploy from a branch"
+- [x] Branch: gh-pages, Folder: / (root)
+- [x] Click Save
+  Site will be live at https://joshuatownsend.github.io/project-minder within ~1 minute
+
+---
+
+## 2026-04-27 | skill-provenance | GITHUB_TOKEN for update-check rate limits
+
+- [ ] Set `GITHUB_TOKEN` environment variable on this machine for GitHub API rate-limit headroom
+  The update-check cache in `/api/catalog-updates` calls the GitHub API to compare lockfile skill
+  hashes against upstream tree SHAs. Unauthenticated requests are capped at 60/hour per IP.
+  With a 24-hour cache TTL this is sufficient for most cases, but adding a token raises the
+  limit to 5,000/hour and avoids any risk of rate-limit errors.
+  Steps:
+  1. Create a GitHub personal access token (classic) at https://github.com/settings/tokens
+     with no scopes — only public repo access is needed.
+  2. Set in your shell profile:
+     `$env:GITHUB_TOKEN = "ghp_xxxxxxxxxxxx"` (PowerShell profile)
+     or `export GITHUB_TOKEN=ghp_xxxxxxxxxxxx` (bash/zsh .profile)
+  3. Restart the Project Minder dev server so the server process inherits the env var.
+
+---

--- a/docs/help/hooks.md
+++ b/docs/help/hooks.md
@@ -23,7 +23,7 @@ Each row shows:
 - **Command preview** — the first 60 characters of the command
 - **local** badge — shown when the hook lives in `settings.local.json`; copying it via Template Mode auto-promotes it to `settings.json` (project-shared)
 - **Source badge** — project name (links to the project detail page) or "user" for global hooks
-- **↗ apply** button — for user-scope and project-scope hooks, copies the hook definition to another project
+- **↗ apply** button — appears for project-scope hooks (including local-scope) and user-scope hooks; copies the hook definition to another project
 
 ## The `/config` Hooks tab
 

--- a/docs/help/hooks.md
+++ b/docs/help/hooks.md
@@ -1,0 +1,38 @@
+# Hooks
+
+The Hooks browser shows every hook entry across all your projects and your user-scope Claude config, organized by source scope.
+
+## Coverage matrix
+
+The four stat cards at the top summarise coverage at a glance:
+
+| Card | What it counts |
+|---|---|
+| **Project** | Hooks in `.claude/settings.json` inside a project directory |
+| **Local** | Hooks in `.claude/settings.local.json` (per-machine, not shared in git) |
+| **User** | Hooks in `~/.claude.json` or `~/.claude/settings.json` (apply everywhere) |
+| **Events** | Number of distinct event types across all hooks |
+
+Click a scope card to filter the list to that scope.
+
+## Row anatomy
+
+Each row shows:
+- **Event chip** — the hook trigger (e.g. `PreToolUse`, `PostToolUse`, `SessionStart`)
+- **Matcher** — the tool or event pattern (e.g. `Edit|Write`)
+- **Command preview** — the first 60 characters of the command
+- **local** badge — shown when the hook lives in `settings.local.json`; copying it via Template Mode auto-promotes it to `settings.json` (project-shared)
+- **Source badge** — project name (links to the project detail page) or "user" for global hooks
+- **↗ apply** button — for user-scope and project-scope hooks, copies the hook definition to another project
+
+## The `/config` Hooks tab
+
+The `/config?type=hooks` tab on the Config page continues to exist for per-project deep-linking (e.g., "View hooks for this project"). The top-level `/hooks` page shows the full cross-project view.
+
+## Filtering
+
+| Control | Effect |
+|---|---|
+| Search | Matches event, matcher, command text, project name (debounced 300ms) |
+| Source dropdown | Filter to `project`, `local`, or `user` scope |
+| Sort | By event name (A–Z) or by project name |

--- a/docs/help/plans.md
+++ b/docs/help/plans.md
@@ -1,0 +1,29 @@
+# Plans
+
+The Plans browser surfaces every file in `~/.claude/plans/` as a searchable, filterable catalog. Plan files are the `.md` files Claude Code writes when you invoke plan mode.
+
+## What you'll see
+
+Each row shows:
+- **Title** — extracted from the plan's front-matter `title:` field, or the first `# ` heading, or the filename.
+- **Tags** — from the front-matter `tags:` array (click a tag to filter).
+- **Modified** — relative timestamp for the file's last modification.
+- **Related sessions** — sessions linked by UUID found anywhere in the plan body.
+
+Expand a row to read the full plan body and click related-session chips to navigate directly to `/sessions/<id>`.
+
+## Filtering and sorting
+
+| Control | Effect |
+|---|---|
+| Search box | Filters by title, slug, or any tag (debounced 300ms) |
+| Tag dropdown | Narrows to plans that include the selected tag |
+| Sort | Modified (newest first) or Title (A–Z) |
+
+## How plans are found
+
+Project Minder scans `~/.claude/plans/*.md`. It does **not** recurse into subdirectories. Files with front-matter are parsed; files without are also shown (title falls back to the heading or filename).
+
+## Related sessions
+
+Session IDs are found by regex-matching UUIDs in the plan body. This is a heuristic — a UUID quoted in prose (e.g., from a log paste) may appear as a false positive. If you want precise control, add a `relatedSessions:` key to the plan's front-matter listing session IDs explicitly (the scanner prefers front-matter when present, planned for a future release).

--- a/docs/help/plans.md
+++ b/docs/help/plans.md
@@ -6,7 +6,7 @@ The Plans browser surfaces every file in `~/.claude/plans/` as a searchable, fil
 
 Each row shows:
 - **Title** — extracted from the plan's front-matter `title:` field, or the first `# ` heading, or the filename.
-- **Tags** — from the front-matter `tags:` array (click a tag to filter).
+- **Tags** — from the front-matter `tags:` array; use the tag dropdown to filter.
 - **Modified** — relative timestamp for the file's last modification.
 - **Related sessions** — sessions linked by UUID found anywhere in the plan body.
 

--- a/docs/help/plugins.md
+++ b/docs/help/plugins.md
@@ -1,0 +1,34 @@
+# Plugins
+
+The Plugins browser lists every Claude Code plugin installed via `~/.claude/installed_plugins.json`, enriched with usage counts from the agent/skill catalog and the SQLite index.
+
+## Row anatomy
+
+Each row shows:
+- **Plugin name** — the plugin's identifier
+- **Marketplace** — the registry the plugin came from (e.g. `anthropics/claude-plugins-official`)
+- **Version** — the installed version, if known
+- **Counts** — `Na · Ns · Nm` = agents · skills · MCP servers contributed by this plugin
+- **Invocations** — total Agent + Skill tool calls attributed to this plugin across all sessions
+- **Status badge** — `enabled`, `disabled`, or `blocked`
+
+Expand a row to see links to the agents/skills/MCP servers contributed by this plugin, plus a link to the plugin's source repository.
+
+## Status meanings
+
+| Status | Meaning |
+|---|---|
+| **enabled** | Plugin is active and its agents/skills/hooks are loaded |
+| **disabled** | Plugin is installed but not enabled in `~/.claude.json` |
+| **blocked** | Plugin appears in `~/.claude/plugins/blocklist.json` |
+
+## Invocation counts
+
+Counts are computed by joining the catalog (which tracks which plugin contributed which agent/skill) with the session index's `tool_uses` table. Counts reflect only sessions that have been indexed — a freshly installed plugin with no sessions yet will show 0.
+
+## Sorting
+
+| Option | Effect |
+|---|---|
+| Name | Alphabetical by plugin name |
+| Invocations | Most-used first |

--- a/docs/help/sql.md
+++ b/docs/help/sql.md
@@ -35,4 +35,4 @@ Your last 20 queries are stored in `localStorage` under the key `pm:sql-history`
 
 ## Database availability
 
-The SQL workbench requires the optional `better-sqlite3` dependency to be installed. If the database is unavailable, a 503 error is shown with a link to the Setup page.
+The SQL workbench requires the optional `better-sqlite3` dependency to be installed. If the database is unavailable, a 503 error is shown with a link to [the Setup page](/setup).

--- a/docs/help/sql.md
+++ b/docs/help/sql.md
@@ -1,0 +1,38 @@
+# SQL Workbench
+
+The SQL page gives you a read-only query interface against the local SQLite session index (`~/.minder/index.db`).
+
+## Running queries
+
+Type a `SELECT` statement in the editor and press **⌘/Ctrl+Enter** (or click **Run**) to execute it. Results appear below as a virtualized table.
+
+Only `SELECT` and `WITH … SELECT` (CTEs) are accepted. Writes, DDL, `PRAGMA` mutations, `ATTACH`, and `VACUUM` are all rejected by two independent layers:
+1. A regex pre-filter on the first keyword
+2. `stmt.readonly` bytecode introspection — catches `WITH … INSERT RETURNING` CTEs that pass a regex
+
+## Schema sidebar
+
+The left sidebar lists every table with its columns. Click a table's chevron to expand the column list. Click **↗ insert SELECT** to paste a `SELECT * FROM "<table>" LIMIT 100;` template into the editor.
+
+## Results
+
+| Feature | Details |
+|---|---|
+| Virtualized rows | Only visible rows are rendered — safe on large result sets |
+| Truncation | Results are capped at 10,000 rows; a banner appears when truncated |
+| NULL display | `NULL` values are shown in italics |
+| Column widths | Fixed at 300px max per column — scroll horizontally for wide tables |
+
+## Export
+
+Export buttons appear once a query returns rows:
+- **CSV** — RFC-4180 compliant (double-quote escaping; CRLF line endings)
+- **JSON** — pretty-printed array of row objects
+
+## Query history
+
+Your last 20 queries are stored in `localStorage` under the key `pm:sql-history`. Click the clock icon to browse and re-run previous queries. Adjacent duplicate entries are deduplicated.
+
+## Database availability
+
+The SQL workbench requires the optional `better-sqlite3` dependency to be installed. If the database is unavailable, a 503 error is shown with a link to the Setup page.

--- a/public/help/hooks.md
+++ b/public/help/hooks.md
@@ -23,7 +23,7 @@ Each row shows:
 - **Command preview** — the first 60 characters of the command
 - **local** badge — shown when the hook lives in `settings.local.json`; copying it via Template Mode auto-promotes it to `settings.json` (project-shared)
 - **Source badge** — project name (links to the project detail page) or "user" for global hooks
-- **↗ apply** button — for user-scope and project-scope hooks, copies the hook definition to another project
+- **↗ apply** button — appears for project-scope hooks (including local-scope) and user-scope hooks; copies the hook definition to another project
 
 ## The `/config` Hooks tab
 

--- a/public/help/hooks.md
+++ b/public/help/hooks.md
@@ -1,0 +1,38 @@
+# Hooks
+
+The Hooks browser shows every hook entry across all your projects and your user-scope Claude config, organized by source scope.
+
+## Coverage matrix
+
+The four stat cards at the top summarise coverage at a glance:
+
+| Card | What it counts |
+|---|---|
+| **Project** | Hooks in `.claude/settings.json` inside a project directory |
+| **Local** | Hooks in `.claude/settings.local.json` (per-machine, not shared in git) |
+| **User** | Hooks in `~/.claude.json` or `~/.claude/settings.json` (apply everywhere) |
+| **Events** | Number of distinct event types across all hooks |
+
+Click a scope card to filter the list to that scope.
+
+## Row anatomy
+
+Each row shows:
+- **Event chip** — the hook trigger (e.g. `PreToolUse`, `PostToolUse`, `SessionStart`)
+- **Matcher** — the tool or event pattern (e.g. `Edit|Write`)
+- **Command preview** — the first 60 characters of the command
+- **local** badge — shown when the hook lives in `settings.local.json`; copying it via Template Mode auto-promotes it to `settings.json` (project-shared)
+- **Source badge** — project name (links to the project detail page) or "user" for global hooks
+- **↗ apply** button — for user-scope and project-scope hooks, copies the hook definition to another project
+
+## The `/config` Hooks tab
+
+The `/config?type=hooks` tab on the Config page continues to exist for per-project deep-linking (e.g., "View hooks for this project"). The top-level `/hooks` page shows the full cross-project view.
+
+## Filtering
+
+| Control | Effect |
+|---|---|
+| Search | Matches event, matcher, command text, project name (debounced 300ms) |
+| Source dropdown | Filter to `project`, `local`, or `user` scope |
+| Sort | By event name (A–Z) or by project name |

--- a/public/help/plans.md
+++ b/public/help/plans.md
@@ -1,0 +1,29 @@
+# Plans
+
+The Plans browser surfaces every file in `~/.claude/plans/` as a searchable, filterable catalog. Plan files are the `.md` files Claude Code writes when you invoke plan mode.
+
+## What you'll see
+
+Each row shows:
+- **Title** — extracted from the plan's front-matter `title:` field, or the first `# ` heading, or the filename.
+- **Tags** — from the front-matter `tags:` array (click a tag to filter).
+- **Modified** — relative timestamp for the file's last modification.
+- **Related sessions** — sessions linked by UUID found anywhere in the plan body.
+
+Expand a row to read the full plan body and click related-session chips to navigate directly to `/sessions/<id>`.
+
+## Filtering and sorting
+
+| Control | Effect |
+|---|---|
+| Search box | Filters by title, slug, or any tag (debounced 300ms) |
+| Tag dropdown | Narrows to plans that include the selected tag |
+| Sort | Modified (newest first) or Title (A–Z) |
+
+## How plans are found
+
+Project Minder scans `~/.claude/plans/*.md`. It does **not** recurse into subdirectories. Files with front-matter are parsed; files without are also shown (title falls back to the heading or filename).
+
+## Related sessions
+
+Session IDs are found by regex-matching UUIDs in the plan body. This is a heuristic — a UUID quoted in prose (e.g., from a log paste) may appear as a false positive. If you want precise control, add a `relatedSessions:` key to the plan's front-matter listing session IDs explicitly (the scanner prefers front-matter when present, planned for a future release).

--- a/public/help/plans.md
+++ b/public/help/plans.md
@@ -6,7 +6,7 @@ The Plans browser surfaces every file in `~/.claude/plans/` as a searchable, fil
 
 Each row shows:
 - **Title** — extracted from the plan's front-matter `title:` field, or the first `# ` heading, or the filename.
-- **Tags** — from the front-matter `tags:` array (click a tag to filter).
+- **Tags** — from the front-matter `tags:` array; use the tag dropdown to filter.
 - **Modified** — relative timestamp for the file's last modification.
 - **Related sessions** — sessions linked by UUID found anywhere in the plan body.
 

--- a/public/help/plugins.md
+++ b/public/help/plugins.md
@@ -1,0 +1,34 @@
+# Plugins
+
+The Plugins browser lists every Claude Code plugin installed via `~/.claude/installed_plugins.json`, enriched with usage counts from the agent/skill catalog and the SQLite index.
+
+## Row anatomy
+
+Each row shows:
+- **Plugin name** — the plugin's identifier
+- **Marketplace** — the registry the plugin came from (e.g. `anthropics/claude-plugins-official`)
+- **Version** — the installed version, if known
+- **Counts** — `Na · Ns · Nm` = agents · skills · MCP servers contributed by this plugin
+- **Invocations** — total Agent + Skill tool calls attributed to this plugin across all sessions
+- **Status badge** — `enabled`, `disabled`, or `blocked`
+
+Expand a row to see links to the agents/skills/MCP servers contributed by this plugin, plus a link to the plugin's source repository.
+
+## Status meanings
+
+| Status | Meaning |
+|---|---|
+| **enabled** | Plugin is active and its agents/skills/hooks are loaded |
+| **disabled** | Plugin is installed but not enabled in `~/.claude.json` |
+| **blocked** | Plugin appears in `~/.claude/plugins/blocklist.json` |
+
+## Invocation counts
+
+Counts are computed by joining the catalog (which tracks which plugin contributed which agent/skill) with the session index's `tool_uses` table. Counts reflect only sessions that have been indexed — a freshly installed plugin with no sessions yet will show 0.
+
+## Sorting
+
+| Option | Effect |
+|---|---|
+| Name | Alphabetical by plugin name |
+| Invocations | Most-used first |

--- a/public/help/sql.md
+++ b/public/help/sql.md
@@ -35,4 +35,4 @@ Your last 20 queries are stored in `localStorage` under the key `pm:sql-history`
 
 ## Database availability
 
-The SQL workbench requires the optional `better-sqlite3` dependency to be installed. If the database is unavailable, a 503 error is shown with a link to the Setup page.
+The SQL workbench requires the optional `better-sqlite3` dependency to be installed. If the database is unavailable, a 503 error is shown with a link to [the Setup page](/setup).

--- a/public/help/sql.md
+++ b/public/help/sql.md
@@ -1,0 +1,38 @@
+# SQL Workbench
+
+The SQL page gives you a read-only query interface against the local SQLite session index (`~/.minder/index.db`).
+
+## Running queries
+
+Type a `SELECT` statement in the editor and press **⌘/Ctrl+Enter** (or click **Run**) to execute it. Results appear below as a virtualized table.
+
+Only `SELECT` and `WITH … SELECT` (CTEs) are accepted. Writes, DDL, `PRAGMA` mutations, `ATTACH`, and `VACUUM` are all rejected by two independent layers:
+1. A regex pre-filter on the first keyword
+2. `stmt.readonly` bytecode introspection — catches `WITH … INSERT RETURNING` CTEs that pass a regex
+
+## Schema sidebar
+
+The left sidebar lists every table with its columns. Click a table's chevron to expand the column list. Click **↗ insert SELECT** to paste a `SELECT * FROM "<table>" LIMIT 100;` template into the editor.
+
+## Results
+
+| Feature | Details |
+|---|---|
+| Virtualized rows | Only visible rows are rendered — safe on large result sets |
+| Truncation | Results are capped at 10,000 rows; a banner appears when truncated |
+| NULL display | `NULL` values are shown in italics |
+| Column widths | Fixed at 300px max per column — scroll horizontally for wide tables |
+
+## Export
+
+Export buttons appear once a query returns rows:
+- **CSV** — RFC-4180 compliant (double-quote escaping; CRLF line endings)
+- **JSON** — pretty-printed array of row objects
+
+## Query history
+
+Your last 20 queries are stored in `localStorage` under the key `pm:sql-history`. Click the clock icon to browse and re-run previous queries. Adjacent duplicate entries are deduplicated.
+
+## Database availability
+
+The SQL workbench requires the optional `better-sqlite3` dependency to be installed. If the database is unavailable, a 503 error is shown with a link to the Setup page.

--- a/src/app/api/plans/[slug]/route.ts
+++ b/src/app/api/plans/[slug]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { scanClaudePlans } from "@/lib/scanner/claudePlans";
+
+const PLANS_DIR = path.join(os.homedir(), ".claude", "plans");
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  if (!slug || /[/\\]/.test(slug)) {
+    return NextResponse.json({ error: "invalid slug" }, { status: 400 });
+  }
+
+  const filePath = path.join(PLANS_DIR, `${slug}.md`);
+  // Ensure we haven't escaped the plans dir via a crafted slug
+  if (!filePath.startsWith(PLANS_DIR)) {
+    return NextResponse.json({ error: "invalid slug" }, { status: 400 });
+  }
+
+  try {
+    const [body, plans] = await Promise.all([
+      fs.readFile(filePath, "utf-8"),
+      scanClaudePlans(),
+    ]);
+    const meta = plans.find((p) => p.slug === slug);
+    if (!meta) {
+      return NextResponse.json({ error: "not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ...meta, body });
+  } catch {
+    return NextResponse.json({ error: "not found" }, { status: 404 });
+  }
+}

--- a/src/app/api/plans/[slug]/route.ts
+++ b/src/app/api/plans/[slug]/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { promises as fs } from "fs";
 import path from "path";
 import os from "os";
-import { scanClaudePlans } from "@/lib/scanner/claudePlans";
+import { parseFrontmatter } from "@/lib/indexer/parseFrontmatter";
 
 const PLANS_DIR = path.join(os.homedir(), ".claude", "plans");
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
 
 export async function GET(
   _request: NextRequest,
@@ -16,21 +17,44 @@ export async function GET(
   }
 
   const filePath = path.join(PLANS_DIR, `${slug}.md`);
-  // Ensure we haven't escaped the plans dir via a crafted slug
   if (!filePath.startsWith(PLANS_DIR)) {
     return NextResponse.json({ error: "invalid slug" }, { status: 400 });
   }
 
   try {
-    const [body, plans] = await Promise.all([
+    const [raw, stat] = await Promise.all([
       fs.readFile(filePath, "utf-8"),
-      scanClaudePlans(),
+      fs.stat(filePath),
     ]);
-    const meta = plans.find((p) => p.slug === slug);
-    if (!meta) {
-      return NextResponse.json({ error: "not found" }, { status: 404 });
-    }
-    return NextResponse.json({ ...meta, body });
+
+    const { fm, body } = parseFrontmatter(raw);
+
+    const title =
+      typeof fm.title === "string" && fm.title.trim()
+        ? fm.title.trim()
+        : body.match(/^#\s+(.+)$/m)?.[1]?.trim() ?? slug;
+
+    const rawTags = fm.tags;
+    const tags = Array.isArray(rawTags)
+      ? rawTags.filter((t): t is string => typeof t === "string")
+      : typeof rawTags === "string"
+      ? rawTags.split(",").map((t) => t.trim()).filter(Boolean)
+      : [];
+
+    const relatedSessionIds = [
+      ...new Set([...body.matchAll(UUID_RE)].map((m) => m[0].toLowerCase())),
+    ];
+
+    return NextResponse.json({
+      slug,
+      path: filePath,
+      title,
+      tags,
+      relatedSessionIds,
+      mtime: stat.mtime.toISOString(),
+      sizeBytes: stat.size,
+      body,
+    });
   } catch {
     return NextResponse.json({ error: "not found" }, { status: 404 });
   }

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { scanClaudePlans } from "@/lib/scanner/claudePlans";
+import type { PlanEntry } from "@/lib/types";
+
+const CACHE_TTL_MS = 2 * 60 * 1000;
+
+const g = globalThis as unknown as {
+  __plansCache?: { data: PlanEntry[]; cachedAt: number } | null;
+};
+
+function getCache(): PlanEntry[] | null {
+  const slot = g.__plansCache;
+  if (!slot) return null;
+  if (Date.now() - slot.cachedAt < CACHE_TTL_MS) return slot.data;
+  g.__plansCache = null;
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get("q")?.toLowerCase() ?? undefined;
+  const tag = request.nextUrl.searchParams.get("tag") ?? undefined;
+  const sessionId = request.nextUrl.searchParams.get("session") ?? undefined;
+
+  let plans = getCache();
+  if (!plans) {
+    plans = await scanClaudePlans();
+    if (!q && !tag && !sessionId) {
+      g.__plansCache = { data: plans, cachedAt: Date.now() };
+    }
+  }
+
+  if (q) {
+    plans = plans.filter((p) =>
+      [p.title, p.slug, ...p.tags].join(" ").toLowerCase().includes(q)
+    );
+  }
+  if (tag) {
+    plans = plans.filter((p) => p.tags.includes(tag));
+  }
+  if (sessionId) {
+    plans = plans.filter((p) => p.relatedSessionIds.includes(sessionId.toLowerCase()));
+  }
+
+  return NextResponse.json(plans);
+}

--- a/src/app/api/plugins/route.ts
+++ b/src/app/api/plugins/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { loadPluginRollup } from "@/lib/data/pluginRollup";
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get("q")?.toLowerCase() ?? undefined;
+
+  let rows = await loadPluginRollup();
+
+  if (q) {
+    rows = rows.filter((r) =>
+      [r.plugin.name, r.plugin.marketplace, r.plugin.version]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(q)
+    );
+  }
+
+  return NextResponse.json(rows);
+}

--- a/src/app/hooks/page.tsx
+++ b/src/app/hooks/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { HooksBrowser } from "@/components/HooksBrowser";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+
+export default function HooksPage() {
+  useDocumentTitle("Hooks");
+  return <HooksBrowser />;
+}

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import { ComingSoonPage } from "@/components/ComingSoonPage";
+import { PlansBrowser } from "@/components/PlansBrowser";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function PlansPage() {
   useDocumentTitle("Plans");
-  return (
-    <ComingSoonPage
-      title="Plan-mode browser"
-      wave={5}
-      cluster="L"
-      todoRefs={["#152"]}
-      blurb="Catalog of plan.md files written in Claude Code's plan-mode. Each plan will surface alongside the session it came from with the same browser pattern used by /agents and /skills."
-    />
-  );
+  return <PlansBrowser />;
 }

--- a/src/app/plugins/page.tsx
+++ b/src/app/plugins/page.tsx
@@ -1,17 +1,9 @@
 "use client";
 
-import { ComingSoonPage } from "@/components/ComingSoonPage";
+import { PluginsBrowser } from "@/components/PluginsBrowser";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function PluginsPage() {
   useDocumentTitle("Plugins");
-  return (
-    <ComingSoonPage
-      title="Plugins browser"
-      wave={5}
-      cluster="L"
-      todoRefs={["#156"]}
-      blurb="Every installed plugin with per-capability invocation counts and per-plugin detail pages. Walks ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/ for full attribution."
-    />
-  );
+  return <PluginsBrowser />;
 }

--- a/src/app/sql/page.tsx
+++ b/src/app/sql/page.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import { ComingSoonPage } from "@/components/ComingSoonPage";
+import { SqlBrowser } from "@/components/SqlBrowser";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 
 export default function SqlPage() {
   useDocumentTitle("SQL");
   return (
-    <ComingSoonPage
-      title="SQL query interface"
-      wave={5}
-      cluster="L"
-      todoRefs={["#237"]}
-      blurb="Power-user SELECT-only interface against the SQLite session DB. Sortable result table, CSV export, EXPLAIN-validated queries with regex pre-checks for safety."
-    />
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+      <SqlBrowser />
+    </div>
   );
 }

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -59,7 +59,7 @@ const GROUPS: Group[] = [
   {
     label: "Config",
     children: [
-      item("/config?type=hooks", "Hooks", { matchType: "hooks" }),
+      item("/hooks", "Hooks"),
       item("/config?type=mcp",   "MCP",   { matchType: "mcp" }),
       item("/settings",          "Settings"),
       item("/setup",             "Setup"),

--- a/src/components/HooksBrowser.tsx
+++ b/src/components/HooksBrowser.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Search, Webhook } from "lucide-react";
+import Link from "next/link";
+import { useHooks } from "@/hooks/useHooks";
+import { Pill, inlineCode, commandPreview } from "./config/primitives";
+import { ApplyUnitButton } from "./ApplyUnitButton";
+import type { HookSource } from "@/lib/types";
+
+const SOURCE_OPTIONS = ["all", "project", "local", "user"] as const;
+type SourceFilter = (typeof SOURCE_OPTIONS)[number];
+
+const SORT_OPTIONS = [
+  { value: "event", label: "Event" },
+  { value: "project", label: "Project" },
+] as const;
+type SortBy = (typeof SORT_OPTIONS)[number]["value"];
+
+export function HooksBrowser() {
+  const [rawQuery, setRawQuery] = useState("");
+  const [query, setQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const [sortBy, setSortBy] = useState<SortBy>("event");
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(rawQuery), 300);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  const { data: allHooks, loading, error } = useHooks();
+
+  const filtered = allHooks.filter((h) => {
+    if (sourceFilter !== "all" && h.source !== sourceFilter) return false;
+    if (query) {
+      const q = query.toLowerCase();
+      const text = [h.event, h.matcher ?? "", h.commands[0]?.command ?? "", h.projectName ?? ""].join(" ").toLowerCase();
+      if (!text.includes(q)) return false;
+    }
+    return true;
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (sortBy === "project") {
+      const pa = a.projectName ?? "";
+      const pb = b.projectName ?? "";
+      if (pa !== pb) return pa.localeCompare(pb);
+    }
+    return a.event.localeCompare(b.event);
+  });
+
+  // Coverage matrix counts
+  const projectCount = allHooks.filter((h) => h.source === "project").length;
+  const localCount = allHooks.filter((h) => h.source === "local").length;
+  const userCount = allHooks.filter((h) => h.source === "user").length;
+
+  const uniqueEvents = new Set(allHooks.map((h) => h.event)).size;
+
+  const virtualizer = useVirtualizer({
+    count: sorted.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 44,
+    overscan: 8,
+    getItemKey: (i) => `${sorted[i].unitKey}-${i}`,
+  });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <Webhook style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
+        <h1
+          style={{
+            fontSize: "0.72rem",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--text-secondary)",
+            fontFamily: "var(--font-body)",
+            margin: 0,
+          }}
+        >
+          Hooks
+        </h1>
+      </header>
+
+      {/* Coverage matrix */}
+      {!loading && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(4, 1fr)",
+            gap: "8px",
+          }}
+        >
+          {[
+            { label: "Project", count: projectCount, source: "project" as HookSource },
+            { label: "Local", count: localCount, source: "local" as HookSource },
+            { label: "User", count: userCount, source: "user" as HookSource },
+            { label: "Events", count: uniqueEvents, source: null },
+          ].map(({ label, count, source }) => (
+            <button
+              key={label}
+              onClick={() => source && setSourceFilter((f) => f === source ? "all" : source)}
+              style={{
+                padding: "10px 12px",
+                background:
+                  source && sourceFilter === source
+                    ? "var(--info-bg)"
+                    : "var(--surface-2)",
+                border: `1px solid ${source && sourceFilter === source ? "var(--info-border, var(--info))" : "var(--border)"}`,
+                borderRadius: "var(--radius)",
+                cursor: source ? "pointer" : "default",
+                textAlign: "left",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: "1.2rem",
+                  fontWeight: 700,
+                  fontFamily: "var(--font-mono)",
+                  color: "var(--text-primary)",
+                  lineHeight: 1,
+                }}
+              >
+                {count}
+              </div>
+              <div
+                style={{
+                  fontSize: "0.65rem",
+                  color: "var(--text-muted)",
+                  fontFamily: "var(--font-body)",
+                  marginTop: "3px",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                {label}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+        <div
+          style={{
+            position: "relative",
+            flex: 1,
+            maxWidth: "340px",
+          }}
+        >
+          <Search
+            style={{
+              position: "absolute",
+              left: "8px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              width: "12px",
+              height: "12px",
+              color: "var(--text-muted)",
+              pointerEvents: "none",
+            }}
+          />
+          <input
+            value={rawQuery}
+            onChange={(e) => setRawQuery(e.target.value)}
+            placeholder="Search hooks…"
+            style={{
+              width: "100%",
+              padding: "6px 8px 6px 26px",
+              background: "var(--surface-2)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              fontSize: "0.78rem",
+              fontFamily: "var(--font-body)",
+              color: "var(--text-primary)",
+              outline: "none",
+            }}
+          />
+        </div>
+
+        <select
+          value={sourceFilter}
+          onChange={(e) => setSourceFilter(e.target.value as SourceFilter)}
+          style={{
+            padding: "5px 8px",
+            background: "var(--surface-2)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            fontSize: "0.75rem",
+            fontFamily: "var(--font-body)",
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+          }}
+        >
+          {SOURCE_OPTIONS.map((s) => (
+            <option key={s} value={s}>
+              {s === "all" ? "All sources" : s}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as SortBy)}
+          style={{
+            padding: "5px 8px",
+            background: "var(--surface-2)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            fontSize: "0.75rem",
+            fontFamily: "var(--font-body)",
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+          }}
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              Sort: {o.label}
+            </option>
+          ))}
+        </select>
+
+        <span
+          style={{
+            marginLeft: "auto",
+            fontSize: "0.72rem",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {sorted.length} hook{sorted.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div
+          style={{
+            padding: "8px 12px",
+            background: "var(--error-bg, #2a0000)",
+            borderRadius: "var(--radius)",
+            fontSize: "0.78rem",
+            color: "var(--error, #f87171)",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Virtualised list */}
+      {loading ? (
+        <LoadingSkeleton />
+      ) : sorted.length === 0 ? (
+        <Empty query={rawQuery} />
+      ) : (
+        <div
+          ref={parentRef}
+          style={{ height: "600px", overflowY: "auto" }}
+        >
+          <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
+            {virtualizer.getVirtualItems().map((vItem) => {
+              const h = sorted[vItem.index];
+              return (
+                <div
+                  key={vItem.key}
+                  data-index={vItem.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${vItem.start}px)`,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    padding: "7px 0",
+                    borderBottom: "1px solid var(--border-subtle)",
+                  }}
+                >
+                  <Pill tone="info">{h.event}</Pill>
+                  <span
+                    style={{
+                      flex: 1,
+                      minWidth: 0,
+                      fontSize: "0.72rem",
+                      display: "inline-flex",
+                      gap: "6px",
+                      alignItems: "center",
+                      overflow: "hidden",
+                      whiteSpace: "nowrap",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {h.matcher && <code style={inlineCode}>{h.matcher}</code>}
+                    <span
+                      style={{
+                        color: "var(--text-secondary)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      {commandPreview(h.commands[0]?.command, h.commands.length)}
+                    </span>
+                  </span>
+                  {h.source === "local" && <LocalScopeBadge />}
+                  {h.projectSlug ? (
+                    <ApplyUnitButton
+                      unit={{ kind: "hook", key: h.unitKey }}
+                      source={{ kind: "project", slug: h.projectSlug }}
+                      excludeTargetSlugs={[h.projectSlug]}
+                      compact
+                    />
+                  ) : h.source === "user" ? (
+                    <ApplyUnitButton
+                      unit={{ kind: "hook", key: h.unitKey }}
+                      source={{ kind: "user" }}
+                      compact
+                    />
+                  ) : null}
+                  <SourceBadge projectSlug={h.projectSlug} projectName={h.projectName} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LocalScopeBadge() {
+  return (
+    <span
+      title=".claude/settings.local.json — per-machine; copying via Template Mode auto-promotes to settings.json (project-shared)"
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6rem",
+        color: "var(--warning, #f59e0b)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "3px",
+        padding: "1px 5px",
+        letterSpacing: "0.04em",
+      }}
+    >
+      local
+    </span>
+  );
+}
+
+function SourceBadge({
+  projectSlug,
+  projectName,
+}: {
+  projectSlug?: string;
+  projectName?: string;
+}) {
+  if (!projectSlug || !projectName) {
+    return (
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.6rem",
+          color: "var(--text-muted)",
+          border: "1px solid var(--border-subtle)",
+          borderRadius: "3px",
+          padding: "1px 5px",
+        }}
+      >
+        user
+      </span>
+    );
+  }
+  return (
+    <Link
+      href={`/project/${projectSlug}`}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.6rem",
+        color: "var(--info)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "3px",
+        padding: "1px 5px",
+        textDecoration: "none",
+      }}
+      title={`project: ${projectName}`}
+    >
+      {projectName}
+    </Link>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            height: "40px",
+            borderRadius: "var(--radius)",
+            background: "var(--surface-2)",
+            opacity: 1 - i * 0.1,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Empty({ query }: { query: string }) {
+  return (
+    <div
+      style={{
+        padding: "40px 0",
+        textAlign: "center",
+        color: "var(--text-muted)",
+        fontSize: "0.8rem",
+        fontFamily: "var(--font-body)",
+      }}
+    >
+      {query ? `No hooks match "${query}"` : "No hooks configured."}
+    </div>
+  );
+}

--- a/src/components/PlansBrowser.tsx
+++ b/src/components/PlansBrowser.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import { useEffect, useRef, useState, useMemo } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Search, FileText, ChevronDown, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { usePlans, fetchPlanBody } from "@/hooks/usePlans";
+import { formatRelativeTime } from "@/lib/utils";
+import type { PlanEntry } from "@/lib/types";
+
+const SORT_OPTIONS = [
+  { value: "mtime", label: "Modified" },
+  { value: "title", label: "Title" },
+] as const;
+type SortBy = (typeof SORT_OPTIONS)[number]["value"];
+
+type BodyState = { state: "idle" } | { state: "loading" } | { state: "done"; body: string };
+
+export function PlansBrowser() {
+  const [rawQuery, setRawQuery] = useState("");
+  const [query, setQuery] = useState("");
+  const [tagFilter, setTagFilter] = useState<string>("all");
+  const [sortBy, setSortBy] = useState<SortBy>("mtime");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [bodiesById, setBodiesById] = useState<Map<string, BodyState>>(new Map());
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(rawQuery), 300);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  const { data: plans, loading, error } = usePlans({ q: query || undefined });
+
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const p of plans) {
+      for (const t of p.tags) set.add(t);
+    }
+    return Array.from(set).sort();
+  }, [plans]);
+
+  const filtered = tagFilter === "all"
+    ? plans
+    : plans.filter((p) => p.tags.includes(tagFilter));
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (sortBy === "title") return a.title.localeCompare(b.title);
+    return b.mtime.localeCompare(a.mtime);
+  });
+
+  const virtualizer = useVirtualizer({
+    count: sorted.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 60,
+    overscan: 6,
+    getItemKey: (i) => sorted[i].slug,
+  });
+
+  function toggleExpand(slug: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) {
+        next.delete(slug);
+      } else {
+        next.add(slug);
+        if (!bodiesById.has(slug)) {
+          setBodiesById((m) => new Map(m).set(slug, { state: "loading" }));
+          fetchPlanBody(slug)
+            .then((body) => {
+              setBodiesById((m) =>
+                new Map(m).set(slug, { state: "done", body: body ?? "" })
+              );
+            })
+            .catch(() => {
+              setBodiesById((m) =>
+                new Map(m).set(slug, { state: "done", body: "" })
+              );
+            });
+        }
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <FileText style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
+        <h1
+          style={{
+            fontSize: "0.72rem",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--text-secondary)",
+            fontFamily: "var(--font-body)",
+            margin: 0,
+          }}
+        >
+          Plans
+        </h1>
+        <span
+          style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "var(--text-muted)" }}
+        >
+          ~/.claude/plans/
+        </span>
+      </header>
+
+      {/* Filters */}
+      <div style={{ display: "flex", gap: "8px", alignItems: "center", flexWrap: "wrap" }}>
+        <div style={{ position: "relative", flex: 1, maxWidth: "340px" }}>
+          <Search
+            style={{
+              position: "absolute",
+              left: "8px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              width: "12px",
+              height: "12px",
+              color: "var(--text-muted)",
+              pointerEvents: "none",
+            }}
+          />
+          <input
+            value={rawQuery}
+            onChange={(e) => setRawQuery(e.target.value)}
+            placeholder="Search plans…"
+            style={{
+              width: "100%",
+              padding: "6px 8px 6px 26px",
+              background: "var(--surface-2)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              fontSize: "0.78rem",
+              fontFamily: "var(--font-body)",
+              color: "var(--text-primary)",
+              outline: "none",
+            }}
+          />
+        </div>
+
+        {allTags.length > 0 && (
+          <select
+            value={tagFilter}
+            onChange={(e) => setTagFilter(e.target.value)}
+            style={{
+              padding: "5px 8px",
+              background: "var(--surface-2)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              fontSize: "0.75rem",
+              fontFamily: "var(--font-body)",
+              color: "var(--text-secondary)",
+              cursor: "pointer",
+            }}
+          >
+            <option value="all">All tags</option>
+            {allTags.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        )}
+
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as SortBy)}
+          style={{
+            padding: "5px 8px",
+            background: "var(--surface-2)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            fontSize: "0.75rem",
+            fontFamily: "var(--font-body)",
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+          }}
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              Sort: {o.label}
+            </option>
+          ))}
+        </select>
+
+        <span
+          style={{
+            marginLeft: "auto",
+            fontSize: "0.72rem",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {sorted.length} plan{sorted.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: "8px 12px",
+            background: "var(--error-bg, #2a0000)",
+            borderRadius: "var(--radius)",
+            fontSize: "0.78rem",
+            color: "var(--error, #f87171)",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <LoadingSkeleton />
+      ) : sorted.length === 0 ? (
+        <Empty query={rawQuery} />
+      ) : (
+        <div ref={parentRef} style={{ overflowY: "auto", maxHeight: "70vh" }}>
+          <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
+            {virtualizer.getVirtualItems().map((vItem) => {
+              const plan = sorted[vItem.index];
+              const expanded = expandedIds.has(plan.slug);
+              const bodyState = bodiesById.get(plan.slug) ?? { state: "idle" };
+              return (
+                <div
+                  key={vItem.key}
+                  data-index={vItem.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${vItem.start}px)`,
+                    borderBottom: "1px solid var(--border-subtle)",
+                  }}
+                >
+                  <PlanRow
+                    plan={plan}
+                    expanded={expanded}
+                    onToggle={() => toggleExpand(plan.slug)}
+                    bodyState={bodyState}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PlanRow({
+  plan,
+  expanded,
+  onToggle,
+  bodyState,
+}: {
+  plan: PlanEntry;
+  expanded: boolean;
+  onToggle: () => void;
+  bodyState: BodyState;
+}) {
+  return (
+    <div style={{ padding: "10px 0" }}>
+      <div
+        style={{ display: "flex", alignItems: "flex-start", gap: "8px", cursor: "pointer" }}
+        onClick={onToggle}
+      >
+        <span style={{ marginTop: "3px", color: "var(--text-muted)", flexShrink: 0 }}>
+          {expanded ? (
+            <ChevronDown style={{ width: "12px", height: "12px" }} />
+          ) : (
+            <ChevronRight style={{ width: "12px", height: "12px" }} />
+          )}
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+            <span
+              style={{
+                fontSize: "0.82rem",
+                fontWeight: 600,
+                color: "var(--text-primary)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {plan.title}
+            </span>
+            {plan.tags.map((tag) => (
+              <span
+                key={tag}
+                style={{
+                  fontSize: "0.65rem",
+                  fontFamily: "var(--font-mono)",
+                  padding: "1px 6px",
+                  background: "var(--surface-2)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "10px",
+                  color: "var(--text-muted)",
+                }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              marginTop: "3px",
+            }}
+          >
+            <span
+              style={{
+                fontSize: "0.68rem",
+                color: "var(--text-muted)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {formatRelativeTime(plan.mtime)}
+            </span>
+            {plan.relatedSessionIds.length > 0 && (
+              <span
+                style={{
+                  fontSize: "0.65rem",
+                  color: "var(--info)",
+                  fontFamily: "var(--font-mono)",
+                }}
+              >
+                {plan.relatedSessionIds.length} session
+                {plan.relatedSessionIds.length !== 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {expanded && (
+        <div
+          style={{
+            marginTop: "8px",
+            paddingLeft: "20px",
+            paddingBottom: "8px",
+          }}
+        >
+          {bodyState.state === "loading" && (
+            <div
+              style={{ color: "var(--text-muted)", fontSize: "0.75rem", padding: "8px 0" }}
+            >
+              Loading…
+            </div>
+          )}
+          {bodyState.state === "done" && (
+            <>
+              <pre
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.72rem",
+                  color: "var(--text-secondary)",
+                  background: "var(--surface-2)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius)",
+                  padding: "10px 12px",
+                  overflowX: "auto",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  maxHeight: "400px",
+                  overflowY: "auto",
+                }}
+              >
+                {bodyState.body || "(empty)"}
+              </pre>
+              {plan.relatedSessionIds.length > 0 && (
+                <div
+                  style={{
+                    marginTop: "8px",
+                    display: "flex",
+                    gap: "6px",
+                    flexWrap: "wrap",
+                    alignItems: "center",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "0.65rem",
+                      color: "var(--text-muted)",
+                      fontFamily: "var(--font-body)",
+                    }}
+                  >
+                    Related sessions:
+                  </span>
+                  {plan.relatedSessionIds.map((id) => (
+                    <Link
+                      key={id}
+                      href={`/sessions/${id}`}
+                      style={{
+                        fontSize: "0.65rem",
+                        fontFamily: "var(--font-mono)",
+                        color: "var(--info)",
+                        textDecoration: "none",
+                      }}
+                      title={id}
+                    >
+                      {id.slice(0, 8)}…
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            height: "54px",
+            borderRadius: "var(--radius)",
+            background: "var(--surface-2)",
+            opacity: 1 - i * 0.12,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Empty({ query }: { query: string }) {
+  return (
+    <div
+      style={{
+        padding: "40px 0",
+        textAlign: "center",
+        color: "var(--text-muted)",
+        fontSize: "0.8rem",
+        fontFamily: "var(--font-body)",
+      }}
+    >
+      {query
+        ? `No plans match "${query}"`
+        : "No plans found in ~/.claude/plans/"}
+    </div>
+  );
+}

--- a/src/components/PluginsBrowser.tsx
+++ b/src/components/PluginsBrowser.tsx
@@ -329,7 +329,7 @@ function PluginRow({
           {agentCount > 0 && (
             <div style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}>
               <Link
-                href={`/agents?source=plugin`}
+                href={`/agents?source=plugin&q=${encodeURIComponent(plugin.name)}`}
                 style={{ color: "var(--info)", textDecoration: "none" }}
               >
                 {agentCount} agent{agentCount !== 1 ? "s" : ""}
@@ -339,7 +339,7 @@ function PluginRow({
           {skillCount > 0 && (
             <div style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}>
               <Link
-                href={`/skills?source=plugin`}
+                href={`/skills?source=plugin&q=${encodeURIComponent(plugin.name)}`}
                 style={{ color: "var(--info)", textDecoration: "none" }}
               >
                 {skillCount} skill{skillCount !== 1 ? "s" : ""}

--- a/src/components/PluginsBrowser.tsx
+++ b/src/components/PluginsBrowser.tsx
@@ -1,0 +1,444 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Search, Box, ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { usePlugins } from "@/hooks/usePlugins";
+import { ApplyUnitButton } from "./ApplyUnitButton";
+import type { PluginRollupRow } from "@/hooks/usePlugins";
+
+const SORT_OPTIONS = [
+  { value: "name", label: "Name" },
+  { value: "invocations", label: "Invocations" },
+] as const;
+type SortBy = (typeof SORT_OPTIONS)[number]["value"];
+
+function pluginRowKey(row: PluginRollupRow): string {
+  return `${row.plugin.name}@${row.plugin.marketplace}`;
+}
+
+export function PluginsBrowser() {
+  const [rawQuery, setRawQuery] = useState("");
+  const [query, setQuery] = useState("");
+  const [sortBy, setSortBy] = useState<SortBy>("name");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(rawQuery), 300);
+    return () => clearTimeout(t);
+  }, [rawQuery]);
+
+  const { data: plugins, loading, error } = usePlugins(query || undefined);
+
+  const sorted = [...plugins].sort((a, b) => {
+    if (sortBy === "invocations") return b.totalInvocations - a.totalInvocations;
+    return a.plugin.name.localeCompare(b.plugin.name);
+  });
+
+  const virtualizer = useVirtualizer({
+    count: sorted.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 56,
+    overscan: 6,
+    getItemKey: (i) => pluginRowKey(sorted[i]),
+  });
+
+  function toggleExpand(key: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <Box style={{ width: "14px", height: "14px", color: "var(--text-muted)" }} />
+        <h1
+          style={{
+            fontSize: "0.72rem",
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--text-secondary)",
+            fontFamily: "var(--font-body)",
+            margin: 0,
+          }}
+        >
+          Plugins
+        </h1>
+      </header>
+
+      {/* Filters */}
+      <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+        <div style={{ position: "relative", flex: 1, maxWidth: "340px" }}>
+          <Search
+            style={{
+              position: "absolute",
+              left: "8px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              width: "12px",
+              height: "12px",
+              color: "var(--text-muted)",
+              pointerEvents: "none",
+            }}
+          />
+          <input
+            value={rawQuery}
+            onChange={(e) => setRawQuery(e.target.value)}
+            placeholder="Search plugins…"
+            style={{
+              width: "100%",
+              padding: "6px 8px 6px 26px",
+              background: "var(--surface-2)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              fontSize: "0.78rem",
+              fontFamily: "var(--font-body)",
+              color: "var(--text-primary)",
+              outline: "none",
+            }}
+          />
+        </div>
+
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as SortBy)}
+          style={{
+            padding: "5px 8px",
+            background: "var(--surface-2)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            fontSize: "0.75rem",
+            fontFamily: "var(--font-body)",
+            color: "var(--text-secondary)",
+            cursor: "pointer",
+          }}
+        >
+          {SORT_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              Sort: {o.label}
+            </option>
+          ))}
+        </select>
+
+        <span
+          style={{
+            marginLeft: "auto",
+            fontSize: "0.72rem",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {sorted.length} plugin{sorted.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: "8px 12px",
+            background: "var(--error-bg, #2a0000)",
+            borderRadius: "var(--radius)",
+            fontSize: "0.78rem",
+            color: "var(--error, #f87171)",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <LoadingSkeleton />
+      ) : sorted.length === 0 ? (
+        <Empty query={rawQuery} />
+      ) : (
+        <div ref={parentRef} style={{ overflowY: "auto", maxHeight: "70vh" }}>
+          <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
+            {virtualizer.getVirtualItems().map((vItem) => {
+              const row = sorted[vItem.index];
+              const rowKey = pluginRowKey(row);
+              const expanded = expandedIds.has(rowKey);
+              return (
+                <div
+                  key={vItem.key}
+                  data-index={vItem.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${vItem.start}px)`,
+                    borderBottom: "1px solid var(--border-subtle)",
+                  }}
+                >
+                  <PluginRow
+                    row={row}
+                    expanded={expanded}
+                    onToggle={() => toggleExpand(rowKey)}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PluginRow({
+  row,
+  expanded,
+  onToggle,
+}: {
+  row: PluginRollupRow;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const { plugin, agentCount, skillCount, mcpServerCount, totalInvocations } = row;
+  const status: "enabled" | "disabled" | "blocked" = plugin.blocked
+    ? "blocked"
+    : plugin.enabled
+    ? "enabled"
+    : "disabled";
+
+  return (
+    <div style={{ padding: "10px 0" }}>
+      <div
+        style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer" }}
+        onClick={onToggle}
+      >
+        <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>
+          {expanded ? (
+            <ChevronDown style={{ width: "12px", height: "12px" }} />
+          ) : (
+            <ChevronRight style={{ width: "12px", height: "12px" }} />
+          )}
+        </span>
+
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: "0.82rem",
+            fontWeight: 600,
+            color: "var(--text-primary)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {plugin.name}
+        </span>
+
+        {plugin.marketplace && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.62rem",
+              color: "var(--text-muted)",
+              flexShrink: 0,
+            }}
+          >
+            {plugin.marketplace}
+          </span>
+        )}
+
+        {plugin.version && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.62rem",
+              color: "var(--text-muted)",
+              flexShrink: 0,
+            }}
+          >
+            v{plugin.version}
+          </span>
+        )}
+
+        {(agentCount > 0 || skillCount > 0 || mcpServerCount > 0) && (
+          <span
+            style={{
+              fontSize: "0.68rem",
+              fontFamily: "var(--font-mono)",
+              color: "var(--text-muted)",
+              flexShrink: 0,
+            }}
+          >
+            {[
+              agentCount > 0 && `${agentCount}a`,
+              skillCount > 0 && `${skillCount}s`,
+              mcpServerCount > 0 && `${mcpServerCount}m`,
+            ].filter(Boolean).join(" · ")}
+          </span>
+        )}
+
+        {totalInvocations > 0 && (
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.65rem",
+              fontWeight: 600,
+              padding: "1px 6px",
+              background: "var(--surface-2)",
+              border: "1px solid var(--border)",
+              borderRadius: "3px",
+              color: "var(--text-secondary)",
+              flexShrink: 0,
+            }}
+          >
+            {totalInvocations.toLocaleString()}×
+          </span>
+        )}
+
+        <StatusPill status={status} />
+
+        {plugin.enabled && (
+          <ApplyUnitButton
+            unit={{
+              kind: "plugin",
+              key: plugin.marketplace
+                ? `${plugin.name}@${plugin.marketplace}`
+                : plugin.name,
+            }}
+            source={{ kind: "user" }}
+            compact
+          />
+        )}
+      </div>
+
+      {expanded && (
+        <div
+          style={{
+            paddingLeft: "20px",
+            paddingTop: "8px",
+            paddingBottom: "8px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "6px",
+          }}
+        >
+          {agentCount > 0 && (
+            <div style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}>
+              <Link
+                href={`/agents?source=plugin`}
+                style={{ color: "var(--info)", textDecoration: "none" }}
+              >
+                {agentCount} agent{agentCount !== 1 ? "s" : ""}
+              </Link>
+            </div>
+          )}
+          {skillCount > 0 && (
+            <div style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}>
+              <Link
+                href={`/skills?source=plugin`}
+                style={{ color: "var(--info)", textDecoration: "none" }}
+              >
+                {skillCount} skill{skillCount !== 1 ? "s" : ""}
+              </Link>
+            </div>
+          )}
+          {mcpServerCount > 0 && (
+            <div style={{ fontSize: "0.72rem", color: "var(--text-secondary)" }}>
+              <Link
+                href={`/config?type=mcp`}
+                style={{ color: "var(--info)", textDecoration: "none" }}
+              >
+                {mcpServerCount} MCP server{mcpServerCount !== 1 ? "s" : ""}
+              </Link>
+            </div>
+          )}
+          {plugin.pluginRepoUrl && (
+            <a
+              href={plugin.pluginRepoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "4px",
+                fontSize: "0.68rem",
+                color: "var(--text-muted)",
+                textDecoration: "none",
+              }}
+            >
+              <ExternalLink style={{ width: "10px", height: "10px" }} />
+              Source
+            </a>
+          )}
+          {agentCount === 0 && skillCount === 0 && mcpServerCount === 0 && (
+            <span style={{ fontSize: "0.72rem", color: "var(--text-muted)" }}>
+              No indexed catalog entries
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: "enabled" | "disabled" | "blocked" }) {
+  const colors = {
+    enabled: { bg: "var(--success-bg, #002a00)", text: "var(--success, #4ade80)" },
+    disabled: { bg: "var(--surface-2)", text: "var(--text-muted)" },
+    blocked: { bg: "var(--error-bg, #2a0000)", text: "var(--error, #f87171)" },
+  }[status];
+  return (
+    <span
+      style={{
+        fontSize: "0.6rem",
+        fontFamily: "var(--font-mono)",
+        padding: "1px 5px",
+        background: colors.bg,
+        color: colors.text,
+        border: "1px solid var(--border)",
+        borderRadius: "3px",
+        flexShrink: 0,
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          style={{
+            height: "48px",
+            borderRadius: "var(--radius)",
+            background: "var(--surface-2)",
+            opacity: 1 - i * 0.12,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Empty({ query }: { query: string }) {
+  return (
+    <div
+      style={{
+        padding: "40px 0",
+        textAlign: "center",
+        color: "var(--text-muted)",
+        fontSize: "0.8rem",
+        fontFamily: "var(--font-body)",
+      }}
+    >
+      {query ? `No plugins match "${query}"` : "No plugins installed."}
+    </div>
+  );
+}

--- a/src/components/SqlBrowser.tsx
+++ b/src/components/SqlBrowser.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { Play, Download, Clock } from "lucide-react";
+import { SqlSchemaSidebar } from "./SqlSchemaSidebar";
+import { SqlResultsTable } from "./SqlResultsTable";
+import { useSqlHistory } from "@/hooks/useSqlHistory";
+import { toCsv } from "@/lib/csv";
+import { downloadBlob } from "@/lib/downloadBlob";
+
+interface SqlResult {
+  rows: Record<string, unknown>[];
+  columns: string[];
+  rowCount: number;
+  truncated: boolean;
+  durationMs: number;
+}
+
+export function SqlBrowser() {
+  const [sql, setSql] = useState("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;");
+  const [result, setResult] = useState<SqlResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { history, pushHistory } = useSqlHistory();
+
+  const runQuery = useCallback(async () => {
+    const trimmed = sql.trim();
+    if (!trimmed || running) return;
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/sql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ sql: trimmed }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? `HTTP ${res.status}`);
+      } else {
+        setResult(data as SqlResult);
+        pushHistory(trimmed);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setRunning(false);
+    }
+  }, [sql, running, pushHistory]);
+
+  function insertSql(snippet: string) {
+    setSql(snippet);
+    textareaRef.current?.focus();
+  }
+
+  function exportCsv() {
+    if (!result) return;
+    const content = toCsv(result.rows, result.columns);
+    downloadBlob(content, "query-results.csv", "text/csv;charset=utf-8");
+  }
+
+  function exportJson() {
+    if (!result) return;
+    downloadBlob(
+      JSON.stringify(result.rows, null, 2),
+      "query-results.json",
+      "application/json"
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flex: 1, minHeight: 0, overflow: "hidden" }}>
+      <SqlSchemaSidebar onInsert={insertSql} />
+
+      <div style={{ display: "flex", flexDirection: "column", flex: 1, minWidth: 0 }}>
+        {/* Editor pane */}
+        <div
+          style={{
+            padding: "12px",
+            borderBottom: "1px solid var(--border)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "8px",
+          }}
+        >
+          <textarea
+            ref={textareaRef}
+            value={sql}
+            onChange={(e) => setSql(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                runQuery();
+              }
+            }}
+            spellCheck={false}
+            rows={6}
+            placeholder="SELECT * FROM sessions LIMIT 10;"
+            style={{
+              width: "100%",
+              background: "var(--surface-2)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              padding: "8px 10px",
+              fontSize: "0.8rem",
+              fontFamily: "var(--font-mono)",
+              color: "var(--text-primary)",
+              resize: "vertical",
+              outline: "none",
+              lineHeight: 1.5,
+            }}
+          />
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <button
+              onClick={runQuery}
+              disabled={running}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "5px",
+                padding: "5px 12px",
+                background: running ? "var(--surface-2)" : "var(--info)",
+                color: running ? "var(--text-muted)" : "#fff",
+                border: "none",
+                borderRadius: "var(--radius)",
+                fontSize: "0.75rem",
+                fontFamily: "var(--font-body)",
+                fontWeight: 600,
+                cursor: running ? "not-allowed" : "pointer",
+              }}
+            >
+              <Play style={{ width: "12px", height: "12px" }} />
+              {running ? "Running…" : "Run"}
+            </button>
+            <span
+              style={{
+                fontSize: "0.68rem",
+                color: "var(--text-muted)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              ⌘/Ctrl+Enter
+            </span>
+
+            {result && result.rows.length > 0 && (
+              <>
+                <button
+                  onClick={exportCsv}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "4px",
+                    padding: "4px 10px",
+                    background: "var(--surface-2)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius)",
+                    fontSize: "0.72rem",
+                    fontFamily: "var(--font-body)",
+                    cursor: "pointer",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  <Download style={{ width: "11px", height: "11px" }} />
+                  CSV
+                </button>
+                <button
+                  onClick={exportJson}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "4px",
+                    padding: "4px 10px",
+                    background: "var(--surface-2)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius)",
+                    fontSize: "0.72rem",
+                    fontFamily: "var(--font-body)",
+                    cursor: "pointer",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  <Download style={{ width: "11px", height: "11px" }} />
+                  JSON
+                </button>
+              </>
+            )}
+
+            {history.length > 0 && (
+              <div style={{ marginLeft: "auto", position: "relative" }}>
+                <button
+                  onClick={() => setHistoryOpen((o) => !o)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "4px",
+                    padding: "4px 8px",
+                    background: "var(--surface-2)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius)",
+                    fontSize: "0.72rem",
+                    fontFamily: "var(--font-body)",
+                    cursor: "pointer",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  <Clock style={{ width: "11px", height: "11px" }} />
+                  History ({history.length})
+                </button>
+                {historyOpen && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      right: 0,
+                      top: "calc(100% + 4px)",
+                      background: "var(--surface)",
+                      border: "1px solid var(--border)",
+                      borderRadius: "var(--radius)",
+                      boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+                      zIndex: 50,
+                      width: "400px",
+                      maxHeight: "300px",
+                      overflowY: "auto",
+                    }}
+                  >
+                    {history.map((entry, i) => (
+                      <button
+                        key={i}
+                        onClick={() => {
+                          setSql(entry);
+                          setHistoryOpen(false);
+                          textareaRef.current?.focus();
+                        }}
+                        style={{
+                          display: "block",
+                          width: "100%",
+                          padding: "6px 10px",
+                          textAlign: "left",
+                          background: "none",
+                          border: "none",
+                          borderBottom: "1px solid var(--border)",
+                          cursor: "pointer",
+                          fontSize: "0.72rem",
+                          fontFamily: "var(--font-mono)",
+                          color: "var(--text-secondary)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                        title={entry}
+                      >
+                        {entry}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Error banner */}
+        {error && (
+          <div
+            style={{
+              padding: "8px 12px",
+              background: "var(--error-bg, #2a0000)",
+              borderBottom: "1px solid var(--border)",
+              fontSize: "0.78rem",
+              fontFamily: "var(--font-mono)",
+              color: "var(--error, #f87171)",
+            }}
+          >
+            {error === "db unavailable"
+              ? "Database not initialized — visit Setup to enable the SQLite index."
+              : `Error: ${error}`}
+          </div>
+        )}
+
+        {/* Results area */}
+        <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
+          {result ? (
+            <SqlResultsTable
+              rows={result.rows}
+              columns={result.columns}
+              truncated={result.truncated}
+              durationMs={result.durationMs}
+              rowCount={result.rowCount}
+            />
+          ) : !error && !running ? (
+            <div
+              style={{
+                flex: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "var(--text-muted)",
+                fontSize: "0.8rem",
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              Run a query to see results
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SqlBrowser.tsx
+++ b/src/components/SqlBrowser.tsx
@@ -5,6 +5,7 @@ import { Play, Download, Clock } from "lucide-react";
 import { SqlSchemaSidebar } from "./SqlSchemaSidebar";
 import { SqlResultsTable } from "./SqlResultsTable";
 import { useSqlHistory } from "@/hooks/useSqlHistory";
+import Link from "next/link";
 import { toCsv } from "@/lib/csv";
 import { downloadBlob } from "@/lib/downloadBlob";
 
@@ -273,9 +274,17 @@ export function SqlBrowser() {
               color: "var(--error, #f87171)",
             }}
           >
-            {error === "db unavailable"
-              ? "Database not initialized — visit Setup to enable the SQLite index."
-              : `Error: ${error}`}
+            {error === "db unavailable" ? (
+              <>
+                Database not initialized —{" "}
+                <Link href="/setup" style={{ color: "var(--info)" }}>
+                  visit Setup
+                </Link>{" "}
+                to enable the SQLite index.
+              </>
+            ) : (
+              `Error: ${error}`
+            )}
           </div>
         )}
 

--- a/src/components/SqlResultsTable.tsx
+++ b/src/components/SqlResultsTable.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+interface SqlResultsTableProps {
+  rows: Record<string, unknown>[];
+  columns: string[];
+  truncated: boolean;
+  durationMs: number;
+  rowCount: number;
+}
+
+const cellStyle: React.CSSProperties = {
+  padding: "4px 10px",
+  fontSize: "0.75rem",
+  fontFamily: "var(--font-mono)",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  minWidth: "80px",
+  maxWidth: "300px",
+  flexShrink: 0,
+};
+
+export function SqlResultsTable({ rows, columns, truncated, durationMs, rowCount }: SqlResultsTableProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 28,
+    overscan: 8,
+  });
+
+  if (rows.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "24px",
+          textAlign: "center",
+          color: "var(--text-muted)",
+          fontSize: "0.8rem",
+          fontFamily: "var(--font-body)",
+        }}
+      >
+        Query returned 0 rows in {durationMs}ms.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+      {truncated && (
+        <div
+          style={{
+            padding: "6px 12px",
+            background: "var(--warning-bg, #2a1f00)",
+            borderBottom: "1px solid var(--border)",
+            fontSize: "0.75rem",
+            color: "var(--warning, #f59e0b)",
+            fontFamily: "var(--font-body)",
+          }}
+        >
+          Results truncated at {rowCount.toLocaleString()} rows. Add a LIMIT to see all results.
+        </div>
+      )}
+      <div
+        style={{
+          padding: "4px 12px",
+          borderBottom: "1px solid var(--border)",
+          fontSize: "0.72rem",
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        {rowCount.toLocaleString()} row{rowCount !== 1 ? "s" : ""} · {durationMs}ms ·{" "}
+        {columns.length} column{columns.length !== 1 ? "s" : ""}
+      </div>
+
+      {/* Single scroll container — header and body share the same horizontal scroll axis */}
+      <div ref={parentRef} style={{ flex: 1, overflow: "auto" }}>
+        {/* Sticky header — scrolls horizontally with body, pins vertically */}
+        <div
+          style={{
+            position: "sticky",
+            top: 0,
+            zIndex: 1,
+            background: "var(--surface-2)",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          <div style={{ display: "flex", minWidth: "max-content" }}>
+            {columns.map((col) => (
+              <div
+                key={col}
+                style={{ ...cellStyle, fontWeight: 600, color: "var(--text-secondary)" }}
+              >
+                {col}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
+          {virtualizer.getVirtualItems().map((vItem) => {
+            const row = rows[vItem.index];
+            return (
+              <div
+                key={vItem.key}
+                data-index={vItem.index}
+                ref={virtualizer.measureElement}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  transform: `translateY(${vItem.start}px)`,
+                  display: "flex",
+                  minWidth: "max-content",
+                  borderBottom: "1px solid var(--border-subtle, var(--border))",
+                }}
+              >
+                {columns.map((col) => {
+                  const val = row[col];
+                  return (
+                    <div
+                      key={col}
+                      style={{
+                        ...cellStyle,
+                        color:
+                          val === null || val === undefined
+                            ? "var(--text-muted)"
+                            : "var(--text-primary)",
+                      }}
+                      title={val === null || val === undefined ? "NULL" : String(val)}
+                    >
+                      {val === null || val === undefined ? (
+                        <span style={{ fontStyle: "italic" }}>NULL</span>
+                      ) : (
+                        String(val)
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SqlSchemaSidebar.tsx
+++ b/src/components/SqlSchemaSidebar.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import { SQL_SCHEMA } from "@/lib/sqlSchemaSnapshot";
+
+interface SqlSchemaSidebarProps {
+  onInsert: (sql: string) => void;
+}
+
+export function SqlSchemaSidebar({ onInsert }: SqlSchemaSidebarProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  function toggle(table: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(table)) next.delete(table);
+      else next.add(table);
+      return next;
+    });
+  }
+
+  return (
+    <aside
+      style={{
+        width: "200px",
+        flexShrink: 0,
+        borderRight: "1px solid var(--border)",
+        overflowY: "auto",
+        fontSize: "0.72rem",
+        fontFamily: "var(--font-mono)",
+      }}
+    >
+      <div
+        style={{
+          padding: "8px 10px",
+          fontSize: "0.65rem",
+          fontWeight: 600,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          color: "var(--text-muted)",
+          borderBottom: "1px solid var(--border)",
+        }}
+      >
+        Schema
+      </div>
+      {SQL_SCHEMA.map((entry) => {
+        const open = expanded.has(entry.table);
+        return (
+          <div key={entry.table}>
+            <button
+              onClick={() => toggle(entry.table)}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "4px",
+                width: "100%",
+                padding: "4px 8px",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: "var(--text-secondary)",
+                fontSize: "0.72rem",
+                fontFamily: "var(--font-mono)",
+                textAlign: "left",
+                borderBottom: "1px solid transparent",
+              }}
+              title={`SELECT * FROM "${entry.table}" LIMIT 100`}
+              onDoubleClick={() => onInsert(`SELECT * FROM "${entry.table}" LIMIT 100;`)}
+            >
+              {open ? (
+                <ChevronDown style={{ width: "10px", height: "10px", flexShrink: 0 }} />
+              ) : (
+                <ChevronRight style={{ width: "10px", height: "10px", flexShrink: 0 }} />
+              )}
+              <span
+                style={{
+                  color: entry.virtual ? "var(--text-muted)" : "var(--text-primary)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {entry.table}
+              </span>
+              {entry.virtual && (
+                <span style={{ color: "var(--text-muted)", fontSize: "0.6rem" }}>fts</span>
+              )}
+            </button>
+            {open && (
+              <div style={{ paddingLeft: "20px", paddingBottom: "4px" }}>
+                {entry.columns.map((col) => (
+                  <div
+                    key={col}
+                    style={{
+                      padding: "1px 4px",
+                      color: "var(--text-muted)",
+                      fontSize: "0.68rem",
+                    }}
+                  >
+                    {col}
+                  </div>
+                ))}
+                <button
+                  onClick={() => onInsert(`SELECT * FROM "${entry.table}" LIMIT 100;`)}
+                  style={{
+                    marginTop: "4px",
+                    padding: "2px 6px",
+                    fontSize: "0.64rem",
+                    fontFamily: "var(--font-mono)",
+                    background: "var(--surface-2)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "3px",
+                    cursor: "pointer",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  ↗ insert SELECT
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </aside>
+  );
+}

--- a/src/hooks/useHooks.ts
+++ b/src/hooks/useHooks.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import type { HookRow } from "@/hooks/useConfig";
+
+export function useHooks(query?: string) {
+  const [data, setData] = useState<HookRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch_ = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ type: "hooks" });
+      if (query) params.set("q", query);
+      const res = await fetch(`/api/claude-config?${params}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const payload = await res.json() as { hooks: HookRow[] };
+      setData(payload.hooks ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch error");
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  useEffect(() => {
+    fetch_();
+  }, [fetch_]);
+
+  return { data, loading, error };
+}

--- a/src/hooks/usePlans.ts
+++ b/src/hooks/usePlans.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import type { PlanEntry } from "@/lib/types";
+
+export function usePlans(opts: { q?: string; tag?: string } = {}) {
+  const [data, setData] = useState<PlanEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch_ = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (opts.q) params.set("q", opts.q);
+      if (opts.tag) params.set("tag", opts.tag);
+      const qs = params.toString();
+      const res = await fetch(`/api/plans${qs ? `?${qs}` : ""}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData(await res.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch error");
+    } finally {
+      setLoading(false);
+    }
+  }, [opts.q, opts.tag]);
+
+  useEffect(() => {
+    fetch_();
+  }, [fetch_]);
+
+  return { data, loading, error };
+}
+
+export async function fetchPlanBody(slug: string): Promise<string | null> {
+  try {
+    const res = await fetch(`/api/plans/${encodeURIComponent(slug)}`);
+    if (!res.ok) return null;
+    const data = await res.json() as { body?: string };
+    return data.body ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/hooks/usePlugins.ts
+++ b/src/hooks/usePlugins.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import type { PluginRollupRow } from "@/lib/data/pluginRollup";
+export type { PluginRollupRow };
+
+export function usePlugins(q?: string) {
+  const [data, setData] = useState<PluginRollupRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch_ = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (q) params.set("q", q);
+      const qs = params.toString();
+      const res = await fetch(`/api/plugins${qs ? `?${qs}` : ""}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData(await res.json());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "fetch error");
+    } finally {
+      setLoading(false);
+    }
+  }, [q]);
+
+  useEffect(() => {
+    fetch_();
+  }, [fetch_]);
+
+  return { data, loading, error };
+}

--- a/src/hooks/useSqlHistory.ts
+++ b/src/hooks/useSqlHistory.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+const STORAGE_KEY = "pm:sql-history";
+const MAX_HISTORY = 20;
+
+function loadHistory(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(entries: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    /* storage full or unavailable */
+  }
+}
+
+export function useSqlHistory() {
+  const [history, setHistory] = useState<string[]>(() => loadHistory());
+
+  const pushHistory = useCallback((sql: string) => {
+    const trimmed = sql.trim();
+    if (!trimmed) return;
+    setHistory((prev) => {
+      // Dedup adjacent identical entries
+      if (prev[0] === trimmed) return prev;
+      const next = [trimmed, ...prev.filter((e) => e !== trimmed)].slice(0, MAX_HISTORY);
+      saveHistory(next);
+      return next;
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    saveHistory([]);
+    setHistory([]);
+  }, []);
+
+  return { history, pushHistory, clearHistory };
+}

--- a/src/hooks/useSqlHistory.ts
+++ b/src/hooks/useSqlHistory.ts
@@ -11,7 +11,7 @@ function loadHistory(): string[] {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
   } catch {
     return [];
   }

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,17 @@
+/** Escape a single value per RFC-4180. */
+export function escapeCell(val: unknown): string {
+  const str = val === null || val === undefined ? "" : String(val);
+  if (str.includes('"') || str.includes(",") || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/** Build an RFC-4180 CSV string (CRLF line endings, header row first). */
+export function toCsv(rows: Record<string, unknown>[], columns: string[]): string {
+  const lines: string[] = [columns.map(escapeCell).join(",")];
+  for (const row of rows) {
+    lines.push(columns.map((col) => escapeCell(row[col])).join(","));
+  }
+  return lines.join("\r\n");
+}

--- a/src/lib/data/pluginRollup.ts
+++ b/src/lib/data/pluginRollup.ts
@@ -1,0 +1,89 @@
+import "server-only";
+import { getUserConfig } from "@/lib/userConfigCache";
+import { loadCatalog } from "@/lib/indexer/catalog";
+import { getAgentUsage, getSkillUsage } from "@/lib/data/index";
+import { readPluginScopeMcp } from "@/lib/scanner/pluginMcp";
+import type { PluginEntry } from "@/lib/types";
+
+export interface PluginRollupRow {
+  plugin: PluginEntry;
+  agentCount: number;
+  skillCount: number;
+  mcpServerCount: number;
+  totalInvocations: number;
+}
+
+const CACHE_TTL_MS = 2 * 60 * 1000;
+
+const g = globalThis as unknown as {
+  __pluginRollupCache?: { data: PluginRollupRow[]; cachedAt: number } | null;
+};
+
+function getCache(): PluginRollupRow[] | null {
+  const slot = g.__pluginRollupCache;
+  if (!slot) return null;
+  if (Date.now() - slot.cachedAt < CACHE_TTL_MS) return slot.data;
+  g.__pluginRollupCache = null;
+  return null;
+}
+
+export function invalidatePluginRollupCache(): void {
+  g.__pluginRollupCache = null;
+}
+
+export async function loadPluginRollup(): Promise<PluginRollupRow[]> {
+  const cached = getCache();
+  if (cached) return cached;
+
+  const [userConfig, catalog, agentUsage, skillUsage, mcpServers] = await Promise.all([
+    getUserConfig(),
+    loadCatalog({ includeProjects: false }),
+    getAgentUsage(),
+    getSkillUsage(),
+    readPluginScopeMcp(),
+  ]);
+
+  const plugins = userConfig.plugins.plugins;
+
+  const agentInvocations = new Map<string, number>(
+    agentUsage.stats.map((s) => [s.name, s.invocations])
+  );
+  const skillInvocations = new Map<string, number>(
+    skillUsage.stats.map((s) => [s.name, s.invocations])
+  );
+
+  const rows: PluginRollupRow[] = [];
+
+  for (const plugin of plugins) {
+    const pluginAgents = catalog.agents.filter((a) => a.pluginName === plugin.name);
+    const pluginSkills = catalog.skills.filter((s) => s.pluginName === plugin.name);
+
+    const agentInvTotal = pluginAgents.reduce(
+      (sum, a) => sum + (agentInvocations.get(a.name) ?? 0),
+      0
+    );
+    const skillInvTotal = pluginSkills.reduce(
+      (sum, s) => sum + (skillInvocations.get(s.name) ?? 0),
+      0
+    );
+
+    // MCP servers: match by installPath prefix of sourcePath
+    const mcpServerCount = plugin.installPath
+      ? mcpServers.filter((m) =>
+          m.sourcePath.startsWith(plugin.installPath! + "/") ||
+          m.sourcePath.startsWith(plugin.installPath! + "\\")
+        ).length
+      : 0;
+
+    rows.push({
+      plugin,
+      agentCount: pluginAgents.length,
+      skillCount: pluginSkills.length,
+      mcpServerCount,
+      totalInvocations: agentInvTotal + skillInvTotal,
+    });
+  }
+
+  g.__pluginRollupCache = { data: rows, cachedAt: Date.now() };
+  return rows;
+}

--- a/src/lib/downloadBlob.ts
+++ b/src/lib/downloadBlob.ts
@@ -4,6 +4,8 @@ export function downloadBlob(content: string, filename: string, type: string): v
   const a = document.createElement("a");
   a.href = url;
   a.download = filename;
+  document.body.appendChild(a);
   a.click();
-  URL.revokeObjectURL(url);
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/src/lib/downloadBlob.ts
+++ b/src/lib/downloadBlob.ts
@@ -1,0 +1,9 @@
+export function downloadBlob(content: string, filename: string, type: string): void {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -19,6 +19,10 @@ export const helpMapping: Record<string, string> = {
   '/config': 'config',
   '/setup': 'setup',
   '/settings': 'settings',
+  '/plans': 'plans',
+  '/hooks': 'hooks',
+  '/plugins': 'plugins',
+  '/sql': 'sql',
 }
 
 /**
@@ -67,6 +71,10 @@ export const helpSlugs = [
   'setup',
   'settings',
   'templates',
+  'plans',
+  'hooks',
+  'plugins',
+  'sql',
 ] as const
 
 export type HelpSlug = (typeof helpSlugs)[number]

--- a/src/lib/scanner/claudePlans.ts
+++ b/src/lib/scanner/claudePlans.ts
@@ -1,0 +1,86 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { parseFrontmatter } from "../indexer/parseFrontmatter";
+import type { PlanEntry } from "../types";
+
+const PLANS_DIR = path.join(os.homedir(), ".claude", "plans");
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+/** Scan ~/.claude/plans/*.md and return a PlanEntry per file. Fails open. */
+export async function scanClaudePlans(): Promise<PlanEntry[]> {
+  let files: string[];
+  try {
+    const entries = await fs.readdir(PLANS_DIR, { withFileTypes: true });
+    files = entries
+      .filter((e) => e.isFile() && e.name.endsWith(".md"))
+      .map((e) => path.join(PLANS_DIR, e.name));
+  } catch {
+    return [];
+  }
+
+  const results = await Promise.all(files.map(readOnePlan));
+  return results.filter((p): p is PlanEntry => p !== null);
+}
+
+async function readOnePlan(filePath: string): Promise<PlanEntry | null> {
+  try {
+    const [raw, stat] = await Promise.all([
+      fs.readFile(filePath, "utf-8"),
+      fs.stat(filePath),
+    ]);
+
+    const { fm, body } = parseFrontmatter(raw);
+
+    const slug = path.basename(filePath, ".md");
+
+    const title = pickTitle(fm, body, slug);
+
+    const tags = pickTags(fm);
+
+    const relatedSessionIds = [...body.matchAll(UUID_RE)].map((m) => m[0].toLowerCase());
+    const uniqueSessionIds = [...new Set(relatedSessionIds)];
+
+    return {
+      slug,
+      path: filePath,
+      title,
+      tags,
+      relatedSessionIds: uniqueSessionIds,
+      mtime: stat.mtime.toISOString(),
+      sizeBytes: stat.size,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function pickTitle(
+  fm: Record<string, unknown>,
+  body: string,
+  fallback: string
+): string {
+  if (typeof fm.title === "string" && fm.title.trim()) {
+    return fm.title.trim();
+  }
+  const headingMatch = body.match(/^#\s+(.+)$/m);
+  if (headingMatch) {
+    return headingMatch[1].trim();
+  }
+  return fallback;
+}
+
+function pickTags(fm: Record<string, unknown>): string[] {
+  const raw = fm.tags;
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    return raw.filter((t): t is string => typeof t === "string");
+  }
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+  return [];
+}

--- a/src/lib/sqlSchemaSnapshot.ts
+++ b/src/lib/sqlSchemaSnapshot.ts
@@ -1,0 +1,120 @@
+// Last verified: schema version 6 (src/lib/db/schema.sql + migrations v1-v6)
+// Re-verify with `tests/sqlSchemaSnapshot.test.ts` after any migration.
+
+export interface TableSchema {
+  table: string;
+  columns: string[];
+  /** FTS5 virtual tables — PRAGMA table_info behaves differently for these. */
+  virtual?: true;
+}
+
+export const SQL_SCHEMA: TableSchema[] = [
+  {
+    table: "meta",
+    columns: ["key", "value"],
+  },
+  {
+    table: "sessions",
+    columns: [
+      "session_id", "project_slug", "project_dir_name", "file_path",
+      "file_mtime_ms", "file_size", "byte_offset", "start_ts", "end_ts",
+      "primary_model", "status", "outcome", "turn_count", "user_turn_count",
+      "assistant_turn_count", "tool_call_count", "error_count", "input_tokens",
+      "output_tokens", "cache_create_tokens", "cache_read_tokens", "cost_usd",
+      "cache_hit_ratio", "max_context_fill", "has_compaction_loop",
+      "has_tool_failure_streak", "has_one_shot", "verified_task_count",
+      "one_shot_task_count", "git_branch", "initial_prompt", "last_prompt",
+      "slug", "continued_from_session_id", "has_thinking", "cli_version",
+      "has_resume_anomaly", "compact_boundary_count", "derived_version",
+      "indexed_at_ms",
+    ],
+  },
+  {
+    table: "turns",
+    columns: [
+      "session_id", "turn_index", "ts", "role", "model", "input_tokens",
+      "output_tokens", "cache_create_tokens", "cache_read_tokens", "context_fill",
+      "is_error", "parent_tool_use_id", "text_offset", "text_preview", "cost_usd",
+      "tool_result_preview", "category", "turn_duration_ms", "has_thinking",
+      "derived_version",
+    ],
+  },
+  {
+    table: "tool_uses",
+    columns: [
+      "session_id", "turn_index", "sequence_in_turn", "tool_use_id", "ts",
+      "tool_name", "mcp_server", "mcp_tool", "agent_name", "skill_name",
+      "arguments_json", "file_path", "file_op", "duration_ms", "is_error",
+    ],
+  },
+  {
+    table: "file_edits",
+    columns: ["session_id", "turn_index", "file_path", "op", "ts"],
+  },
+  {
+    table: "daily_costs",
+    columns: [
+      "day", "project_slug", "model", "input_tokens", "output_tokens",
+      "cache_create_tokens", "cache_read_tokens", "cost_usd", "turn_count",
+      "session_count",
+    ],
+  },
+  {
+    table: "category_costs",
+    columns: ["day", "project_slug", "category", "turns", "tokens", "cost_usd"],
+  },
+  {
+    table: "agents",
+    columns: [
+      "id", "name", "source", "project_slug", "plugin_name", "description",
+      "category", "model", "tools_json", "body_excerpt", "body_path",
+      "file_mtime_ms", "file_size", "provenance_json", "derived_version",
+      "indexed_at_ms",
+    ],
+  },
+  {
+    table: "skills",
+    columns: [
+      "id", "name", "source", "project_slug", "plugin_name", "description",
+      "layout", "user_invocable", "argument_hint", "version", "body_excerpt",
+      "body_path", "file_mtime_ms", "file_size", "provenance_json",
+      "derived_version", "indexed_at_ms",
+    ],
+  },
+  {
+    table: "commands",
+    columns: [
+      "id", "name", "source", "project_slug", "plugin_name", "description",
+      "argument_hint", "body_excerpt", "body_path", "file_mtime_ms", "file_size",
+      "derived_version", "indexed_at_ms",
+    ],
+  },
+  {
+    table: "mcp_servers",
+    columns: [
+      "id", "name", "source", "project_slug", "command", "args_json", "env_json",
+      "description_hash", "enabled", "indexed_at_ms",
+    ],
+  },
+  {
+    table: "otel_events",
+    columns: ["id", "ts", "session_id", "event_name", "payload_json"],
+  },
+  {
+    table: "indexer_runs",
+    columns: [
+      "id", "started_at_ms", "finished_at_ms", "kind", "files_seen",
+      "files_changed", "rows_written", "error",
+    ],
+  },
+  {
+    table: "prompts_fts",
+    columns: ["session_id", "turn_index", "role", "ts", "text"],
+    virtual: true,
+  },
+  {
+    table: "catalog_fts",
+    columns: ["kind", "id", "name", "description", "text"],
+    virtual: true,
+  },
+];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -542,6 +542,23 @@ export interface PluginsInfo {
   plugins: PluginEntry[];
 }
 
+// ─── Plans ───────────────────────────────────────────────────────────────────
+
+export interface PlanEntry {
+  /** Filename without .md extension — stable identifier. */
+  slug: string;
+  /** Absolute path to the plan file. */
+  path: string;
+  /** Title from front-matter `title:` or first `# ` heading, else the slug. */
+  title: string;
+  /** Tags from front-matter `tags:` array. Empty when absent. */
+  tags: string[];
+  /** Session UUIDs found by regex in the plan body (heuristic). */
+  relatedSessionIds: string[];
+  mtime: string;
+  sizeBytes: number;
+}
+
 // ─── CI/CD ───────────────────────────────────────────────────────────────────
 
 export interface WorkflowJob {

--- a/tests/claudePlans.test.ts
+++ b/tests/claudePlans.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import path from "path";
+import os from "os";
+import type { Dirent, Stats } from "fs";
+
+const mockReaddir = vi.fn();
+const mockReadFile = vi.fn();
+const mockStat = vi.fn();
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readdir: mockReaddir,
+      readFile: mockReadFile,
+      stat: mockStat,
+    },
+  };
+});
+
+const PLANS_DIR = path.join(os.homedir(), ".claude", "plans");
+
+async function freshScanner() {
+  vi.resetModules();
+  return import("@/lib/scanner/claudePlans");
+}
+
+function dirent(name: string): Dirent {
+  return { isFile: () => true, isDirectory: () => false, name } as unknown as Dirent;
+}
+
+function stat(mtime = new Date("2026-05-01T10:00:00Z"), size = 100): Stats {
+  return { mtime, size } as unknown as Stats;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("scanClaudePlans", () => {
+  it("returns empty array when plans dir does not exist", async () => {
+    mockReaddir.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    const { scanClaudePlans } = await freshScanner();
+    expect(await scanClaudePlans()).toEqual([]);
+  });
+
+  it("returns empty array when plans dir is empty", async () => {
+    mockReaddir.mockResolvedValue([]);
+    const { scanClaudePlans } = await freshScanner();
+    expect(await scanClaudePlans()).toEqual([]);
+  });
+
+  it("parses a plan file with front-matter title and tags", async () => {
+    const raw = `---\ntitle: My Great Plan\ntags:\n  - wave5\n  - auth\n---\n\nBody text here.`;
+    mockReaddir.mockResolvedValue([dirent("my-great-plan.md")]);
+    mockReadFile.mockResolvedValue(raw);
+    mockStat.mockResolvedValue(stat(new Date("2026-05-01T10:00:00Z"), raw.length));
+
+    const { scanClaudePlans } = await freshScanner();
+    const results = await scanClaudePlans();
+
+    expect(results).toHaveLength(1);
+    const p = results[0];
+    expect(p.slug).toBe("my-great-plan");
+    expect(p.title).toBe("My Great Plan");
+    expect(p.tags).toEqual(["wave5", "auth"]);
+    expect(p.relatedSessionIds).toEqual([]);
+    expect(p.path).toBe(path.join(PLANS_DIR, "my-great-plan.md"));
+    expect(p.mtime).toBe("2026-05-01T10:00:00.000Z");
+  });
+
+  it("falls back to first # heading when no front-matter title", async () => {
+    const raw = `# Implementation Plan\n\nSome details here.`;
+    mockReaddir.mockResolvedValue([dirent("impl-plan.md")]);
+    mockReadFile.mockResolvedValue(raw);
+    mockStat.mockResolvedValue(stat());
+
+    const { scanClaudePlans } = await freshScanner();
+    const results = await scanClaudePlans();
+    expect(results[0].title).toBe("Implementation Plan");
+    expect(results[0].tags).toEqual([]);
+  });
+
+  it("uses slug as title when no front-matter and no heading", async () => {
+    const raw = `Just some prose without a heading.`;
+    mockReaddir.mockResolvedValue([dirent("some-plan-slug.md")]);
+    mockReadFile.mockResolvedValue(raw);
+    mockStat.mockResolvedValue(stat());
+
+    const { scanClaudePlans } = await freshScanner();
+    const results = await scanClaudePlans();
+    expect(results[0].title).toBe("some-plan-slug");
+  });
+
+  it("extracts related session UUIDs from the body", async () => {
+    const uuid1 = "4bb141a4-1a4c-4794-a32a-b6bb351076ba";
+    const uuid2 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const raw = `# Plan\n\nSee session ${uuid1} for context.\nAlso ${uuid2}.`;
+    mockReaddir.mockResolvedValue([dirent("plan.md")]);
+    mockReadFile.mockResolvedValue(raw);
+    mockStat.mockResolvedValue(stat());
+
+    const { scanClaudePlans } = await freshScanner();
+    const results = await scanClaudePlans();
+    expect(results[0].relatedSessionIds).toContain(uuid1);
+    expect(results[0].relatedSessionIds).toContain(uuid2);
+  });
+
+  it("deduplicates the same UUID appearing multiple times", async () => {
+    const uuid = "4bb141a4-1a4c-4794-a32a-b6bb351076ba";
+    const raw = `# Plan\n\nSession ${uuid} is mentioned here.\nAnd again: ${uuid}.`;
+    mockReaddir.mockResolvedValue([dirent("plan.md")]);
+    mockReadFile.mockResolvedValue(raw);
+    mockStat.mockResolvedValue(stat());
+
+    const { scanClaudePlans } = await freshScanner();
+    const results = await scanClaudePlans();
+    expect(results[0].relatedSessionIds).toHaveLength(1);
+    expect(results[0].relatedSessionIds[0]).toBe(uuid);
+  });
+
+  it("skips non-.md files", async () => {
+    mockReaddir.mockResolvedValue([dirent("notes.txt"), dirent("image.png")]);
+    const { scanClaudePlans } = await freshScanner();
+    expect(await scanClaudePlans()).toHaveLength(0);
+  });
+
+  it("skips a file that fails to read and continues (fails open)", async () => {
+    mockReaddir.mockResolvedValue([dirent("good.md"), dirent("bad.md")]);
+    mockReadFile.mockImplementation(async (p: unknown) => {
+      if (String(p).endsWith("bad.md")) throw new Error("EACCES");
+      return "# Good Plan\n\nContent.";
+    });
+    mockStat.mockResolvedValue(stat());
+
+    const { scanClaudePlans } = await freshScanner();
+    const results = await scanClaudePlans();
+    expect(results).toHaveLength(1);
+    expect(results[0].slug).toBe("good");
+  });
+
+  it("normalizes UUIDs to lowercase", async () => {
+    const uuid = "4BB141A4-1A4C-4794-A32A-B6BB351076BA";
+    const raw = `# Plan\n\nSee ${uuid}.`;
+    mockReaddir.mockResolvedValue([dirent("plan.md")]);
+    mockReadFile.mockResolvedValue(raw);
+    mockStat.mockResolvedValue(stat());
+
+    const { scanClaudePlans } = await freshScanner();
+    const results = await scanClaudePlans();
+    expect(results[0].relatedSessionIds[0]).toBe(uuid.toLowerCase());
+  });
+});

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { escapeCell, toCsv } from "@/lib/csv";
+
+describe("escapeCell", () => {
+  it("returns plain string as-is", () => {
+    expect(escapeCell("hello")).toBe("hello");
+  });
+
+  it("quotes a cell containing a comma", () => {
+    expect(escapeCell("a,b")).toBe('"a,b"');
+  });
+
+  it("quotes a cell containing a double quote and escapes it", () => {
+    expect(escapeCell('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("quotes a cell containing a newline", () => {
+    expect(escapeCell("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("quotes a cell containing a carriage return", () => {
+    expect(escapeCell("line1\rline2")).toBe('"line1\rline2"');
+  });
+
+  it("converts null to empty string", () => {
+    expect(escapeCell(null)).toBe("");
+  });
+
+  it("converts undefined to empty string", () => {
+    expect(escapeCell(undefined)).toBe("");
+  });
+
+  it("converts numbers to string", () => {
+    expect(escapeCell(42)).toBe("42");
+    expect(escapeCell(3.14)).toBe("3.14");
+  });
+
+  it("converts 0 to string without quoting", () => {
+    expect(escapeCell(0)).toBe("0");
+  });
+
+  it("handles a cell that is just a double quote", () => {
+    expect(escapeCell('"')).toBe('""""');
+  });
+
+  it("handles a cell with comma AND double quote", () => {
+    expect(escapeCell('a,"b"')).toBe('"a,""b"""');
+  });
+});
+
+describe("toCsv", () => {
+  it("produces a header row and data rows separated by CRLF", () => {
+    const rows = [{ name: "Alice", age: 30 }];
+    const result = toCsv(rows, ["name", "age"]);
+    expect(result).toBe("name,age\r\nAlice,30");
+  });
+
+  it("handles multiple rows", () => {
+    const rows = [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    const result = toCsv(rows, ["x", "y"]);
+    expect(result).toBe("x,y\r\n1,2\r\n3,4");
+  });
+
+  it("produces only a header row for empty rows array", () => {
+    const result = toCsv([], ["a", "b"]);
+    expect(result).toBe("a,b");
+  });
+
+  it("escapes values with commas", () => {
+    const rows = [{ val: "hello, world" }];
+    const result = toCsv(rows, ["val"]);
+    expect(result).toBe('val\r\n"hello, world"');
+  });
+
+  it("handles null values as empty strings", () => {
+    const rows = [{ a: null, b: "ok" }];
+    const result = toCsv(rows, ["a", "b"]);
+    expect(result).toBe("a,b\r\n,ok");
+  });
+
+  it("columns order determines output order regardless of row key order", () => {
+    const rows = [{ b: 2, a: 1 }];
+    const result = toCsv(rows as Record<string, unknown>[], ["a", "b"]);
+    expect(result).toBe("a,b\r\n1,2");
+  });
+
+  it("uses empty string for missing columns", () => {
+    const rows = [{ a: 1 }];
+    const result = toCsv(rows as Record<string, unknown>[], ["a", "b"]);
+    expect(result).toBe("a,b\r\n1,");
+  });
+});

--- a/tests/pluginRollup.test.ts
+++ b/tests/pluginRollup.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/userConfigCache", () => ({ getUserConfig: vi.fn() }));
+vi.mock("@/lib/indexer/catalog", () => ({ loadCatalog: vi.fn() }));
+vi.mock("@/lib/data/index", () => ({ getAgentUsage: vi.fn(), getSkillUsage: vi.fn() }));
+vi.mock("@/lib/scanner/pluginMcp", () => ({ readPluginScopeMcp: vi.fn() }));
+
+import { getUserConfig } from "@/lib/userConfigCache";
+import { loadCatalog } from "@/lib/indexer/catalog";
+import { getAgentUsage, getSkillUsage } from "@/lib/data/index";
+import { readPluginScopeMcp } from "@/lib/scanner/pluginMcp";
+
+const mockGetUserConfig = vi.mocked(getUserConfig);
+const mockLoadCatalog = vi.mocked(loadCatalog);
+const mockGetAgentUsage = vi.mocked(getAgentUsage);
+const mockGetSkillUsage = vi.mocked(getSkillUsage);
+const mockReadPluginScopeMcp = vi.mocked(readPluginScopeMcp);
+
+function makePlugin(name: string, installPath?: string) {
+  return {
+    name,
+    marketplace: "anthropics/plugins",
+    enabled: true,
+    blocked: false,
+    installPath,
+  };
+}
+
+function makeAgent(name: string, pluginName?: string) {
+  return { name, pluginName, kind: "agent" as const, source: "plugin" as const };
+}
+
+function makeSkill(name: string, pluginName?: string) {
+  return { name, pluginName, kind: "skill" as const, source: "plugin" as const };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Clear cache between tests
+  const g = globalThis as unknown as { __pluginRollupCache?: unknown };
+  g.__pluginRollupCache = null;
+});
+
+describe("loadPluginRollup", () => {
+  async function freshRollup() {
+    vi.resetModules();
+    return import("@/lib/data/pluginRollup");
+  }
+
+  function setupMocks(opts: {
+    plugins?: ReturnType<typeof makePlugin>[];
+    agents?: ReturnType<typeof makeAgent>[];
+    skills?: ReturnType<typeof makeSkill>[];
+    agentStats?: { name: string; invocations: number }[];
+    skillStats?: { name: string; invocations: number }[];
+    mcpServers?: { name: string; sourcePath: string }[];
+  } = {}) {
+    mockGetUserConfig.mockResolvedValue({
+      plugins: { plugins: opts.plugins ?? [] },
+    } as unknown as Awaited<ReturnType<typeof getUserConfig>>);
+
+    mockLoadCatalog.mockResolvedValue({
+      agents: opts.agents ?? [],
+      skills: opts.skills ?? [],
+    } as unknown as Awaited<ReturnType<typeof loadCatalog>>);
+
+    mockGetAgentUsage.mockResolvedValue({
+      stats: (opts.agentStats ?? []).map((s) => ({ ...s, projects: {}, sessions: [] })),
+      meta: { backend: "db" as const },
+    });
+
+    mockGetSkillUsage.mockResolvedValue({
+      stats: (opts.skillStats ?? []).map((s) => ({ ...s, projects: {}, sessions: [] })),
+      meta: { backend: "db" as const },
+    });
+
+    mockReadPluginScopeMcp.mockResolvedValue(
+      (opts.mcpServers ?? []).map((m) => ({
+        ...m,
+        transport: "stdio" as const,
+        source: "plugin" as const,
+      }))
+    );
+  }
+
+  it("returns empty array when no plugins are installed", async () => {
+    setupMocks({ plugins: [] });
+    const { loadPluginRollup } = await freshRollup();
+    expect(await loadPluginRollup()).toEqual([]);
+  });
+
+  it("counts agents and skills per plugin by pluginName", async () => {
+    setupMocks({
+      plugins: [makePlugin("context7", "/home/.claude/plugins/context7")],
+      agents: [
+        makeAgent("context7-search", "context7"),
+        makeAgent("context7-index", "context7"),
+        makeAgent("other-agent", "other-plugin"),
+      ],
+      skills: [makeSkill("context7-skill", "context7")],
+    });
+    const { loadPluginRollup } = await freshRollup();
+    const rows = await loadPluginRollup();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].agentCount).toBe(2);
+    expect(rows[0].skillCount).toBe(1);
+  });
+
+  it("sums invocations for agents and skills belonging to the plugin", async () => {
+    setupMocks({
+      plugins: [makePlugin("clerk", "/home/.claude/plugins/clerk")],
+      agents: [makeAgent("clerk-verify", "clerk"), makeAgent("clerk-sync", "clerk")],
+      skills: [makeSkill("clerk-auth", "clerk")],
+      agentStats: [
+        { name: "clerk-verify", invocations: 10 },
+        { name: "clerk-sync", invocations: 5 },
+        { name: "other-agent", invocations: 99 },
+      ],
+      skillStats: [{ name: "clerk-auth", invocations: 3 }],
+    });
+    const { loadPluginRollup } = await freshRollup();
+    const rows = await loadPluginRollup();
+    expect(rows[0].totalInvocations).toBe(18); // 10 + 5 + 3
+  });
+
+  it("counts MCP servers by installPath prefix match", async () => {
+    const installPath = "/home/.claude/plugins/context7";
+    setupMocks({
+      plugins: [makePlugin("context7", installPath)],
+      mcpServers: [
+        { name: "ctx-mcp", sourcePath: `${installPath}/.mcp.json` },
+        { name: "other-mcp", sourcePath: "/home/.claude/plugins/other/.mcp.json" },
+      ],
+    });
+    const { loadPluginRollup } = await freshRollup();
+    const rows = await loadPluginRollup();
+    expect(rows[0].mcpServerCount).toBe(1);
+  });
+
+  it("sets mcpServerCount to 0 when plugin has no installPath", async () => {
+    setupMocks({
+      plugins: [makePlugin("ghost-plugin")], // no installPath
+      mcpServers: [{ name: "mcp", sourcePath: "/somewhere/.mcp.json" }],
+    });
+    const { loadPluginRollup } = await freshRollup();
+    const rows = await loadPluginRollup();
+    expect(rows[0].mcpServerCount).toBe(0);
+  });
+
+  it("sets all counts to 0 when plugin has no catalog entries", async () => {
+    setupMocks({
+      plugins: [makePlugin("empty-plugin", "/plugins/empty")],
+      agents: [],
+      skills: [],
+    });
+    const { loadPluginRollup } = await freshRollup();
+    const rows = await loadPluginRollup();
+    expect(rows[0]).toMatchObject({
+      agentCount: 0,
+      skillCount: 0,
+      mcpServerCount: 0,
+      totalInvocations: 0,
+    });
+  });
+
+  it("returns one row per installed plugin", async () => {
+    setupMocks({
+      plugins: [
+        makePlugin("plugin-a", "/plugins/a"),
+        makePlugin("plugin-b", "/plugins/b"),
+      ],
+    });
+    const { loadPluginRollup } = await freshRollup();
+    const rows = await loadPluginRollup();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.plugin.name)).toEqual(["plugin-a", "plugin-b"]);
+  });
+});

--- a/tests/sqlSchemaSnapshot.test.ts
+++ b/tests/sqlSchemaSnapshot.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import path from "path";
+import os from "os";
+import { SQL_SCHEMA } from "@/lib/sqlSchemaSnapshot";
+
+const DB_PATH = path.join(os.homedir(), ".minder", "index.db");
+
+let driverAvailable = false;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require("better-sqlite3");
+  driverAvailable = true;
+} catch {
+  /* driver not installed — skip live checks */
+}
+
+describe("SQL_SCHEMA", () => {
+  it("has at least one table", () => {
+    expect(SQL_SCHEMA.length).toBeGreaterThan(0);
+  });
+
+  it("each entry has a non-empty table name and at least one column", () => {
+    for (const entry of SQL_SCHEMA) {
+      expect(entry.table, "table name must be a non-empty string").toBeTruthy();
+      expect(entry.columns.length, `${entry.table} must have at least one column`).toBeGreaterThan(0);
+      for (const col of entry.columns) {
+        expect(col, `column in ${entry.table}`).toBeTruthy();
+      }
+    }
+  });
+
+  it("has no duplicate table names", () => {
+    const names = SQL_SCHEMA.map((e) => e.table);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("includes both regular and virtual (FTS5) tables", () => {
+    const regular = SQL_SCHEMA.filter((e) => !e.virtual);
+    const virtual = SQL_SCHEMA.filter((e) => e.virtual);
+    expect(regular.length).toBeGreaterThan(0);
+    expect(virtual.length).toBeGreaterThan(0);
+  });
+
+  it("includes the sessions table", () => {
+    const sessions = SQL_SCHEMA.find((e) => e.table === "sessions");
+    expect(sessions).toBeDefined();
+    expect(sessions!.columns).toContain("session_id");
+    expect(sessions!.columns).toContain("project_slug");
+  });
+});
+
+describe.skipIf(!driverAvailable || !existsSync(DB_PATH))("live DB column check", () => {
+  it("snapshot columns match PRAGMA table_info for each non-virtual table", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Database = require("better-sqlite3");
+    const db = new Database(DB_PATH, { readonly: true });
+    try {
+      for (const entry of SQL_SCHEMA.filter((e) => !e.virtual)) {
+        const pragmaRows = db
+          .prepare(`PRAGMA table_info("${entry.table}")`)
+          .all() as { name: string }[];
+        const liveColumns = pragmaRows.map((r: { name: string }) => r.name);
+        expect(liveColumns, `table "${entry.table}" live columns`).toEqual(
+          expect.arrayContaining(entry.columns)
+        );
+        expect(entry.columns, `table "${entry.table}" snapshot columns`).toEqual(
+          expect.arrayContaining(liveColumns)
+        );
+      }
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **`/sql`** — read-only SQL workbench against `~/.minder/index.db`. Schema sidebar (collapsible, one-click SELECT template). Virtualised results table with sticky header + unified horizontal scroll (header and body now share one scroll container — columns align correctly). CSV (RFC-4180 via new `csv.ts`) and JSON export. localStorage history (max 20, dedup adjacent). Read-only enforced by `better-sqlite3` `stmt.readonly` bytecode introspection. (#237)
- **`/hooks`** — coverage matrix (project/local/user scope counts + unique event count). Virtualised hook list reusing `Pill`, `commandPreview`, `ApplyUnitButton` from `ConfigBrowser`. Matrix counts always reflect unfiltered totals; search is client-side. AppNav Hooks entry now links here instead of `/config?type=hooks`. (#154)
- **`/plans`** — scans `~/.claude/plans/*.md` via new `claudePlans.ts`. Extracts title (front-matter → heading → slug), tags, related session UUIDs by regex. Tag filter, debounced search, sort by mtime/title. Expand → full body + clickable session chips. (#152)
- **`/plugins`** — `pluginRollup.ts` JOIN helper: installed plugins × catalog × agent/skill usage × MCP servers. Per-plugin counts + invocation rollup. 2-min cache. Status badge (enabled/disabled/blocked). (#156)

## New shared utilities

| File | Purpose |
|---|---|
| `src/lib/csv.ts` | RFC-4180 escaper — `escapeCell`, `toCsv` |
| `src/lib/downloadBlob.ts` | Shared blob download helper (extracted from SqlBrowser, replaces inline copy) |
| `src/lib/sqlSchemaSnapshot.ts` | Hardcoded schema v6 table/column list (13 tables + 2 FTS5 virtual) |
| `src/lib/scanner/claudePlans.ts` | `~/.claude/plans` scanner |
| `src/lib/data/pluginRollup.ts` | Plugin JOIN with 2-min `globalThis` cache |

## Test plan

- [ ] `/sql`: run `SELECT name FROM sqlite_master WHERE type='table'`; try `INSERT INTO …` (rejected with SQL error banner); export CSV — open in spreadsheet, verify column alignment; history dropdown shows previous queries
- [ ] `/sql` wide result: run `SELECT * FROM sessions LIMIT 5` — header columns must horizontally scroll in sync with body rows (fixed in this PR)
- [ ] `/hooks`: coverage matrix counts equal sum of each source-filtered list; ApplyUnitButton on a project-source hook works; search narrows list without changing matrix counts
- [ ] `/plans`: at least one plan loads; tag filter narrows results; expand shows body; related-session chips navigate to `/sessions/<id>`
- [ ] `/plugins`: plugin row shows correct agent/skill/MCP counts (spot-check against `/agents?source=plugin`); status badge correct; expand shows links
- [ ] AppNav: Hooks link → `/hooks` (not `/config?type=hooks`); Config tab Hooks still appears for project deep-links

## Verification

1195 tests passing, typecheck clean (pre-commit hook ran on commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)