### PR TITLE
feat(wave6.2): 5 D3 viz — concurrency timeline, error propagation, model delegation, agent network, file coupling arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 6.2 — Cluster O + G remainder: 5 D3 visualizations.** TODOs #207, #209, #211, #212, #213.
+  - **Concurrency Timeline (#207).** New "Concurrency" tab on session detail (visible when session has subagents). Gantt-style horizontal bars showing main agent + each subagent over session duration. Bar width = active time span; falls back to turn-index proportions when wall-clock timestamps are missing. `GET /api/sessions/[sessionId]/concurrency-timeline` (60s cache).
+  - **Error Propagation Map (#209).** New "Errors" tab on project detail (visible when project has sessions). Cross-session bar chart of error rates by subagent hierarchy depth (red → purple gradient), top error-prone agents, and tool error breakdown. `GET /api/projects/[slug]/error-propagation` (5-min cache + mtime key).
+  - **Model Delegation Flow (#211).** New "Delegation" tab on session detail (visible when session has subagents). Two-column Bezier flow diagram: primary models (left) → subagent models (right). Curve thickness = delegation count; curve opacity = token volume. `GET /api/sessions/[sessionId]/model-delegation` (60s cache).
+  - **Agent Network Graph (#213).** New "Network" tab on session detail (visible when session has subagents). D3 force-directed graph of agent communication. Node radius = message volume; directed arrows = delegation edges. `GET /api/sessions/[sessionId]/agent-network` (60s cache).
+  - **File Coupling Arc (#212).** Replaces bar list in the Hot Files panel "File Coupling" section when ≥4 unique files are present. Arc diagram with files on a horizontal axis, quadratic Bezier arcs for co-edited pairs (opacity = coupling strength, thickness = co-occurrence count). Click a file node to highlight incident arcs.
+  - New shared palette `agentPalette.ts` (8-color + depth gradient + model family colors) and `relPath.ts` helper extracted for viz reuse.
+
 - **Wave 6.1 — Cluster N: D3 Visualizations.** TODOs #201, #203, #205.
   - **D3 framework (`D3Container`, `Axes`).** Shared `ResizeObserver`-backed SVG wrapper with render-prop API and reusable axis components. Establishes the `next/dynamic` + `ssr:false` lazy-load convention (first D3 usage in the codebase).
   - **Orchestration DAG (#201).** New "Orchestration" tab on session detail pages (visible when `subagentCount > 0`). D3 hierarchy tree showing parent→child subagent delegation, colored by agent type. Computed on demand from JSONL via `GET /api/sessions/[sessionId]/orchestration` (60s cache).

--- a/docs/help/project-details.md
+++ b/docs/help/project-details.md
@@ -110,4 +110,15 @@ Appears when the project has Claude sessions. Shows cross-session file intellige
 
 - **Summary strip** — unique files edited, total edit operations, and sessions analysed.
 - **Hot Files** — files ranked by total edit count, with a bar chart and per-file breakdown of write / edit / delete operations and the number of sessions that touched each file.
-- **File Coupling** — pairs of files that are frequently co-edited in the same session, ranked by co-occurrence count. Each pair shows a coupling strength percentage (0 = unrelated, 100 = always edited together).
+- **File Coupling** — when 4 or more files are co-edited, an **arc diagram** shows pairs of files as quadratic Bezier arcs above a horizontal file axis. Arc thickness scales with co-occurrence count; arc opacity scales with coupling strength. Click a file node to highlight its arcs and dim unrelated ones. With fewer than 4 files, falls back to a bar list.
+
+## Errors Tab
+
+Appears when the project has Claude sessions. Cross-session error analysis across all subagent hierarchy levels:
+
+- **Summary strip** — total sessions, agent nodes, errors, and overall error rate.
+- **Errors by hierarchy depth** — bar chart colored red (depth 0) → purple (depth 6+). Depth 0 = direct subagents of the main conversation; higher depths = nested subagents. Hover a bar for depth, error count/total, and rate.
+- **Top error-prone agents** — agents that appeared in at least 3 invocations, ranked by error count with a bar showing their rate.
+- **Tool error breakdown** — which tools were involved in error turns across all sidechain sessions. Only tools with 2+ occurrences are shown.
+
+When no errors have occurred across any session, the tab shows a success confirmation with the session count.

--- a/docs/help/sessions.md
+++ b/docs/help/sessions.md
@@ -80,6 +80,15 @@ Cards for each spawned subagent showing type, description, and top tools used.
 ### Orchestration
 D3-powered DAG (directed acyclic graph) showing how subagents were spawned during the session. Each node is a spawned agent; edges show parent→child delegation. Node colors identify the agent type; hover for a tooltip with agent name and depth. Only appears when the session spawned at least one subagent (`subagentCount > 0`). Deep nesting beyond level 6 is collapsed into a `+N more` placeholder. Computed on demand from the original JSONL.
 
+### Concurrency
+Gantt-style timeline showing the main agent and each subagent as horizontal bars, positioned by wall-clock timestamps (falls back to turn-index proportions when timestamps are unavailable). Bar width represents active duration; bar label shows turn count. Hover a bar for `agentName · N turns`. A footnote appears when turn-index fallback is used. Only visible when the session has subagents.
+
+### Delegation
+Two-column Bezier flow diagram: primary models (left column) → subagent models (right column). Curve thickness scales with delegation count; curve opacity scales with token volume. Node height is proportional to total tokens routed through that model. Hover a curve for `ParentModel → ChildModel · N delegations · X.XK tokens`. Only visible when the session has subagents.
+
+### Network
+D3 force-directed graph of agent communication within the session. Each node represents a unique agent (collapsed across multiple invocations); node radius scales with message volume. Directed arrows show delegation edges. Hover a node for agent name and message count. A virtual `main` node anchors root-level delegations. Only visible when the session has subagents.
+
 ### Diagnosis
 Post-hoc 8-category quality analysis of the session, computed on demand from the JSONL:
 

--- a/public/help/project-details.md
+++ b/public/help/project-details.md
@@ -110,4 +110,15 @@ Appears when the project has Claude sessions. Shows cross-session file intellige
 
 - **Summary strip** — unique files edited, total edit operations, and sessions analysed.
 - **Hot Files** — files ranked by total edit count, with a bar chart and per-file breakdown of write / edit / delete operations and the number of sessions that touched each file.
-- **File Coupling** — pairs of files that are frequently co-edited in the same session, ranked by co-occurrence count. Each pair shows a coupling strength percentage (0 = unrelated, 100 = always edited together).
+- **File Coupling** — when 4 or more files are co-edited, an **arc diagram** shows pairs of files as quadratic Bezier arcs above a horizontal file axis. Arc thickness scales with co-occurrence count; arc opacity scales with coupling strength. Click a file node to highlight its arcs and dim unrelated ones. With fewer than 4 files, falls back to a bar list.
+
+## Errors Tab
+
+Appears when the project has Claude sessions. Cross-session error analysis across all subagent hierarchy levels:
+
+- **Summary strip** — total sessions, agent nodes, errors, and overall error rate.
+- **Errors by hierarchy depth** — bar chart colored red (depth 0) → purple (depth 6+). Depth 0 = direct subagents of the main conversation; higher depths = nested subagents. Hover a bar for depth, error count/total, and rate.
+- **Top error-prone agents** — agents that appeared in at least 3 invocations, ranked by error count with a bar showing their rate.
+- **Tool error breakdown** — which tools were involved in error turns across all sidechain sessions. Only tools with 2+ occurrences are shown.
+
+When no errors have occurred across any session, the tab shows a success confirmation with the session count.

--- a/public/help/sessions.md
+++ b/public/help/sessions.md
@@ -80,6 +80,15 @@ Cards for each spawned subagent showing type, description, and top tools used.
 ### Orchestration
 D3-powered DAG (directed acyclic graph) showing how subagents were spawned during the session. Each node is a spawned agent; edges show parent→child delegation. Node colors identify the agent type; hover for a tooltip with agent name and depth. Only appears when the session spawned at least one subagent (`subagentCount > 0`). Deep nesting beyond level 6 is collapsed into a `+N more` placeholder. Computed on demand from the original JSONL.
 
+### Concurrency
+Gantt-style timeline showing the main agent and each subagent as horizontal bars, positioned by wall-clock timestamps (falls back to turn-index proportions when timestamps are unavailable). Bar width represents active duration; bar label shows turn count. Hover a bar for `agentName · N turns`. A footnote appears when turn-index fallback is used. Only visible when the session has subagents.
+
+### Delegation
+Two-column Bezier flow diagram: primary models (left column) → subagent models (right column). Curve thickness scales with delegation count; curve opacity scales with token volume. Node height is proportional to total tokens routed through that model. Hover a curve for `ParentModel → ChildModel · N delegations · X.XK tokens`. Only visible when the session has subagents.
+
+### Network
+D3 force-directed graph of agent communication within the session. Each node represents a unique agent (collapsed across multiple invocations); node radius scales with message volume. Directed arrows show delegation edges. Hover a node for agent name and message count. A virtual `main` node anchors root-level delegations. Only visible when the session has subagents.
+
 ### Diagnosis
 Post-hoc 8-category quality analysis of the session, computed on demand from the JSONL:
 

--- a/src/app/api/projects/[slug]/error-propagation/route.ts
+++ b/src/app/api/projects/[slug]/error-propagation/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildErrorPropagation, type ErrorReport } from "@/lib/usage/errorPropagation";
+import { getJsonlMaxMtime } from "@/lib/usage/parser";
+import { getCachedScan, setCachedScan } from "@/lib/cache";
+import { scanAllProjects } from "@/lib/scanner";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheSlot {
+  data: ErrorReport;
+  cachedAt: number;
+  jsonlMtime: number;
+}
+
+const globalForError = globalThis as unknown as {
+  __errorPropagationCache?: Map<string, CacheSlot>;
+};
+
+function getCache(): Map<string, CacheSlot> {
+  if (!globalForError.__errorPropagationCache) {
+    globalForError.__errorPropagationCache = new Map();
+  }
+  return globalForError.__errorPropagationCache;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+
+  try {
+    const cache = getCache();
+    const currentMtime = getJsonlMaxMtime();
+    const cached = cache.get(slug);
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS && cached.jsonlMtime === currentMtime) {
+      return NextResponse.json(cached.data);
+    }
+
+    let scan = getCachedScan();
+    if (!scan) {
+      scan = await scanAllProjects();
+      setCachedScan(scan);
+    }
+    const project = scan.projects.find((p) => p.slug === slug);
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const data = await buildErrorPropagation(project.path);
+    cache.set(slug, { data, cachedAt: Date.now(), jsonlMtime: currentMtime });
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error(`[error-propagation] slug="${slug}":`, err);
+    return NextResponse.json(
+      { error: "Failed to compute error propagation. Check server logs." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/projects/[slug]/error-propagation/route.ts
+++ b/src/app/api/projects/[slug]/error-propagation/route.ts
@@ -1,8 +1,26 @@
+import { promises as fsPromises } from "fs";
+import path from "path";
+import os from "os";
 import { NextRequest, NextResponse } from "next/server";
 import { buildErrorPropagation, type ErrorReport } from "@/lib/usage/errorPropagation";
-import { getJsonlMaxMtime } from "@/lib/usage/parser";
+import { encodeProjectPath } from "@/lib/usage/projectMatch";
 import { getCachedScan, setCachedScan } from "@/lib/cache";
 import { scanAllProjects } from "@/lib/scanner";
+
+async function getProjectJsonlMaxMtime(projectPath: string): Promise<number> {
+  const dir = path.join(os.homedir(), ".claude", "projects", encodeProjectPath(projectPath));
+  try {
+    const entries = await fsPromises.readdir(dir);
+    const mtimes = await Promise.all(
+      entries
+        .filter((f) => f.endsWith(".jsonl"))
+        .map((f) => fsPromises.stat(path.join(dir, f)).then((s) => s.mtimeMs).catch(() => 0))
+    );
+    return mtimes.length ? Math.max(...mtimes) : 0;
+  } catch {
+    return 0;
+  }
+}
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -31,11 +49,6 @@ export async function GET(
 
   try {
     const cache = getCache();
-    const currentMtime = getJsonlMaxMtime();
-    const cached = cache.get(slug);
-    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS && cached.jsonlMtime === currentMtime) {
-      return NextResponse.json(cached.data);
-    }
 
     let scan = getCachedScan();
     if (!scan) {
@@ -45,6 +58,12 @@ export async function GET(
     const project = scan.projects.find((p) => p.slug === slug);
     if (!project) {
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    const currentMtime = await getProjectJsonlMaxMtime(project.path);
+    const cached = cache.get(slug);
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS && cached.jsonlMtime === currentMtime) {
+      return NextResponse.json(cached.data);
     }
 
     const data = await buildErrorPropagation(project.path);

--- a/src/app/api/sessions/[sessionId]/agent-network/route.ts
+++ b/src/app/api/sessions/[sessionId]/agent-network/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildAgentNetwork, type NetworkReport } from "@/lib/usage/agentNetwork";
+import { isValidSessionId, parseSessionTurns } from "@/lib/usage/parser";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+
+const globalForNetwork = globalThis as unknown as {
+  __agentNetworkCache?: Map<string, { report: NetworkReport; expiresAt: number }>;
+};
+
+function getCache() {
+  if (!globalForNetwork.__agentNetworkCache) {
+    globalForNetwork.__agentNetworkCache = new Map();
+  }
+  return globalForNetwork.__agentNetworkCache;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  if (!isValidSessionId(sessionId)) {
+    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
+  }
+
+  const now = Date.now();
+  const cache = getCache();
+  const cached = cache.get(sessionId);
+  if (cached && now < cached.expiresAt) {
+    return NextResponse.json(cached.report);
+  }
+
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  let filePath: string | null = null;
+  let projectDirName = "";
+
+  try {
+    const dirs = await fs.readdir(projectsDir);
+    for (const dir of dirs) {
+      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
+      try {
+        await fs.access(candidate);
+        filePath = candidate;
+        projectDirName = dir;
+        break;
+      } catch {
+        // not here
+      }
+    }
+  } catch {
+    return NextResponse.json({ error: "Could not read projects directory" }, { status: 500 });
+  }
+
+  if (!filePath) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const turns = await parseSessionTurns(filePath, projectDirName, { includeSidechains: true });
+  const report = buildAgentNetwork(turns);
+
+  cache.set(sessionId, { report, expiresAt: now + 60_000 });
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(key);
+  }
+
+  return NextResponse.json(report);
+}

--- a/src/app/api/sessions/[sessionId]/agent-network/route.ts
+++ b/src/app/api/sessions/[sessionId]/agent-network/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildAgentNetwork, type NetworkReport } from "@/lib/usage/agentNetwork";
-import { isValidSessionId, parseSessionTurns } from "@/lib/usage/parser";
-import { promises as fs } from "fs";
-import path from "path";
-import os from "os";
+import { findSessionFile, parseSessionTurns } from "@/lib/usage/parser";
 
 const globalForNetwork = globalThis as unknown as {
   __agentNetworkCache?: Map<string, { report: NetworkReport; expiresAt: number }>;
@@ -22,49 +19,20 @@ export async function GET(
 ) {
   const { sessionId } = await params;
 
-  if (!isValidSessionId(sessionId)) {
-    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
-  }
-
   const now = Date.now();
   const cache = getCache();
   const cached = cache.get(sessionId);
-  if (cached && now < cached.expiresAt) {
-    return NextResponse.json(cached.report);
-  }
+  if (cached && now < cached.expiresAt) return NextResponse.json(cached.report);
 
-  const projectsDir = path.join(os.homedir(), ".claude", "projects");
-  let filePath: string | null = null;
-  let projectDirName = "";
+  const found = await findSessionFile(sessionId);
+  if (!found) return NextResponse.json({ error: "Session not found" }, { status: 404 });
 
-  try {
-    const dirs = await fs.readdir(projectsDir);
-    for (const dir of dirs) {
-      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
-      try {
-        await fs.access(candidate);
-        filePath = candidate;
-        projectDirName = dir;
-        break;
-      } catch {
-        // not here
-      }
-    }
-  } catch {
-    return NextResponse.json({ error: "Could not read projects directory" }, { status: 500 });
-  }
-
-  if (!filePath) {
-    return NextResponse.json({ error: "Session not found" }, { status: 404 });
-  }
-
-  const turns = await parseSessionTurns(filePath, projectDirName, { includeSidechains: true });
+  const turns = await parseSessionTurns(found.filePath, found.projectDirName, { includeSidechains: true });
   const report = buildAgentNetwork(turns);
 
   cache.set(sessionId, { report, expiresAt: now + 60_000 });
   for (const [key, entry] of cache) {
     if (entry.expiresAt <= now) cache.delete(key);
   }
-
   return NextResponse.json(report);
 }

--- a/src/app/api/sessions/[sessionId]/concurrency-timeline/route.ts
+++ b/src/app/api/sessions/[sessionId]/concurrency-timeline/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildConcurrencyTimeline, type TimelineReport } from "@/lib/usage/concurrencyTimeline";
-import { isValidSessionId, parseSessionTurns } from "@/lib/usage/parser";
-import { promises as fs } from "fs";
-import path from "path";
-import os from "os";
+import { findSessionFile, parseSessionTurns } from "@/lib/usage/parser";
 
 const globalForConcurrency = globalThis as unknown as {
   __concurrencyCache?: Map<string, { report: TimelineReport; expiresAt: number }>;
@@ -22,49 +19,20 @@ export async function GET(
 ) {
   const { sessionId } = await params;
 
-  if (!isValidSessionId(sessionId)) {
-    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
-  }
-
   const now = Date.now();
   const cache = getCache();
   const cached = cache.get(sessionId);
-  if (cached && now < cached.expiresAt) {
-    return NextResponse.json(cached.report);
-  }
+  if (cached && now < cached.expiresAt) return NextResponse.json(cached.report);
 
-  const projectsDir = path.join(os.homedir(), ".claude", "projects");
-  let filePath: string | null = null;
-  let projectDirName = "";
+  const found = await findSessionFile(sessionId);
+  if (!found) return NextResponse.json({ error: "Session not found" }, { status: 404 });
 
-  try {
-    const dirs = await fs.readdir(projectsDir);
-    for (const dir of dirs) {
-      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
-      try {
-        await fs.access(candidate);
-        filePath = candidate;
-        projectDirName = dir;
-        break;
-      } catch {
-        // not here
-      }
-    }
-  } catch {
-    return NextResponse.json({ error: "Could not read projects directory" }, { status: 500 });
-  }
-
-  if (!filePath) {
-    return NextResponse.json({ error: "Session not found" }, { status: 404 });
-  }
-
-  const turns = await parseSessionTurns(filePath, projectDirName, { includeSidechains: true });
+  const turns = await parseSessionTurns(found.filePath, found.projectDirName, { includeSidechains: true });
   const report = buildConcurrencyTimeline(turns);
 
   cache.set(sessionId, { report, expiresAt: now + 60_000 });
   for (const [key, entry] of cache) {
     if (entry.expiresAt <= now) cache.delete(key);
   }
-
   return NextResponse.json(report);
 }

--- a/src/app/api/sessions/[sessionId]/concurrency-timeline/route.ts
+++ b/src/app/api/sessions/[sessionId]/concurrency-timeline/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildConcurrencyTimeline, type TimelineReport } from "@/lib/usage/concurrencyTimeline";
+import { isValidSessionId, parseSessionTurns } from "@/lib/usage/parser";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+
+const globalForConcurrency = globalThis as unknown as {
+  __concurrencyCache?: Map<string, { report: TimelineReport; expiresAt: number }>;
+};
+
+function getCache() {
+  if (!globalForConcurrency.__concurrencyCache) {
+    globalForConcurrency.__concurrencyCache = new Map();
+  }
+  return globalForConcurrency.__concurrencyCache;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  if (!isValidSessionId(sessionId)) {
+    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
+  }
+
+  const now = Date.now();
+  const cache = getCache();
+  const cached = cache.get(sessionId);
+  if (cached && now < cached.expiresAt) {
+    return NextResponse.json(cached.report);
+  }
+
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  let filePath: string | null = null;
+  let projectDirName = "";
+
+  try {
+    const dirs = await fs.readdir(projectsDir);
+    for (const dir of dirs) {
+      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
+      try {
+        await fs.access(candidate);
+        filePath = candidate;
+        projectDirName = dir;
+        break;
+      } catch {
+        // not here
+      }
+    }
+  } catch {
+    return NextResponse.json({ error: "Could not read projects directory" }, { status: 500 });
+  }
+
+  if (!filePath) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const turns = await parseSessionTurns(filePath, projectDirName, { includeSidechains: true });
+  const report = buildConcurrencyTimeline(turns);
+
+  cache.set(sessionId, { report, expiresAt: now + 60_000 });
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(key);
+  }
+
+  return NextResponse.json(report);
+}

--- a/src/app/api/sessions/[sessionId]/model-delegation/route.ts
+++ b/src/app/api/sessions/[sessionId]/model-delegation/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { buildModelDelegation, type DelegationReport } from "@/lib/usage/modelDelegation";
-import { isValidSessionId, parseSessionTurns } from "@/lib/usage/parser";
-import { promises as fs } from "fs";
-import path from "path";
-import os from "os";
+import { findSessionFile, parseSessionTurns } from "@/lib/usage/parser";
 
 const globalForDelegation = globalThis as unknown as {
   __delegationCache?: Map<string, { report: DelegationReport; expiresAt: number }>;
@@ -22,49 +19,20 @@ export async function GET(
 ) {
   const { sessionId } = await params;
 
-  if (!isValidSessionId(sessionId)) {
-    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
-  }
-
   const now = Date.now();
   const cache = getCache();
   const cached = cache.get(sessionId);
-  if (cached && now < cached.expiresAt) {
-    return NextResponse.json(cached.report);
-  }
+  if (cached && now < cached.expiresAt) return NextResponse.json(cached.report);
 
-  const projectsDir = path.join(os.homedir(), ".claude", "projects");
-  let filePath: string | null = null;
-  let projectDirName = "";
+  const found = await findSessionFile(sessionId);
+  if (!found) return NextResponse.json({ error: "Session not found" }, { status: 404 });
 
-  try {
-    const dirs = await fs.readdir(projectsDir);
-    for (const dir of dirs) {
-      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
-      try {
-        await fs.access(candidate);
-        filePath = candidate;
-        projectDirName = dir;
-        break;
-      } catch {
-        // not here
-      }
-    }
-  } catch {
-    return NextResponse.json({ error: "Could not read projects directory" }, { status: 500 });
-  }
-
-  if (!filePath) {
-    return NextResponse.json({ error: "Session not found" }, { status: 404 });
-  }
-
-  const turns = await parseSessionTurns(filePath, projectDirName, { includeSidechains: true });
+  const turns = await parseSessionTurns(found.filePath, found.projectDirName, { includeSidechains: true });
   const report = buildModelDelegation(turns);
 
   cache.set(sessionId, { report, expiresAt: now + 60_000 });
   for (const [key, entry] of cache) {
     if (entry.expiresAt <= now) cache.delete(key);
   }
-
   return NextResponse.json(report);
 }

--- a/src/app/api/sessions/[sessionId]/model-delegation/route.ts
+++ b/src/app/api/sessions/[sessionId]/model-delegation/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildModelDelegation, type DelegationReport } from "@/lib/usage/modelDelegation";
+import { isValidSessionId, parseSessionTurns } from "@/lib/usage/parser";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+
+const globalForDelegation = globalThis as unknown as {
+  __delegationCache?: Map<string, { report: DelegationReport; expiresAt: number }>;
+};
+
+function getCache() {
+  if (!globalForDelegation.__delegationCache) {
+    globalForDelegation.__delegationCache = new Map();
+  }
+  return globalForDelegation.__delegationCache;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  if (!isValidSessionId(sessionId)) {
+    return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
+  }
+
+  const now = Date.now();
+  const cache = getCache();
+  const cached = cache.get(sessionId);
+  if (cached && now < cached.expiresAt) {
+    return NextResponse.json(cached.report);
+  }
+
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  let filePath: string | null = null;
+  let projectDirName = "";
+
+  try {
+    const dirs = await fs.readdir(projectsDir);
+    for (const dir of dirs) {
+      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
+      try {
+        await fs.access(candidate);
+        filePath = candidate;
+        projectDirName = dir;
+        break;
+      } catch {
+        // not here
+      }
+    }
+  } catch {
+    return NextResponse.json({ error: "Could not read projects directory" }, { status: 500 });
+  }
+
+  if (!filePath) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const turns = await parseSessionTurns(filePath, projectDirName, { includeSidechains: true });
+  const report = buildModelDelegation(turns);
+
+  cache.set(sessionId, { report, expiresAt: now + 60_000 });
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(key);
+  }
+
+  return NextResponse.json(report);
+}

--- a/src/components/HotFilesPanel.tsx
+++ b/src/components/HotFilesPanel.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { HotFilesResult, HotFile } from "@/lib/usage/fileTracker";
 import type { FileCouplingResult, FilePair } from "@/lib/usage/fileCoupling";
+
+const FileCouplingArc = dynamic(
+  () => import("./viz/FileCouplingArc").then((m) => m.FileCouplingArc),
+  { ssr: false, loading: () => <Skeleton className="h-64" /> }
+);
 
 interface HotFilesResponse {
   slug: string;
@@ -269,10 +276,12 @@ export function HotFilesPanel({ slug }: HotFilesPanelProps) {
           <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
             No co-edited file pairs found (minimum 2 sessions required).
           </p>
-        ) : (
+        ) : pairs.length < 4 ? (
           pairs.slice(0, 20).map((p) => (
             <PairRow key={p.fileA + "\0" + p.fileB} pair={p} max={maxCoOccurrences} />
           ))
+        ) : (
+          <FileCouplingArc result={couplingData.result} />
         )}
       </section>
     </div>

--- a/src/components/HotFilesPanel.tsx
+++ b/src/components/HotFilesPanel.tsx
@@ -276,7 +276,7 @@ export function HotFilesPanel({ slug }: HotFilesPanelProps) {
           <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
             No co-edited file pairs found (minimum 2 sessions required).
           </p>
-        ) : pairs.length < 4 ? (
+        ) : new Set(pairs.flatMap((p) => [p.fileA, p.fileB])).size < 4 ? (
           pairs.slice(0, 20).map((p) => (
             <PairRow key={p.fileA + "\0" + p.fileB} pair={p} max={maxCoOccurrences} />
           ))

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -21,6 +21,13 @@ import { ClaudeMdAuditPanel } from "./ClaudeMdAuditPanel";
 import { ContextBudgetPanel } from "./ContextBudgetPanel";
 import { EfficiencyTab } from "./EfficiencyTab";
 import { HotFilesPanel } from "./HotFilesPanel";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const ErrorPropagationMap = dynamic(
+  () => import("./viz/ErrorPropagationMap").then((m) => m.ErrorPropagationMap),
+  { ssr: false, loading: () => <Skeleton className="h-64" /> }
+);
 import { PatternsPanel } from "./PatternsPanel";
 import {
   ArrowLeft,
@@ -39,7 +46,7 @@ import { formatDistanceToNow } from "date-fns";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-type TabKey = "overview" | "context" | "todos" | "sessions" | "manual-steps" | "insights" | "memory" | "agents" | "skills" | "efficiency" | "hot-files" | "patterns" | "config" | "config-history";
+type TabKey = "overview" | "context" | "todos" | "sessions" | "manual-steps" | "insights" | "memory" | "agents" | "skills" | "efficiency" | "hot-files" | "errors" | "patterns" | "config" | "config-history";
 
 interface ProjectDetailProps {
   project: ProjectData;
@@ -143,6 +150,7 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
     { key: "skills",      label: "Skills" },
     ...(hasSessions ? [{ key: "efficiency"   as TabKey, label: "Efficiency"   }] : []),
     ...(hasSessions ? [{ key: "hot-files"   as TabKey, label: "Hot Files"    }] : []),
+    ...(hasSessions ? [{ key: "errors"      as TabKey, label: "Errors"       }] : []),
     ...(hasSessions ? [{ key: "patterns"    as TabKey, label: "Patterns"     }] : []),
     ...(hasConfig       ? [{ key: "config"       as TabKey, label: "Config"       }] : []),
     ...(hasConfigHistory ? [{ key: "config-history" as TabKey, label: "Config History" }] : []),
@@ -556,6 +564,11 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
           {/* ── HOT FILES ────────────────────────────────────────────── */}
           {activeTab === "hot-files" && (
             <HotFilesPanel slug={project.slug} />
+          )}
+
+          {/* ── ERRORS ───────────────────────────────────────────────── */}
+          {activeTab === "errors" && (
+            <ErrorPropagationMap slug={project.slug} />
           )}
 
           {/* ── PATTERNS ─────────────────────────────────────────────── */}

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -9,6 +9,18 @@ const OrchestrationDAG = dynamic(
   () => import("./viz/OrchestrationDAG").then((m) => m.OrchestrationDAG),
   { ssr: false, loading: () => <Skeleton className="h-96" /> }
 );
+const ConcurrencyTimeline = dynamic(
+  () => import("./viz/ConcurrencyTimeline").then((m) => m.ConcurrencyTimeline),
+  { ssr: false, loading: () => <Skeleton className="h-48" /> }
+);
+const ModelDelegationFlow = dynamic(
+  () => import("./viz/ModelDelegationFlow").then((m) => m.ModelDelegationFlow),
+  { ssr: false, loading: () => <Skeleton className="h-80" /> }
+);
+const AgentNetworkGraph = dynamic(
+  () => import("./viz/AgentNetworkGraph").then((m) => m.AgentNetworkGraph),
+  { ssr: false, loading: () => <Skeleton className="h-96" /> }
+);
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { SessionTimeline } from "./SessionTimeline";
 import { SessionFileOps } from "./SessionFileOps";
@@ -130,7 +142,7 @@ function StatCell({
 }
 
 // ── Tab bar ───────────────────────────────────────────────────────────────────
-type TabKey = "timeline" | "tools" | "files" | "skills" | "subagents" | "orchestration" | "handoff" | "diagnosis" | "feedback";
+type TabKey = "timeline" | "tools" | "files" | "skills" | "subagents" | "orchestration" | "concurrency" | "delegation" | "network" | "handoff" | "diagnosis" | "feedback";
 
 function TabBar({
   tabs, active, onChange,
@@ -214,6 +226,15 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
       : []),
     ...(data.subagentCount > 0
       ? [{ key: "orchestration" as TabKey, label: "Orchestration" }]
+      : []),
+    ...(data.subagents.length > 0
+      ? [{ key: "concurrency" as TabKey, label: "Concurrency" }]
+      : []),
+    ...(data.subagents.length > 0
+      ? [{ key: "delegation" as TabKey, label: "Delegation" }]
+      : []),
+    ...(data.subagents.length > 0
+      ? [{ key: "network" as TabKey, label: "Network" }]
       : []),
     { key: "handoff",   label: "Handoff"   },
     { key: "diagnosis", label: "Diagnosis" },
@@ -445,6 +466,18 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
 
           {activeTab === "orchestration" && (
             <OrchestrationDAG sessionId={data.sessionId} />
+          )}
+
+          {activeTab === "concurrency" && (
+            <ConcurrencyTimeline sessionId={data.sessionId} />
+          )}
+
+          {activeTab === "delegation" && (
+            <ModelDelegationFlow sessionId={data.sessionId} />
+          )}
+
+          {activeTab === "network" && (
+            <AgentNetworkGraph sessionId={data.sessionId} />
           )}
 
           {activeTab === "handoff" && (

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -228,13 +228,11 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
       ? [{ key: "orchestration" as TabKey, label: "Orchestration" }]
       : []),
     ...(data.subagents.length > 0
-      ? [{ key: "concurrency" as TabKey, label: "Concurrency" }]
-      : []),
-    ...(data.subagents.length > 0
-      ? [{ key: "delegation" as TabKey, label: "Delegation" }]
-      : []),
-    ...(data.subagents.length > 0
-      ? [{ key: "network" as TabKey, label: "Network" }]
+      ? ([
+          { key: "concurrency", label: "Concurrency" },
+          { key: "delegation",  label: "Delegation"  },
+          { key: "network",     label: "Network"     },
+        ] as { key: TabKey; label: string }[])
       : []),
     { key: "handoff",   label: "Handoff"   },
     { key: "diagnosis", label: "Diagnosis" },

--- a/src/components/viz/AgentNetworkGraph.tsx
+++ b/src/components/viz/AgentNetworkGraph.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useRef, useCallback, useId } from "react";
 import * as d3 from "d3";
 import { AGENT_COLORS } from "./agentPalette";
+import { useReportFetch } from "@/hooks/useReportFetch";
 import type { NetworkReport, NetworkNode, NetworkEdge } from "@/lib/usage/agentNetwork";
 
 interface Props {
@@ -13,17 +14,9 @@ const HEIGHT = 480;
 const MARGIN = { top: 20, right: 20, bottom: 20, left: 20 };
 
 export function AgentNetworkGraph({ sessionId }: Props) {
-  const [data, setData] = useState<NetworkReport | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    fetch(`/api/sessions/${sessionId}/agent-network`)
-      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
-      .then((d: NetworkReport) => { setData(d); setLoading(false); })
-      .catch((e: string) => { setError(String(e)); setLoading(false); });
-  }, [sessionId]);
+  const { data, loading, error } = useReportFetch<NetworkReport>(
+    `/api/sessions/${sessionId}/agent-network`
+  );
 
   if (loading) {
     return <div style={{ height: `${HEIGHT}px`, background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;
@@ -49,6 +42,7 @@ function ForceGraph({ data }: { data: NetworkReport }) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [tooltip, setTooltip] = useState<{ x: number; y: number; content: string } | null>(null);
+  const markerId = useId().replace(/:/g, "");
 
   const showTooltip = useCallback((x: number, y: number, content: string) => {
     setTooltip({ x, y, content });
@@ -92,9 +86,9 @@ function ForceGraph({ data }: { data: NetworkReport }) {
       .append("g")
       .attr("transform", `translate(${MARGIN.left},${MARGIN.top})`);
 
-    // Arrow marker
+    // Arrow marker — markerId from useId() ensures uniqueness across concurrent instances
     svg.append("defs").append("marker")
-      .attr("id", `arrow-${sessionIdHash(data)}`)
+      .attr("id", `arrow-${markerId}`)
       .attr("viewBox", "0 -4 8 8")
       .attr("refX", 18)
       .attr("refY", 0)
@@ -112,7 +106,7 @@ function ForceGraph({ data }: { data: NetworkReport }) {
       .attr("stroke", "var(--border-default)")
       .attr("stroke-width", (d) => Math.sqrt(d.weight) + 0.5)
       .attr("stroke-opacity", 0.6)
-      .attr("marker-end", `url(#arrow-${sessionIdHash(data)})`);
+      .attr("marker-end", `url(#arrow-${markerId})`);
 
     const node = g.selectAll("g.node")
       .data(nodes)
@@ -182,9 +176,4 @@ function ForceGraph({ data }: { data: NetworkReport }) {
       )}
     </div>
   );
-}
-
-// Stable hash of node count to make marker IDs unique per graph instance
-function sessionIdHash(data: NetworkReport): string {
-  return String(data.nodes.length);
 }

--- a/src/components/viz/AgentNetworkGraph.tsx
+++ b/src/components/viz/AgentNetworkGraph.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useState, useRef, useCallback } from "react";
+import * as d3 from "d3";
+import { AGENT_COLORS } from "./agentPalette";
+import type { NetworkReport, NetworkNode, NetworkEdge } from "@/lib/usage/agentNetwork";
+
+interface Props {
+  sessionId: string;
+}
+
+const HEIGHT = 480;
+const MARGIN = { top: 20, right: 20, bottom: 20, left: 20 };
+
+export function AgentNetworkGraph({ sessionId }: Props) {
+  const [data, setData] = useState<NetworkReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/sessions/${sessionId}/agent-network`)
+      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
+      .then((d: NetworkReport) => { setData(d); setLoading(false); })
+      .catch((e: string) => { setError(String(e)); setLoading(false); });
+  }, [sessionId]);
+
+  if (loading) {
+    return <div style={{ height: `${HEIGHT}px`, background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;
+  }
+
+  if (error) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--status-error-text)" }}>{error}</p>;
+  }
+
+  if (!data || data.nodes.length === 0) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--text-muted)", textAlign: "center", padding: "32px 0" }}>No agent network data — session has no subagents.</p>;
+  }
+
+  return <ForceGraph data={data} />;
+}
+
+interface SimNode extends NetworkNode, d3.SimulationNodeDatum {}
+interface SimLink extends d3.SimulationLinkDatum<SimNode> {
+  weight: number;
+}
+
+function ForceGraph({ data }: { data: NetworkReport }) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; content: string } | null>(null);
+
+  const showTooltip = useCallback((x: number, y: number, content: string) => {
+    setTooltip({ x, y, content });
+  }, []);
+  const hideTooltip = useCallback(() => setTooltip(null), []);
+
+  useEffect(() => {
+    const svgEl = svgRef.current;
+    const containerEl = containerRef.current;
+    if (!svgEl || !containerEl) return;
+
+    const width = containerEl.clientWidth;
+    const innerW = width - MARGIN.left - MARGIN.right;
+    const innerH = HEIGHT - MARGIN.top - MARGIN.bottom;
+
+    const maxMessages = Math.max(...data.nodes.map((n) => n.messageCount), 1);
+    const rScale = d3.scaleSqrt().domain([0, maxMessages]).range([5, 22]).clamp(true);
+
+    // Build mutable copies for force sim
+    const nodes: SimNode[] = data.nodes.map((n) => ({ ...n }));
+    const nodeById = new Map(nodes.map((n) => [n.id, n]));
+    const links: SimLink[] = data.edges.map((e: NetworkEdge) => ({
+      source: (nodeById.get(e.from) ?? e.from) as SimNode,
+      target: (nodeById.get(e.to) ?? e.to) as SimNode,
+      weight: e.weight,
+    }));
+
+    const simulation = d3
+      .forceSimulation(nodes)
+      .force("link", d3.forceLink<SimNode, SimLink>(links).id((d) => d.id).distance(100).strength(0.5))
+      .force("charge", d3.forceManyBody().strength(-200))
+      .force("center", d3.forceCenter(innerW / 2, innerH / 2))
+      .force("collision", d3.forceCollide<SimNode>().radius((d) => rScale(d.messageCount) + 8));
+
+    const svg = d3.select(svgEl);
+    svg.selectAll("*").remove();
+
+    const g = svg
+      .attr("width", width)
+      .attr("height", HEIGHT)
+      .append("g")
+      .attr("transform", `translate(${MARGIN.left},${MARGIN.top})`);
+
+    // Arrow marker
+    svg.append("defs").append("marker")
+      .attr("id", `arrow-${sessionIdHash(data)}`)
+      .attr("viewBox", "0 -4 8 8")
+      .attr("refX", 18)
+      .attr("refY", 0)
+      .attr("markerWidth", 6)
+      .attr("markerHeight", 6)
+      .attr("orient", "auto")
+      .append("path")
+      .attr("d", "M0,-4L8,0L0,4")
+      .attr("fill", "var(--border-default)");
+
+    const link = g.selectAll("line")
+      .data(links)
+      .enter()
+      .append("line")
+      .attr("stroke", "var(--border-default)")
+      .attr("stroke-width", (d) => Math.sqrt(d.weight) + 0.5)
+      .attr("stroke-opacity", 0.6)
+      .attr("marker-end", `url(#arrow-${sessionIdHash(data)})`);
+
+    const node = g.selectAll("g.node")
+      .data(nodes)
+      .enter()
+      .append("g")
+      .attr("class", "node")
+      .style("cursor", "default");
+
+    node.append("circle")
+      .attr("r", (d) => rScale(d.messageCount))
+      .attr("fill", (_, i) => AGENT_COLORS[i % AGENT_COLORS.length])
+      .attr("opacity", 0.85)
+      .on("mouseenter", function (_event, d) {
+        const el = this as SVGElement;
+        const rect = el.getBoundingClientRect();
+        showTooltip(rect.left + rect.width / 2, rect.top - 8, `${d.name} · ${d.messageCount} msgs`);
+      })
+      .on("mouseleave", hideTooltip);
+
+    node.append("text")
+      .attr("text-anchor", "middle")
+      .attr("dominant-baseline", "middle")
+      .attr("font-size", "0.6rem")
+      .attr("font-family", "var(--font-mono)")
+      .attr("fill", "var(--text-primary)")
+      .attr("dy", (d) => rScale(d.messageCount) + 10)
+      .style("pointer-events", "none")
+      .text((d) => d.name.length > 16 ? d.name.slice(0, 15) + "…" : d.name);
+
+    simulation.on("tick", () => {
+      link
+        .attr("x1", (d) => (d.source as SimNode).x ?? 0)
+        .attr("y1", (d) => (d.source as SimNode).y ?? 0)
+        .attr("x2", (d) => (d.target as SimNode).x ?? 0)
+        .attr("y2", (d) => (d.target as SimNode).y ?? 0);
+
+      node.attr("transform", (d) => `translate(${d.x ?? 0},${d.y ?? 0})`);
+    });
+
+    return () => {
+      simulation.stop();
+    };
+  }, [data, showTooltip, hideTooltip]);
+
+  return (
+    <div ref={containerRef} style={{ position: "relative", width: "100%" }}>
+      <svg ref={svgRef} style={{ display: "block", overflow: "visible" }} />
+      {tooltip && (
+        <div style={{
+          position: "fixed",
+          left: tooltip.x,
+          top: tooltip.y,
+          transform: "translate(-50%, -100%)",
+          background: "var(--bg-elevated)",
+          border: "1px solid var(--border-default)",
+          borderRadius: "var(--radius)",
+          padding: "4px 8px",
+          fontSize: "0.72rem",
+          fontFamily: "var(--font-mono)",
+          color: "var(--text-primary)",
+          pointerEvents: "none",
+          zIndex: 9999,
+          whiteSpace: "nowrap",
+        }}>
+          {tooltip.content}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Stable hash of node count to make marker IDs unique per graph instance
+function sessionIdHash(data: NetworkReport): string {
+  return String(data.nodes.length);
+}

--- a/src/components/viz/ConcurrencyTimeline.tsx
+++ b/src/components/viz/ConcurrencyTimeline.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { D3Container } from "./D3Container";
 import { AGENT_COLORS } from "./agentPalette";
+import { useReportFetch } from "@/hooks/useReportFetch";
 import type { TimelineReport, TimelineBar } from "@/lib/usage/concurrencyTimeline";
 
 interface Props {
@@ -18,17 +18,9 @@ function barColor(index: number): string {
 }
 
 export function ConcurrencyTimeline({ sessionId }: Props) {
-  const [data, setData] = useState<TimelineReport | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    fetch(`/api/sessions/${sessionId}/concurrency-timeline`)
-      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
-      .then((d: TimelineReport) => { setData(d); setLoading(false); })
-      .catch((e: string) => { setError(String(e)); setLoading(false); });
-  }, [sessionId]);
+  const { data, loading, error } = useReportFetch<TimelineReport>(
+    `/api/sessions/${sessionId}/concurrency-timeline`
+  );
 
   if (loading) {
     return <div style={{ height: "120px", background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;

--- a/src/components/viz/ConcurrencyTimeline.tsx
+++ b/src/components/viz/ConcurrencyTimeline.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { D3Container } from "./D3Container";
+import { AGENT_COLORS } from "./agentPalette";
+import type { TimelineReport, TimelineBar } from "@/lib/usage/concurrencyTimeline";
+
+interface Props {
+  sessionId: string;
+}
+
+const BAR_HEIGHT = 22;
+const BAR_GAP = 6;
+const LABEL_WIDTH = 140;
+
+function barColor(index: number): string {
+  return AGENT_COLORS[index % AGENT_COLORS.length];
+}
+
+export function ConcurrencyTimeline({ sessionId }: Props) {
+  const [data, setData] = useState<TimelineReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/sessions/${sessionId}/concurrency-timeline`)
+      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
+      .then((d: TimelineReport) => { setData(d); setLoading(false); })
+      .catch((e: string) => { setError(String(e)); setLoading(false); });
+  }, [sessionId]);
+
+  if (loading) {
+    return <div style={{ height: "120px", background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;
+  }
+
+  if (error) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--status-error-text)" }}>{error}</p>;
+  }
+
+  if (!data || data.bars.length === 0) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--text-muted)", textAlign: "center", padding: "32px 0" }}>No concurrency data — session has no subagents.</p>;
+  }
+
+  const totalHeight = data.bars.length * (BAR_HEIGHT + BAR_GAP) + BAR_GAP + 28;
+
+  return (
+    <div>
+      {data.usedFallback && (
+        <p style={{ fontSize: "0.72rem", color: "var(--text-muted)", marginBottom: "8px" }}>
+          Wall-clock timestamps unavailable — positions estimated from turn order.
+        </p>
+      )}
+      <D3Container
+        height={totalHeight}
+        margin={{ top: 8, right: 16, bottom: 20, left: LABEL_WIDTH }}
+      >
+        {({ width, showTooltip, hideTooltip }) => (
+          <g>
+            {/* Time axis baseline */}
+            <line x1={0} y1={totalHeight - 48} x2={width} y2={totalHeight - 48} stroke="var(--border-default)" strokeWidth={1} />
+
+            {data.bars.map((bar: TimelineBar, i: number) => {
+              const y = BAR_GAP + i * (BAR_HEIGHT + BAR_GAP);
+              const x = (bar.startPct / 100) * width;
+              const w = Math.max(2, ((bar.endPct - bar.startPct) / 100) * width);
+              const color = bar.nodeId === "__main__" ? "var(--text-secondary)" : barColor(i - 1);
+              const label = bar.agentName.length > 18
+                ? bar.agentName.slice(0, 17) + "…"
+                : bar.agentName;
+
+              return (
+                <g key={bar.nodeId}>
+                  {/* Label (left side, outside SVG inner area) */}
+                  <text
+                    x={-8}
+                    y={y + BAR_HEIGHT / 2}
+                    textAnchor="end"
+                    dominantBaseline="middle"
+                    fontSize="0.68rem"
+                    fontFamily="var(--font-mono)"
+                    fill="var(--text-secondary)"
+                  >
+                    {label}
+                  </text>
+
+                  {/* Bar */}
+                  <rect
+                    x={x}
+                    y={y}
+                    width={w}
+                    height={BAR_HEIGHT}
+                    rx={3}
+                    fill={color}
+                    opacity={0.8}
+                    style={{ cursor: "default" }}
+                    onMouseEnter={(e) => {
+                      const rect = (e.currentTarget as SVGElement).getBoundingClientRect();
+                      showTooltip(
+                        rect.left + rect.width / 2,
+                        rect.top - 8,
+                        `${bar.agentName} · ${bar.turnCount} turns`
+                      );
+                    }}
+                    onMouseLeave={hideTooltip}
+                  />
+
+                  {/* Label inside bar if wide enough */}
+                  {w > 60 && (
+                    <text
+                      x={x + w / 2}
+                      y={y + BAR_HEIGHT / 2}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                      fontSize="0.6rem"
+                      fontFamily="var(--font-mono)"
+                      fill="var(--bg-surface)"
+                      style={{ pointerEvents: "none" }}
+                    >
+                      {bar.turnCount}t
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+
+            {/* 0% / 100% ticks */}
+            <text x={0} y={totalHeight - 36} textAnchor="middle" fontSize="0.58rem" fontFamily="var(--font-mono)" fill="var(--text-muted)">0%</text>
+            <text x={width} y={totalHeight - 36} textAnchor="middle" fontSize="0.58rem" fontFamily="var(--font-mono)" fill="var(--text-muted)">100%</text>
+          </g>
+        )}
+      </D3Container>
+    </div>
+  );
+}

--- a/src/components/viz/ErrorPropagationMap.tsx
+++ b/src/components/viz/ErrorPropagationMap.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import * as d3 from "d3";
 import { D3Container, Axes } from "./D3Container";
 import { depthColor } from "./agentPalette";
+import { useReportFetch } from "@/hooks/useReportFetch";
 import type { ErrorReport, DepthBucket } from "@/lib/usage/errorPropagation";
 
 interface Props {
@@ -11,17 +11,9 @@ interface Props {
 }
 
 export function ErrorPropagationMap({ slug }: Props) {
-  const [data, setData] = useState<ErrorReport | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    fetch(`/api/projects/${slug}/error-propagation`)
-      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
-      .then((d: ErrorReport) => { setData(d); setLoading(false); })
-      .catch((e: string) => { setError(String(e)); setLoading(false); });
-  }, [slug]);
+  const { data, loading, error } = useReportFetch<ErrorReport>(
+    `/api/projects/${slug}/error-propagation`
+  );
 
   if (loading) {
     return <div style={{ height: "240px", background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;

--- a/src/components/viz/ErrorPropagationMap.tsx
+++ b/src/components/viz/ErrorPropagationMap.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import * as d3 from "d3";
+import { D3Container, Axes } from "./D3Container";
+import { depthColor } from "./agentPalette";
+import type { ErrorReport, DepthBucket } from "@/lib/usage/errorPropagation";
+
+interface Props {
+  slug: string;
+}
+
+export function ErrorPropagationMap({ slug }: Props) {
+  const [data, setData] = useState<ErrorReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/projects/${slug}/error-propagation`)
+      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
+      .then((d: ErrorReport) => { setData(d); setLoading(false); })
+      .catch((e: string) => { setError(String(e)); setLoading(false); });
+  }, [slug]);
+
+  if (loading) {
+    return <div style={{ height: "240px", background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;
+  }
+
+  if (error) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--status-error-text)" }}>{error}</p>;
+  }
+
+  if (!data || data.summary.sessionCount === 0 || data.summary.totalErrors === 0) {
+    return (
+      <div style={{ textAlign: "center", padding: "48px 0", color: "var(--text-muted)" }}>
+        <p style={{ fontSize: "0.8rem" }}>
+          {data?.summary.sessionCount
+            ? `No errors recorded across ${data.summary.sessionCount} sessions.`
+            : "No sessions with subagent data found."}
+        </p>
+      </div>
+    );
+  }
+
+  const { summary, byDepth, topAgents, byTool } = data;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+
+      {/* Summary row */}
+      <div style={{ display: "flex", gap: "20px", flexWrap: "wrap" }}>
+        {[
+          { label: "Sessions", value: summary.sessionCount },
+          { label: "Agent nodes", value: summary.totalNodes },
+          { label: "Errors", value: summary.totalErrors, accent: "error" },
+          { label: "Error rate", value: `${(summary.errorRate * 100).toFixed(1)}%`, accent: summary.errorRate > 0.1 ? "error" : undefined },
+        ].map((s) => (
+          <div key={s.label} style={{ display: "flex", flexDirection: "column", gap: "2px", minWidth: "80px" }}>
+            <span style={{ fontSize: "0.6rem", fontWeight: 600, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--text-muted)", fontFamily: "var(--font-body)" }}>{s.label}</span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: "1.1rem", fontWeight: 600, color: s.accent === "error" ? "var(--status-error-text)" : "var(--text-primary)" }}>{s.value}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Errors by depth bar chart */}
+      {byDepth.length > 0 && (
+        <section>
+          <h3 style={{ fontSize: "0.72rem", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-muted)", fontFamily: "var(--font-mono)", marginBottom: "8px" }}>
+            Errors by hierarchy depth
+          </h3>
+          <DepthBarChart buckets={byDepth} />
+        </section>
+      )}
+
+      {/* Top error-prone agents */}
+      {topAgents.length > 0 && (
+        <section>
+          <h3 style={{ fontSize: "0.72rem", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-muted)", fontFamily: "var(--font-mono)", marginBottom: "8px" }}>
+            Top error-prone agents
+          </h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            {topAgents.slice(0, 8).map((a) => (
+              <div key={a.name} style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.75rem", color: "var(--text-secondary)", width: "200px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{a.name}</span>
+                <div style={{ flex: 1, height: "6px", background: "var(--bg-elevated)", borderRadius: "3px", overflow: "hidden" }}>
+                  <div style={{ height: "100%", width: `${a.rate * 100}%`, background: "var(--status-error-text)", borderRadius: "3px" }} />
+                </div>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--text-muted)", width: "60px", textAlign: "right" }}>{a.errors}/{a.total}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Tool breakdown */}
+      {byTool.length > 0 && (
+        <section>
+          <h3 style={{ fontSize: "0.72rem", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-muted)", fontFamily: "var(--font-mono)", marginBottom: "8px" }}>
+            Tool error breakdown
+          </h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            {byTool.slice(0, 10).map((t) => (
+              <div key={t.tool} style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.75rem", color: "var(--text-secondary)", width: "180px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{t.tool}</span>
+                <div style={{ flex: 1, height: "6px", background: "var(--bg-elevated)", borderRadius: "3px", overflow: "hidden" }}>
+                  <div style={{ height: "100%", width: `${t.total > 0 ? (t.errors / t.total) * 100 : 0}%`, background: "var(--status-error-text)", opacity: 0.7, borderRadius: "3px" }} />
+                </div>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--text-muted)", width: "60px", textAlign: "right" }}>{t.errors}e / {t.total}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function DepthBarChart({ buckets }: { buckets: DepthBucket[] }) {
+  const maxRate = Math.max(...buckets.map((b) => b.rate), 0.01);
+  const yScale = d3.scaleLinear().domain([0, maxRate]).range([200, 0]).nice();
+
+  return (
+    <D3Container height={240} margin={{ top: 12, right: 12, bottom: 32, left: 48 }}>
+      {({ width, height, showTooltip, hideTooltip }) => {
+        const xS = d3.scaleBand()
+          .domain(buckets.map((b) => String(b.depth)))
+          .range([0, width])
+          .padding(0.25);
+        const barW = xS.bandwidth();
+
+        return (
+          <g>
+            <Axes xScale={xS as unknown as Parameters<typeof Axes>[0]["xScale"]} yScale={yScale} width={width} height={height} xLabel="Depth" yLabel="Error rate" tickCountX={buckets.length} tickCountY={4} />
+            {buckets.map((b) => {
+              const x = xS(String(b.depth)) ?? 0;
+              const barH = height - yScale(b.rate);
+              return (
+                <rect
+                  key={b.depth}
+                  x={x}
+                  y={yScale(b.rate)}
+                  width={barW}
+                  height={barH}
+                  fill={depthColor(b.depth)}
+                  opacity={0.85}
+                  rx={2}
+                  style={{ cursor: "default" }}
+                  onMouseEnter={(e) => {
+                    const r = (e.currentTarget as SVGElement).getBoundingClientRect();
+                    showTooltip(r.left + r.width / 2, r.top - 8,
+                      `Depth ${b.depth} · ${b.errors}/${b.total} errors (${(b.rate * 100).toFixed(1)}%)`);
+                  }}
+                  onMouseLeave={hideTooltip}
+                />
+              );
+            })}
+          </g>
+        );
+      }}
+    </D3Container>
+  );
+}

--- a/src/components/viz/FileCouplingArc.tsx
+++ b/src/components/viz/FileCouplingArc.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import * as d3 from "d3";
+import { D3Container } from "./D3Container";
+import { relPath } from "./relPath";
+import type { FileCouplingResult, FilePair } from "@/lib/usage/fileCoupling";
+
+interface Props {
+  result: FileCouplingResult;
+  maxFiles?: number;
+}
+
+export function FileCouplingArc({ result, maxFiles = 25 }: Props) {
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const { pairs } = result;
+
+  // Build top-N file set by total pair strength
+  const fileScore = useMemo(() => {
+    const scores = new Map<string, number>();
+    for (const p of pairs) {
+      scores.set(p.fileA, (scores.get(p.fileA) ?? 0) + p.coOccurrences);
+      scores.set(p.fileB, (scores.get(p.fileB) ?? 0) + p.coOccurrences);
+    }
+    return scores;
+  }, [pairs]);
+
+  const topFiles = useMemo(() => {
+    return [...fileScore.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, maxFiles)
+      .map(([f]) => f);
+  }, [fileScore, maxFiles]);
+
+  const topFileSet = useMemo(() => new Set(topFiles), [topFiles]);
+
+  const visiblePairs = useMemo(
+    () => pairs.filter((p) => topFileSet.has(p.fileA) && topFileSet.has(p.fileB)),
+    [pairs, topFileSet]
+  );
+
+  const maxCoOccurrences = Math.max(...visiblePairs.map((p) => p.coOccurrences), 1);
+  const strokeWidth = d3.scaleLinear().domain([1, maxCoOccurrences]).range([0.5, 4]).clamp(true);
+
+  if (topFiles.length < 4) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>Not enough co-edited file pairs to render arc diagram (need ≥ 4 files).</p>;
+  }
+
+  return (
+    <D3Container
+      height={300}
+      margin={{ top: 8, right: 16, bottom: 80, left: 16 }}
+    >
+      {({ width, height, showTooltip, hideTooltip }) => {
+        const xScale = d3.scalePoint()
+          .domain(topFiles)
+          .range([0, width])
+          .padding(0.5);
+
+        const xPos = (f: string) => xScale(f) ?? 0;
+        const axisY = height - 4;
+
+        return (
+          <g>
+            {/* Arcs */}
+            {visiblePairs.map((p: FilePair) => {
+              const xA = xPos(p.fileA);
+              const xB = xPos(p.fileB);
+              const midX = (xA + xB) / 2;
+              const arcH = Math.min(axisY * 0.9, Math.abs(xB - xA) * 0.45);
+              const isSelected = selectedFile !== null;
+              const isIncident = selectedFile === p.fileA || selectedFile === p.fileB;
+
+              return (
+                <path
+                  key={`${p.fileA}\0${p.fileB}`}
+                  d={`M${xA},${axisY} Q${midX},${axisY - arcH} ${xB},${axisY}`}
+                  fill="none"
+                  stroke="var(--accent)"
+                  strokeWidth={strokeWidth(p.coOccurrences)}
+                  strokeOpacity={isSelected ? (isIncident ? p.strength * 0.9 : 0.05) : p.strength * 0.7}
+                  style={{ cursor: "default", transition: "stroke-opacity 0.15s" }}
+                  onMouseEnter={(e) => {
+                    const r = (e.currentTarget as SVGElement).getBoundingClientRect();
+                    showTooltip(r.left + r.width / 2, r.top - 8,
+                      `${relPath(p.fileA)} ↔ ${relPath(p.fileB)} · ${p.coOccurrences}× · strength ${(p.strength * 100).toFixed(0)}%`);
+                  }}
+                  onMouseLeave={hideTooltip}
+                />
+              );
+            })}
+
+            {/* Axis baseline */}
+            <line x1={0} y1={axisY} x2={width} y2={axisY} stroke="var(--border-default)" strokeWidth={1} />
+
+            {/* File nodes */}
+            {topFiles.map((f) => {
+              const x = xPos(f);
+              const isSelected = selectedFile === f;
+              const label = relPath(f);
+              const truncated = label.length > 22 ? "…" + label.slice(-21) : label;
+
+              return (
+                <g
+                  key={f}
+                  style={{ cursor: "pointer" }}
+                  onClick={() => setSelectedFile(selectedFile === f ? null : f)}
+                >
+                  <circle
+                    cx={x}
+                    cy={axisY}
+                    r={isSelected ? 5 : 4}
+                    fill={isSelected ? "var(--accent)" : "var(--text-secondary)"}
+                    opacity={0.9}
+                  />
+                  <text
+                    x={x}
+                    y={axisY + 8}
+                    textAnchor="end"
+                    dominantBaseline="hanging"
+                    fontSize="0.6rem"
+                    fontFamily="var(--font-mono)"
+                    fill={isSelected ? "var(--text-primary)" : "var(--text-muted)"}
+                    transform={`rotate(-45, ${x}, ${axisY + 8})`}
+                    style={{ pointerEvents: "none" }}
+                  >
+                    {truncated}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        );
+      }}
+    </D3Container>
+  );
+}

--- a/src/components/viz/ModelDelegationFlow.tsx
+++ b/src/components/viz/ModelDelegationFlow.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import * as d3 from "d3";
+import { D3Container } from "./D3Container";
+import { MODEL_FAMILY_COLORS } from "./agentPalette";
+import { modelFamily, shortModelName } from "@/lib/usage/modelHelpers";
+import type { DelegationReport, DelegationEdge } from "@/lib/usage/modelDelegation";
+
+interface Props {
+  sessionId: string;
+}
+
+const NODE_WIDTH = 120;
+const NODE_HEIGHT_MAX = 60;
+const NODE_HEIGHT_MIN = 20;
+
+export function ModelDelegationFlow({ sessionId }: Props) {
+  const [data, setData] = useState<DelegationReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/sessions/${sessionId}/model-delegation`)
+      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
+      .then((d: DelegationReport) => { setData(d); setLoading(false); })
+      .catch((e: string) => { setError(String(e)); setLoading(false); });
+  }, [sessionId]);
+
+  if (loading) {
+    return <div style={{ height: "200px", background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;
+  }
+
+  if (error) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--status-error-text)" }}>{error}</p>;
+  }
+
+  if (!data || data.edges.length === 0) {
+    return <p style={{ fontSize: "0.8rem", color: "var(--text-muted)", textAlign: "center", padding: "32px 0" }}>No model delegation data — session has no cross-model subagent calls.</p>;
+  }
+
+  return <FlowInner data={data} />;
+}
+
+function FlowInner({ data }: { data: DelegationReport }) {
+  const { edges, parentModels, childModels } = data;
+
+  const maxTokens = Math.max(...edges.map((e) => e.tokens), 1);
+  const maxCount = Math.max(...edges.map((e) => e.count), 1);
+
+  // Per-model total tokens (for node height)
+  const parentTotals = new Map<string, number>();
+  const childTotals = new Map<string, number>();
+  for (const e of edges) {
+    parentTotals.set(e.from, (parentTotals.get(e.from) ?? 0) + e.tokens);
+    childTotals.set(e.to, (childTotals.get(e.to) ?? 0) + e.tokens);
+  }
+  const maxParentTokens = Math.max(...[...parentTotals.values()], 1);
+  const maxChildTokens = Math.max(...[...childTotals.values()], 1);
+
+  const nodeHeight = (tokens: number, maxT: number) =>
+    NODE_HEIGHT_MIN + ((tokens / maxT) * (NODE_HEIGHT_MAX - NODE_HEIGHT_MIN));
+
+  const strokeWidth = d3.scaleLinear().domain([1, maxCount]).range([1, 6]).clamp(true);
+  const strokeOpacity = (tokens: number) => 0.3 + (tokens / maxTokens) * 0.65;
+
+  // Vertical layout: evenly spaced
+  const vSpacing = (nodes: string[], totalH: number) => {
+    if (nodes.length === 0) return new Map<string, number>();
+    const step = totalH / nodes.length;
+    return new Map(nodes.map((n, i) => [n, step * i + step / 2]));
+  };
+
+  const TOTAL_HEIGHT = 300;
+  const parentYMap = vSpacing(parentModels, TOTAL_HEIGHT);
+  const childYMap = vSpacing(childModels, TOTAL_HEIGHT);
+
+  return (
+    <D3Container height={TOTAL_HEIGHT + 40} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+      {({ width, showTooltip, hideTooltip }) => {
+        const leftX = 0;
+        const rightX = width - NODE_WIDTH;
+        const midX = width / 2;
+
+        return (
+          <g>
+            {/* Bezier edges */}
+            {edges.map((edge: DelegationEdge, i: number) => {
+              const fromY = parentYMap.get(edge.from) ?? 0;
+              const toY = childYMap.get(edge.to) ?? 0;
+              const color = MODEL_FAMILY_COLORS[modelFamily(edge.from)] ?? "var(--text-muted)";
+              return (
+                <path
+                  key={i}
+                  d={`M${leftX + NODE_WIDTH},${fromY} C${midX},${fromY} ${midX},${toY} ${rightX},${toY}`}
+                  fill="none"
+                  stroke={color}
+                  strokeWidth={strokeWidth(edge.count)}
+                  strokeOpacity={strokeOpacity(edge.tokens)}
+                  style={{ cursor: "default" }}
+                  onMouseEnter={(e) => {
+                    const r = (e.currentTarget as SVGElement).getBoundingClientRect();
+                    showTooltip(r.left + r.width / 2, r.top - 8,
+                      `${shortModelName(edge.from)} → ${shortModelName(edge.to)} · ${edge.count} delegations · ${(edge.tokens / 1000).toFixed(1)}K tokens`);
+                  }}
+                  onMouseLeave={hideTooltip}
+                />
+              );
+            })}
+
+            {/* Parent model nodes */}
+            {parentModels.map((m) => {
+              const y = parentYMap.get(m) ?? 0;
+              const h = nodeHeight(parentTotals.get(m) ?? 0, maxParentTokens);
+              const color = MODEL_FAMILY_COLORS[modelFamily(m)] ?? "var(--text-muted)";
+              return (
+                <g key={`parent-${m}`}>
+                  <rect x={leftX} y={y - h / 2} width={NODE_WIDTH} height={h} rx={4} fill={color} opacity={0.9} />
+                  <text x={leftX + NODE_WIDTH / 2} y={y} textAnchor="middle" dominantBaseline="middle"
+                    fontSize="0.65rem" fontFamily="var(--font-mono)" fill="var(--bg-surface)">
+                    {shortModelName(m)}
+                  </text>
+                </g>
+              );
+            })}
+
+            {/* Child model nodes */}
+            {childModels.map((m) => {
+              const y = childYMap.get(m) ?? 0;
+              const h = nodeHeight(childTotals.get(m) ?? 0, maxChildTokens);
+              const color = MODEL_FAMILY_COLORS[modelFamily(m)] ?? "var(--text-muted)";
+              return (
+                <g key={`child-${m}`}>
+                  <rect x={rightX} y={y - h / 2} width={NODE_WIDTH} height={h} rx={4} fill={color} opacity={0.9} />
+                  <text x={rightX + NODE_WIDTH / 2} y={y} textAnchor="middle" dominantBaseline="middle"
+                    fontSize="0.65rem" fontFamily="var(--font-mono)" fill="var(--bg-surface)">
+                    {shortModelName(m)}
+                  </text>
+                </g>
+              );
+            })}
+
+            {/* Column labels */}
+            <text x={leftX + NODE_WIDTH / 2} y={TOTAL_HEIGHT + 16} textAnchor="middle" fontSize="0.62rem" fontFamily="var(--font-mono)" fill="var(--text-muted)">Primary model</text>
+            <text x={rightX + NODE_WIDTH / 2} y={TOTAL_HEIGHT + 16} textAnchor="middle" fontSize="0.62rem" fontFamily="var(--font-mono)" fill="var(--text-muted)">Subagent model</text>
+          </g>
+        );
+      }}
+    </D3Container>
+  );
+}

--- a/src/components/viz/ModelDelegationFlow.tsx
+++ b/src/components/viz/ModelDelegationFlow.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import * as d3 from "d3";
 import { D3Container } from "./D3Container";
 import { MODEL_FAMILY_COLORS } from "./agentPalette";
 import { modelFamily, shortModelName } from "@/lib/usage/modelHelpers";
+import { useReportFetch } from "@/hooks/useReportFetch";
 import type { DelegationReport, DelegationEdge } from "@/lib/usage/modelDelegation";
 
 interface Props {
@@ -16,17 +16,9 @@ const NODE_HEIGHT_MAX = 60;
 const NODE_HEIGHT_MIN = 20;
 
 export function ModelDelegationFlow({ sessionId }: Props) {
-  const [data, setData] = useState<DelegationReport | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    fetch(`/api/sessions/${sessionId}/model-delegation`)
-      .then((r) => r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error)))
-      .then((d: DelegationReport) => { setData(d); setLoading(false); })
-      .catch((e: string) => { setError(String(e)); setLoading(false); });
-  }, [sessionId]);
+  const { data, loading, error } = useReportFetch<DelegationReport>(
+    `/api/sessions/${sessionId}/model-delegation`
+  );
 
   if (loading) {
     return <div style={{ height: "200px", background: "var(--bg-elevated)", borderRadius: "var(--radius)", animation: "pulse 1.5s ease-in-out infinite" }} />;

--- a/src/components/viz/OrchestrationDAG.tsx
+++ b/src/components/viz/OrchestrationDAG.tsx
@@ -3,22 +3,8 @@
 import { useEffect, useState, useMemo } from "react";
 import * as d3 from "d3";
 import { D3Container } from "./D3Container";
+import { agentColor } from "./agentPalette";
 import type { OrchestrationGraph, OrchNode } from "@/lib/usage/orchestrationGraph";
-
-// 6 desaturated hues cycling for agent names
-const AGENT_COLORS = [
-  "var(--accent)",
-  "var(--info)",
-  "var(--status-active-text)",
-  "var(--status-error-text)",
-  "var(--accent-strong)",
-  "var(--info-strong)",
-];
-
-function agentColor(agentName: string | undefined, index: number): string {
-  if (!agentName) return "var(--text-secondary)";
-  return AGENT_COLORS[index % AGENT_COLORS.length];
-}
 
 // Stateless path generator — created once at module scope
 type TreeNodeData = { id: string; node: OrchNode; children: TreeNodeData[] };

--- a/src/components/viz/agentPalette.ts
+++ b/src/components/viz/agentPalette.ts
@@ -1,0 +1,42 @@
+// Shared 8-color agent palette and depth-color stops for all D3 viz.
+// Colors are CSS variable references so they respond to theme changes.
+
+export const AGENT_COLORS = [
+  "var(--accent)",
+  "var(--info)",
+  "var(--status-active-text)",
+  "var(--status-error-text)",
+  "var(--accent-strong)",
+  "var(--info-strong)",
+  "var(--status-warn-text)",
+  "var(--text-secondary)",
+];
+
+export function agentColor(agentName: string | undefined, index: number): string {
+  if (!agentName) return "var(--text-secondary)";
+  return AGENT_COLORS[index % AGENT_COLORS.length];
+}
+
+// Red → purple gradient stops for hierarchy depth (depth 0 = red, depth 6 = purple)
+export const DEPTH_COLORS = [
+  "var(--status-error-text)",   // depth 0
+  "#e05a44",                    // depth 1
+  "#c45a9e",                    // depth 2
+  "#a455c4",                    // depth 3
+  "#844dd4",                    // depth 4
+  "#6644e0",                    // depth 5
+  "var(--info)",                // depth 6+
+];
+
+export function depthColor(depth: number): string {
+  const idx = Math.min(depth, DEPTH_COLORS.length - 1);
+  return DEPTH_COLORS[idx];
+}
+
+// Family colors for model delegation flow
+export const MODEL_FAMILY_COLORS: Record<string, string> = {
+  opus:   "var(--info-strong)",
+  sonnet: "var(--accent)",
+  haiku:  "var(--status-active-text)",
+  other:  "var(--text-muted)",
+};

--- a/src/components/viz/relPath.ts
+++ b/src/components/viz/relPath.ts
@@ -1,0 +1,12 @@
+/**
+ * Normalize a Windows or POSIX absolute path to a readable relative-style
+ * label. Returns the `src/...` subtree when present, otherwise falls back
+ * to the last path segment.
+ */
+export function relPath(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/");
+  const srcIdx = normalized.indexOf("/src/");
+  if (srcIdx !== -1) return normalized.slice(srcIdx + 1);
+  const lastSlash = normalized.lastIndexOf("/");
+  return lastSlash !== -1 ? normalized.slice(lastSlash + 1) : normalized;
+}

--- a/src/hooks/useReportFetch.ts
+++ b/src/hooks/useReportFetch.ts
@@ -14,21 +14,34 @@ export function useReportFetch<T>(url: string): ReportFetchState<T> {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     setLoading(true);
     setData(null);
     setError(null);
-    fetch(url)
-      .then((r) =>
-        r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error))
-      )
+
+    fetch(url, { signal: controller.signal })
+      .then(async (r) => {
+        if (r.ok) return r.json() as Promise<T>;
+        let msg: string;
+        try {
+          const body = await r.json() as { error?: unknown };
+          msg = typeof body?.error === "string" ? body.error : `HTTP ${r.status}`;
+        } catch {
+          msg = `HTTP ${r.status}`;
+        }
+        throw new Error(msg);
+      })
       .then((d: T) => {
         setData(d);
         setLoading(false);
       })
       .catch((e: unknown) => {
-        setError(String(e));
+        if (controller.signal.aborted) return;
+        setError(e instanceof Error ? e.message : String(e));
         setLoading(false);
       });
+
+    return () => controller.abort();
   }, [url]);
 
   return { data, loading, error };

--- a/src/hooks/useReportFetch.ts
+++ b/src/hooks/useReportFetch.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface ReportFetchState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useReportFetch<T>(url: string): ReportFetchState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setData(null);
+    setError(null);
+    fetch(url)
+      .then((r) =>
+        r.ok ? r.json() : r.json().then((e: { error: string }) => Promise.reject(e.error))
+      )
+      .then((d: T) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        setError(String(e));
+        setLoading(false);
+      });
+  }, [url]);
+
+  return { data, loading, error };
+}

--- a/src/lib/usage/agentNetwork.ts
+++ b/src/lib/usage/agentNetwork.ts
@@ -1,0 +1,110 @@
+import type { UsageTurn } from "./types";
+import { buildGraph } from "./orchestrationGraph";
+
+export interface NetworkNode {
+  id: string;
+  name: string;
+  messageCount: number;
+}
+
+export interface NetworkEdge {
+  from: string;
+  to: string;
+  weight: number;
+}
+
+export interface NetworkReport {
+  nodes: NetworkNode[];
+  edges: NetworkEdge[];
+}
+
+export function buildAgentNetwork(turns: UsageTurn[]): NetworkReport {
+  const graph = buildGraph(turns);
+
+  if (graph.nodes.length === 0) return { nodes: [], edges: [] };
+
+  // Project OrchNode instances by agentName — collapse multiple invocations
+  const nodeCountByName = new Map<string, number>();
+  for (const node of graph.nodes) {
+    const name = node.agentName ?? node.toolName ?? node.id;
+    nodeCountByName.set(name, (nodeCountByName.get(name) ?? 0) + 1);
+  }
+
+  // Count sidechain turns per agentName
+  const agentByToolUseId = new Map<string, string>();
+  for (const turn of turns) {
+    if (turn.isSidechain) continue;
+    for (const tc of turn.toolCalls) {
+      if (tc.name === "Agent" && tc.id) {
+        const name =
+          (tc.arguments?.subagent_type as string | undefined) ??
+          (tc.arguments?.agent as string | undefined);
+        if (name) agentByToolUseId.set(tc.id, name);
+      }
+    }
+  }
+
+  const messageCounts = new Map<string, number>();
+  for (const turn of turns) {
+    if (!turn.isSidechain || !turn.parentToolUseId) continue;
+    const agentName = agentByToolUseId.get(turn.parentToolUseId) ?? "subagent";
+    messageCounts.set(agentName, (messageCounts.get(agentName) ?? 0) + 1);
+  }
+
+  // Build projected node set
+  const nodeNames = new Set<string>();
+  for (const node of graph.nodes) {
+    if (node.id.startsWith("__overflow__")) continue;
+    const name = node.agentName ?? node.toolName ?? node.id;
+    nodeNames.add(name);
+  }
+
+  const MAIN = "main";
+  nodeNames.add(MAIN);
+
+  const nodes: NetworkNode[] = [...nodeNames].map((name) => ({
+    id: name,
+    name,
+    messageCount: messageCounts.get(name) ?? 0,
+  }));
+
+  // Build projected edge set: for each OrchEdge, map nodeIds → agentNames
+  const nodeIdToName = new Map<string, string>();
+  for (const node of graph.nodes) {
+    nodeIdToName.set(node.id, node.agentName ?? node.toolName ?? node.id);
+  }
+
+  const edgeMap = new Map<string, number>();
+
+  // Root nodes → edge from "main"
+  const rootIds = new Set(
+    graph.nodes
+      .filter((n) => !graph.edges.some((e) => e.to === n.id))
+      .map((n) => n.id)
+  );
+  for (const rootId of rootIds) {
+    if (rootId.startsWith("__overflow__")) continue;
+    const childName = nodeIdToName.get(rootId);
+    if (!childName) continue;
+    const key = `${MAIN}\0${childName}`;
+    edgeMap.set(key, (edgeMap.get(key) ?? 0) + 1);
+  }
+
+  // Existing graph edges → map to agent names, drop self-loops
+  for (const edge of graph.edges) {
+    if (edge.from.startsWith("__overflow__") || edge.to.startsWith("__overflow__")) continue;
+    const fromName = nodeIdToName.get(edge.from);
+    const toName = nodeIdToName.get(edge.to);
+    if (!fromName || !toName || fromName === toName) continue;
+    const key = `${fromName}\0${toName}`;
+    edgeMap.set(key, (edgeMap.get(key) ?? 0) + 1);
+  }
+
+  const edges: NetworkEdge[] = [];
+  for (const [key, weight] of edgeMap) {
+    const sep = key.indexOf("\0");
+    edges.push({ from: key.slice(0, sep), to: key.slice(sep + 1), weight });
+  }
+
+  return { nodes, edges };
+}

--- a/src/lib/usage/agentNetwork.ts
+++ b/src/lib/usage/agentNetwork.ts
@@ -23,31 +23,18 @@ export function buildAgentNetwork(turns: UsageTurn[]): NetworkReport {
 
   if (graph.nodes.length === 0) return { nodes: [], edges: [] };
 
-  // Project OrchNode instances by agentName — collapse multiple invocations
-  const nodeCountByName = new Map<string, number>();
+  // Build nodeId → agentName from the graph (covers all depths, including nested subagents)
+  const nodeIdToAgentName = new Map<string, string>();
   for (const node of graph.nodes) {
-    const name = node.agentName ?? node.toolName ?? node.id;
-    nodeCountByName.set(name, (nodeCountByName.get(name) ?? 0) + 1);
+    if (node.id.startsWith("__overflow__")) continue;
+    nodeIdToAgentName.set(node.id, node.agentName ?? node.toolName ?? node.id);
   }
 
-  // Count sidechain turns per agentName
-  const agentByToolUseId = new Map<string, string>();
-  for (const turn of turns) {
-    if (turn.isSidechain) continue;
-    for (const tc of turn.toolCalls) {
-      if (tc.name === "Agent" && tc.id) {
-        const name =
-          (tc.arguments?.subagent_type as string | undefined) ??
-          (tc.arguments?.agent as string | undefined);
-        if (name) agentByToolUseId.set(tc.id, name);
-      }
-    }
-  }
-
+  // Count sidechain turns per agentName using the graph-derived map
   const messageCounts = new Map<string, number>();
   for (const turn of turns) {
     if (!turn.isSidechain || !turn.parentToolUseId) continue;
-    const agentName = agentByToolUseId.get(turn.parentToolUseId) ?? "subagent";
+    const agentName = nodeIdToAgentName.get(turn.parentToolUseId) ?? "subagent";
     messageCounts.set(agentName, (messageCounts.get(agentName) ?? 0) + 1);
   }
 
@@ -69,10 +56,7 @@ export function buildAgentNetwork(turns: UsageTurn[]): NetworkReport {
   }));
 
   // Build projected edge set: for each OrchEdge, map nodeIds → agentNames
-  const nodeIdToName = new Map<string, string>();
-  for (const node of graph.nodes) {
-    nodeIdToName.set(node.id, node.agentName ?? node.toolName ?? node.id);
-  }
+  // (reuse nodeIdToAgentName built above)
 
   const edgeMap = new Map<string, number>();
 
@@ -84,7 +68,7 @@ export function buildAgentNetwork(turns: UsageTurn[]): NetworkReport {
   );
   for (const rootId of rootIds) {
     if (rootId.startsWith("__overflow__")) continue;
-    const childName = nodeIdToName.get(rootId);
+    const childName = nodeIdToAgentName.get(rootId);
     if (!childName) continue;
     const key = `${MAIN}\0${childName}`;
     edgeMap.set(key, (edgeMap.get(key) ?? 0) + 1);
@@ -93,8 +77,8 @@ export function buildAgentNetwork(turns: UsageTurn[]): NetworkReport {
   // Existing graph edges → map to agent names, drop self-loops
   for (const edge of graph.edges) {
     if (edge.from.startsWith("__overflow__") || edge.to.startsWith("__overflow__")) continue;
-    const fromName = nodeIdToName.get(edge.from);
-    const toName = nodeIdToName.get(edge.to);
+    const fromName = nodeIdToAgentName.get(edge.from);
+    const toName = nodeIdToAgentName.get(edge.to);
     if (!fromName || !toName || fromName === toName) continue;
     const key = `${fromName}\0${toName}`;
     edgeMap.set(key, (edgeMap.get(key) ?? 0) + 1);

--- a/src/lib/usage/concurrencyTimeline.ts
+++ b/src/lib/usage/concurrencyTimeline.ts
@@ -15,10 +15,9 @@ export interface TimelineReport {
 }
 
 export function buildConcurrencyTimeline(turns: UsageTurn[]): TimelineReport {
-  // Pass 1: tool_use_id → agentName from main-thread Agent calls
+  // Pass 1: tool_use_id → agentName from all Agent calls (including nested sidechains)
   const agentByToolUseId = new Map<string, string>();
   for (const turn of turns) {
-    if (turn.isSidechain) continue;
     for (const tc of turn.toolCalls) {
       if (tc.name === "Agent" && tc.id) {
         const name =

--- a/src/lib/usage/concurrencyTimeline.ts
+++ b/src/lib/usage/concurrencyTimeline.ts
@@ -40,6 +40,7 @@ export function buildConcurrencyTimeline(turns: UsageTurn[]): TimelineReport {
   }
 
   const groups = new Map<string, Group>();
+  const turnIndex = new Map(turns.map((t, i) => [t, i]));
   const mainTurns = turns.filter((t) => !t.isSidechain);
 
   for (let i = 0; i < turns.length; i++) {
@@ -93,7 +94,6 @@ export function buildConcurrencyTimeline(turns: UsageTurn[]): TimelineReport {
     globalMin = Math.min(mainMinTs, ...allMin);
     globalMax = Math.max(mainMaxTs, ...allMax);
   } else {
-    // Fall back to turn-index proportional positions
     globalMin = 0;
     globalMax = turns.length - 1;
   }
@@ -114,7 +114,7 @@ export function buildConcurrencyTimeline(turns: UsageTurn[]): TimelineReport {
       endPct: pct(mainMaxTs),
     });
   } else {
-    const mainIdxs = mainTurns.map((t) => turns.indexOf(t)).filter((i) => i >= 0);
+    const mainIdxs = mainTurns.map((t) => turnIndex.get(t) ?? -1).filter((i) => i >= 0);
     const minIdx = mainIdxs.length ? Math.min(...mainIdxs) : 0;
     const maxIdx = mainIdxs.length ? Math.max(...mainIdxs) : turns.length - 1;
     bars.push({

--- a/src/lib/usage/concurrencyTimeline.ts
+++ b/src/lib/usage/concurrencyTimeline.ts
@@ -1,0 +1,143 @@
+import type { UsageTurn } from "./types";
+
+export interface TimelineBar {
+  agentName: string;
+  /** toolUseId that spawned this sidechain, or "__main__" */
+  nodeId: string;
+  turnCount: number;
+  startPct: number;
+  endPct: number;
+}
+
+export interface TimelineReport {
+  bars: TimelineBar[];
+  usedFallback: boolean;
+}
+
+export function buildConcurrencyTimeline(turns: UsageTurn[]): TimelineReport {
+  // Pass 1: tool_use_id → agentName from main-thread Agent calls
+  const agentByToolUseId = new Map<string, string>();
+  for (const turn of turns) {
+    if (turn.isSidechain) continue;
+    for (const tc of turn.toolCalls) {
+      if (tc.name === "Agent" && tc.id) {
+        const name =
+          (tc.arguments?.subagent_type as string | undefined) ??
+          (tc.arguments?.agent as string | undefined);
+        if (name) agentByToolUseId.set(tc.id, name);
+      }
+    }
+  }
+
+  // Pass 2: group sidechain turns by parentToolUseId
+  interface Group {
+    agentName: string;
+    turnCount: number;
+    firstTs?: number;
+    lastTs?: number;
+    firstIdx: number;
+    lastIdx: number;
+  }
+
+  const groups = new Map<string, Group>();
+  const mainTurns = turns.filter((t) => !t.isSidechain);
+
+  for (let i = 0; i < turns.length; i++) {
+    const t = turns[i];
+    if (!t.isSidechain || !t.parentToolUseId) continue;
+    const id = t.parentToolUseId;
+    const ts = t.timestamp ? Date.parse(t.timestamp) : NaN;
+    const existing = groups.get(id);
+    if (!existing) {
+      groups.set(id, {
+        agentName: agentByToolUseId.get(id) ?? "subagent",
+        turnCount: 1,
+        firstTs: isNaN(ts) ? undefined : ts,
+        lastTs: isNaN(ts) ? undefined : ts,
+        firstIdx: i,
+        lastIdx: i,
+      });
+    } else {
+      existing.turnCount++;
+      if (!isNaN(ts)) {
+        if (existing.firstTs === undefined || ts < existing.firstTs) existing.firstTs = ts;
+        if (existing.lastTs === undefined || ts > existing.lastTs) existing.lastTs = ts;
+      }
+      if (i > existing.lastIdx) existing.lastIdx = i;
+      if (i < existing.firstIdx) existing.firstIdx = i;
+    }
+  }
+
+  if (groups.size === 0) return { bars: [], usedFallback: false };
+
+  // Main agent bar
+  const mainTs = mainTurns
+    .map((t) => (t.timestamp ? Date.parse(t.timestamp) : NaN))
+    .filter((n) => !isNaN(n));
+  const mainMinTs = mainTs.length ? Math.min(...mainTs) : NaN;
+  const mainMaxTs = mainTs.length ? Math.max(...mainTs) : NaN;
+
+  // Check if we have usable wall-clock timestamps
+  const allHaveTs = [...groups.values()].every(
+    (g) => g.firstTs !== undefined && g.lastTs !== undefined
+  );
+  const useTimestamps = allHaveTs && !isNaN(mainMinTs) && mainMaxTs > mainMinTs;
+  const usedFallback = !useTimestamps;
+
+  let globalMin: number;
+  let globalMax: number;
+
+  if (useTimestamps) {
+    const allMin = [...groups.values()].map((g) => g.firstTs!);
+    const allMax = [...groups.values()].map((g) => g.lastTs!);
+    globalMin = Math.min(mainMinTs, ...allMin);
+    globalMax = Math.max(mainMaxTs, ...allMax);
+  } else {
+    // Fall back to turn-index proportional positions
+    globalMin = 0;
+    globalMax = turns.length - 1;
+  }
+
+  const span = globalMax - globalMin || 1;
+
+  const pct = (v: number) => Math.max(0, Math.min(100, ((v - globalMin) / span) * 100));
+
+  const bars: TimelineBar[] = [];
+
+  // Main bar
+  if (useTimestamps && !isNaN(mainMinTs)) {
+    bars.push({
+      agentName: "main",
+      nodeId: "__main__",
+      turnCount: mainTurns.length,
+      startPct: pct(mainMinTs),
+      endPct: pct(mainMaxTs),
+    });
+  } else {
+    const mainIdxs = mainTurns.map((t) => turns.indexOf(t)).filter((i) => i >= 0);
+    const minIdx = mainIdxs.length ? Math.min(...mainIdxs) : 0;
+    const maxIdx = mainIdxs.length ? Math.max(...mainIdxs) : turns.length - 1;
+    bars.push({
+      agentName: "main",
+      nodeId: "__main__",
+      turnCount: mainTurns.length,
+      startPct: pct(minIdx),
+      endPct: pct(maxIdx),
+    });
+  }
+
+  // Sidechain bars
+  for (const [id, g] of groups) {
+    const startV = useTimestamps ? g.firstTs! : g.firstIdx;
+    const endV = useTimestamps ? g.lastTs! : g.lastIdx;
+    bars.push({
+      agentName: g.agentName,
+      nodeId: id,
+      turnCount: g.turnCount,
+      startPct: pct(startV),
+      endPct: pct(endV),
+    });
+  }
+
+  return { bars, usedFallback };
+}

--- a/src/lib/usage/errorPropagation.ts
+++ b/src/lib/usage/errorPropagation.ts
@@ -1,0 +1,160 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { parseSessionTurns } from "./parser";
+import { buildGraph } from "./orchestrationGraph";
+import { encodeProjectPath } from "./projectMatch";
+
+export interface DepthBucket {
+  depth: number;
+  errors: number;
+  total: number;
+  rate: number;
+}
+
+export interface AgentErrorStats {
+  name: string;
+  errors: number;
+  total: number;
+  rate: number;
+}
+
+export interface ToolErrorStats {
+  tool: string;
+  errors: number;
+  total: number;
+}
+
+export interface ErrorReport {
+  summary: {
+    totalNodes: number;
+    totalErrors: number;
+    errorRate: number;
+    sessionCount: number;
+  };
+  byDepth: DepthBucket[];
+  topAgents: AgentErrorStats[];
+  byTool: ToolErrorStats[];
+}
+
+export async function buildErrorPropagation(
+  projectPath: string
+): Promise<ErrorReport> {
+  const projectDirName = encodeProjectPath(projectPath);
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const projectDir = path.join(projectsDir, projectDirName);
+
+  let files: string[] = [];
+  try {
+    const entries = await fs.readdir(projectDir);
+    files = entries
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => path.join(projectDir, f));
+  } catch {
+    return emptyReport();
+  }
+
+  if (files.length === 0) return emptyReport();
+
+  const depthErrors = new Map<number, { errors: number; total: number }>();
+  const agentErrors = new Map<string, { errors: number; total: number }>();
+  const toolErrors = new Map<string, { errors: number; total: number }>();
+  let sessionCount = 0;
+
+  for (const filePath of files) {
+    try {
+      const turns = await parseSessionTurns(filePath, projectDirName, {
+        includeSidechains: true,
+      });
+      if (turns.length === 0) continue;
+      sessionCount++;
+
+      const graph = buildGraph(turns);
+
+      for (const node of graph.nodes) {
+        if (node.id.startsWith("__overflow__")) continue;
+        const depth = node.depth;
+
+        const bucket = depthErrors.get(depth) ?? { errors: 0, total: 0 };
+        bucket.total++;
+        if (node.status === "error") bucket.errors++;
+        depthErrors.set(depth, bucket);
+
+        const agentName = node.agentName ?? "unknown";
+        const aBucket = agentErrors.get(agentName) ?? { errors: 0, total: 0 };
+        aBucket.total++;
+        if (node.status === "error") aBucket.errors++;
+        agentErrors.set(agentName, aBucket);
+      }
+
+      // Tool error breakdown from sidechain turns
+      for (const turn of turns) {
+        if (!turn.isSidechain) continue;
+        for (const tc of turn.toolCalls) {
+          const tBucket = toolErrors.get(tc.name) ?? { errors: 0, total: 0 };
+          tBucket.total++;
+          toolErrors.set(tc.name, tBucket);
+        }
+        // Count tool_result errors — isError flag on the turn level
+        if (turn.isError) {
+          for (const tc of turn.toolCalls) {
+            const tBucket = toolErrors.get(tc.name)!;
+            if (tBucket) tBucket.errors++;
+          }
+        }
+      }
+    } catch {
+      // Skip unreadable sessions
+    }
+  }
+
+  const byDepth: DepthBucket[] = [...depthErrors.entries()]
+    .map(([depth, { errors, total }]) => ({
+      depth,
+      errors,
+      total,
+      rate: total > 0 ? errors / total : 0,
+    }))
+    .sort((a, b) => a.depth - b.depth);
+
+  const topAgents: AgentErrorStats[] = [...agentErrors.entries()]
+    .filter(([, { total }]) => total >= 3)
+    .map(([name, { errors, total }]) => ({
+      name,
+      errors,
+      total,
+      rate: total > 0 ? errors / total : 0,
+    }))
+    .sort((a, b) => b.errors - a.errors)
+    .slice(0, 10);
+
+  const byTool: ToolErrorStats[] = [...toolErrors.entries()]
+    .filter(([, { total }]) => total >= 2)
+    .map(([tool, { errors, total }]) => ({ tool, errors, total }))
+    .sort((a, b) => b.errors - a.errors)
+    .slice(0, 15);
+
+  const totalNodes = byDepth.reduce((s, d) => s + d.total, 0);
+  const totalErrors = byDepth.reduce((s, d) => s + d.errors, 0);
+
+  return {
+    summary: {
+      totalNodes,
+      totalErrors,
+      errorRate: totalNodes > 0 ? totalErrors / totalNodes : 0,
+      sessionCount,
+    },
+    byDepth,
+    topAgents,
+    byTool,
+  };
+}
+
+function emptyReport(): ErrorReport {
+  return {
+    summary: { totalNodes: 0, totalErrors: 0, errorRate: 0, sessionCount: 0 },
+    byDepth: [],
+    topAgents: [],
+    byTool: [],
+  };
+}

--- a/src/lib/usage/errorPropagation.ts
+++ b/src/lib/usage/errorPropagation.ts
@@ -61,51 +61,54 @@ export async function buildErrorPropagation(
   const toolErrors = new Map<string, { errors: number; total: number }>();
   let sessionCount = 0;
 
-  for (const filePath of files) {
-    try {
-      const turns = await parseSessionTurns(filePath, projectDirName, {
-        includeSidechains: true,
-      });
-      if (turns.length === 0) continue;
-      sessionCount++;
+  const BATCH = 10;
+  for (let i = 0; i < files.length; i += BATCH) {
+    await Promise.all(
+      files.slice(i, i + BATCH).map(async (filePath) => {
+        try {
+          const turns = await parseSessionTurns(filePath, projectDirName, {
+            includeSidechains: true,
+          });
+          if (turns.length === 0) return;
+          sessionCount++;
 
-      const graph = buildGraph(turns);
+          const graph = buildGraph(turns);
 
-      for (const node of graph.nodes) {
-        if (node.id.startsWith("__overflow__")) continue;
-        const depth = node.depth;
+          for (const node of graph.nodes) {
+            if (node.id.startsWith("__overflow__")) continue;
+            const depth = node.depth;
 
-        const bucket = depthErrors.get(depth) ?? { errors: 0, total: 0 };
-        bucket.total++;
-        if (node.status === "error") bucket.errors++;
-        depthErrors.set(depth, bucket);
+            const bucket = depthErrors.get(depth) ?? { errors: 0, total: 0 };
+            bucket.total++;
+            if (node.status === "error") bucket.errors++;
+            depthErrors.set(depth, bucket);
 
-        const agentName = node.agentName ?? "unknown";
-        const aBucket = agentErrors.get(agentName) ?? { errors: 0, total: 0 };
-        aBucket.total++;
-        if (node.status === "error") aBucket.errors++;
-        agentErrors.set(agentName, aBucket);
-      }
-
-      // Tool error breakdown from sidechain turns
-      for (const turn of turns) {
-        if (!turn.isSidechain) continue;
-        for (const tc of turn.toolCalls) {
-          const tBucket = toolErrors.get(tc.name) ?? { errors: 0, total: 0 };
-          tBucket.total++;
-          toolErrors.set(tc.name, tBucket);
-        }
-        // Count tool_result errors — isError flag on the turn level
-        if (turn.isError) {
-          for (const tc of turn.toolCalls) {
-            const tBucket = toolErrors.get(tc.name)!;
-            if (tBucket) tBucket.errors++;
+            const agentName = node.agentName ?? "unknown";
+            const aBucket = agentErrors.get(agentName) ?? { errors: 0, total: 0 };
+            aBucket.total++;
+            if (node.status === "error") aBucket.errors++;
+            agentErrors.set(agentName, aBucket);
           }
+
+          for (const turn of turns) {
+            if (!turn.isSidechain) continue;
+            for (const tc of turn.toolCalls) {
+              const tBucket = toolErrors.get(tc.name) ?? { errors: 0, total: 0 };
+              tBucket.total++;
+              toolErrors.set(tc.name, tBucket);
+            }
+            if (turn.isError) {
+              for (const tc of turn.toolCalls) {
+                const tBucket = toolErrors.get(tc.name)!;
+                if (tBucket) tBucket.errors++;
+              }
+            }
+          }
+        } catch {
+          // Skip unreadable sessions
         }
-      }
-    } catch {
-      // Skip unreadable sessions
-    }
+      })
+    );
   }
 
   const byDepth: DepthBucket[] = [...depthErrors.entries()]

--- a/src/lib/usage/modelDelegation.ts
+++ b/src/lib/usage/modelDelegation.ts
@@ -14,10 +14,9 @@ export interface DelegationReport {
 }
 
 export function buildModelDelegation(turns: UsageTurn[]): DelegationReport {
-  // Pass 1: tool_use_id → model of the main-thread assistant turn that called Agent
+  // Pass 1: tool_use_id → model of the assistant turn that called Agent (all depths)
   const modelByToolUseId = new Map<string, string>();
   for (const turn of turns) {
-    if (turn.isSidechain) continue;
     if (turn.role !== "assistant") continue;
     for (const tc of turn.toolCalls) {
       if (tc.name === "Agent" && tc.id) {

--- a/src/lib/usage/modelDelegation.ts
+++ b/src/lib/usage/modelDelegation.ts
@@ -1,0 +1,69 @@
+import type { UsageTurn } from "./types";
+
+export interface DelegationEdge {
+  from: string;
+  to: string;
+  count: number;
+  tokens: number;
+}
+
+export interface DelegationReport {
+  edges: DelegationEdge[];
+  parentModels: string[];
+  childModels: string[];
+}
+
+export function buildModelDelegation(turns: UsageTurn[]): DelegationReport {
+  // Pass 1: tool_use_id → model of the main-thread assistant turn that called Agent
+  const modelByToolUseId = new Map<string, string>();
+  for (const turn of turns) {
+    if (turn.isSidechain) continue;
+    if (turn.role !== "assistant") continue;
+    for (const tc of turn.toolCalls) {
+      if (tc.name === "Agent" && tc.id) {
+        modelByToolUseId.set(tc.id, turn.model ?? "unknown");
+      }
+    }
+  }
+
+  // Pass 2: for each sidechain turn, find parent model via parentToolUseId
+  // Accumulate (parentModel, childModel) → { count, tokens }
+  const edgeMap = new Map<string, { count: number; tokens: number }>();
+
+  for (const turn of turns) {
+    if (!turn.isSidechain || !turn.parentToolUseId) continue;
+    const parentModel = modelByToolUseId.get(turn.parentToolUseId);
+    if (!parentModel) continue;
+    const childModel = turn.model ?? "unknown";
+    const key = `${parentModel}\0${childModel}`;
+    const existing = edgeMap.get(key);
+    const tokens = (turn.inputTokens ?? 0) + (turn.outputTokens ?? 0);
+    if (existing) {
+      existing.count++;
+      existing.tokens += tokens;
+    } else {
+      edgeMap.set(key, { count: 1, tokens });
+    }
+  }
+
+  const edges: DelegationEdge[] = [];
+  const parentSet = new Set<string>();
+  const childSet = new Set<string>();
+
+  for (const [key, { count, tokens }] of edgeMap) {
+    const sep = key.indexOf("\0");
+    const from = key.slice(0, sep);
+    const to = key.slice(sep + 1);
+    edges.push({ from, to, count, tokens });
+    parentSet.add(from);
+    childSet.add(to);
+  }
+
+  edges.sort((a, b) => b.count - a.count);
+
+  return {
+    edges,
+    parentModels: [...parentSet],
+    childModels: [...childSet],
+  };
+}

--- a/src/lib/usage/modelHelpers.ts
+++ b/src/lib/usage/modelHelpers.ts
@@ -1,0 +1,18 @@
+export type ModelFamily = "opus" | "sonnet" | "haiku" | "other";
+
+export function modelFamily(model: string | undefined | null): ModelFamily {
+  if (!model) return "other";
+  const lower = model.toLowerCase();
+  if (lower.includes("opus")) return "opus";
+  if (lower.includes("sonnet")) return "sonnet";
+  if (lower.includes("haiku")) return "haiku";
+  return "other";
+}
+
+/** Strip `claude-` prefix and trailing `-YYYYMMDD` build tag. */
+export function shortModelName(model: string | undefined | null): string {
+  if (!model) return "unknown";
+  let s = model.replace(/^claude-/i, "");
+  s = s.replace(/-\d{8}$/, "");
+  return s;
+}

--- a/src/lib/usage/orchestrationGraph.ts
+++ b/src/lib/usage/orchestrationGraph.ts
@@ -1,7 +1,4 @@
-import { promises as fs } from "fs";
-import path from "path";
-import os from "os";
-import { parseSessionTurns, isValidSessionId } from "./parser";
+import { findSessionFile, parseSessionTurns } from "./parser";
 import type { UsageTurn } from "./types";
 
 export interface OrchNode {
@@ -183,32 +180,8 @@ export function buildGraph(turns: UsageTurn[]): OrchestrationGraph {
 export async function loadOrchestrationGraph(
   sessionId: string
 ): Promise<OrchestrationGraph | null> {
-  if (!isValidSessionId(sessionId)) return null;
-
-  const projectsDir = path.join(os.homedir(), ".claude", "projects");
-
-  let filePath: string | null = null;
-  let projectDirName = "";
-
-  try {
-    const dirs = await fs.readdir(projectsDir);
-    for (const dir of dirs) {
-      const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
-      try {
-        await fs.access(candidate);
-        filePath = candidate;
-        projectDirName = dir;
-        break;
-      } catch {
-        // not here
-      }
-    }
-  } catch {
-    return null;
-  }
-
-  if (!filePath) return null;
-
-  const turns = await parseSessionTurns(filePath, projectDirName, { includeSidechains: true });
+  const found = await findSessionFile(sessionId);
+  if (!found) return null;
+  const turns = await parseSessionTurns(found.filePath, found.projectDirName, { includeSidechains: true });
   return buildGraph(turns);
 }

--- a/src/lib/usage/parser.ts
+++ b/src/lib/usage/parser.ts
@@ -586,8 +586,9 @@ export async function findSessionFile(
   try {
     const entries = await fs.readdir(projectsDir, { withFileTypes: true });
     dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
-  } catch {
-    return null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw err;
   }
   for (const dir of dirs) {
     const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);

--- a/src/lib/usage/parser.ts
+++ b/src/lib/usage/parser.ts
@@ -571,6 +571,37 @@ export async function loadSessionTurnsBySessionId(
 }
 
 /**
+ * Locate the JSONL file for a session across all `~/.claude/projects/` subdirs.
+ * Returns `{ filePath, projectDirName }` when found, or `null` when not found.
+ * Used by session-detail API routes that need to call `parseSessionTurns` with
+ * custom options (e.g. `{ includeSidechains: true }`) before the higher-level
+ * `loadSessionTurnsBySessionId` helper applies its own defaults.
+ */
+export async function findSessionFile(
+  sessionId: string
+): Promise<{ filePath: string; projectDirName: string } | null> {
+  if (!isValidSessionId(sessionId)) return null;
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  let dirs: string[];
+  try {
+    const entries = await fs.readdir(projectsDir, { withFileTypes: true });
+    dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch {
+    return null;
+  }
+  for (const dir of dirs) {
+    const candidate = path.join(projectsDir, dir, `${sessionId}.jsonl`);
+    try {
+      await fs.access(candidate);
+      return { filePath: candidate, projectDirName: dir };
+    } catch {
+      // not in this dir
+    }
+  }
+  return null;
+}
+
+/**
  * Like `loadSessionTurnsBySessionId` but also returns the `SessionTurnsMeta`
  * (compact boundaries, CLI version, thinking flag) needed by the diagnosis
  * route's `extras` parameter. Returns `null` when the session id can't be

--- a/tests/agentNetwork.test.ts
+++ b/tests/agentNetwork.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { buildAgentNetwork } from "@/lib/usage/agentNetwork";
+import type { UsageTurn } from "@/lib/usage/types";
+
+function makeTurn(overrides: Partial<UsageTurn>): UsageTurn {
+  return {
+    timestamp: new Date().toISOString(),
+    sessionId: "sess1",
+    projectSlug: "proj",
+    projectDirName: "proj",
+    model: "claude-sonnet-4-6",
+    role: "assistant",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    toolCalls: [],
+    ...overrides,
+  };
+}
+
+describe("buildAgentNetwork", () => {
+  it("returns empty report when no sidechains", () => {
+    const turns = [makeTurn({ role: "user" }), makeTurn({})];
+    const result = buildAgentNetwork(turns);
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it("produces main node + 1 agent node for single subagent", () => {
+    const toolUseId = "net-001";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        toolCalls: [{ name: "Agent", id: toolUseId, arguments: { subagent_type: "code-reviewer" } }],
+      }),
+      makeTurn({ isSidechain: true, parentToolUseId: toolUseId }),
+      makeTurn({ isSidechain: true, parentToolUseId: toolUseId }),
+    ];
+
+    const result = buildAgentNetwork(turns);
+    expect(result.nodes.some((n) => n.id === "main")).toBe(true);
+    expect(result.nodes.some((n) => n.id === "code-reviewer")).toBe(true);
+
+    const agentNode = result.nodes.find((n) => n.id === "code-reviewer")!;
+    expect(agentNode.messageCount).toBe(2);
+
+    const edge = result.edges.find((e) => e.from === "main" && e.to === "code-reviewer");
+    expect(edge).toBeDefined();
+  });
+
+  it("collapses multiple invocations of same agent into one node", () => {
+    const id1 = "net-002";
+    const id2 = "net-003";
+    const turns = [
+      makeTurn({ role: "assistant", toolCalls: [{ name: "Agent", id: id1, arguments: { subagent_type: "helper" } }] }),
+      makeTurn({ isSidechain: true, parentToolUseId: id1 }),
+      makeTurn({ role: "assistant", toolCalls: [{ name: "Agent", id: id2, arguments: { subagent_type: "helper" } }] }),
+      makeTurn({ isSidechain: true, parentToolUseId: id2 }),
+    ];
+
+    const result = buildAgentNetwork(turns);
+    const helperNodes = result.nodes.filter((n) => n.id === "helper");
+    expect(helperNodes).toHaveLength(1);
+    expect(helperNodes[0].messageCount).toBe(2);
+  });
+
+  it("does not produce self-edges from same agent to same agent", () => {
+    const id1 = "net-004";
+    const turns = [
+      makeTurn({ role: "assistant", toolCalls: [{ name: "Agent", id: id1, arguments: { subagent_type: "planner" } }] }),
+      makeTurn({ isSidechain: true, parentToolUseId: id1 }),
+    ];
+
+    const result = buildAgentNetwork(turns);
+    const selfEdges = result.edges.filter((e) => e.from === e.to);
+    expect(selfEdges).toHaveLength(0);
+  });
+
+  it("produces edge from main to each root-level agent", () => {
+    const id1 = "net-005";
+    const id2 = "net-006";
+    const turns = [
+      makeTurn({ role: "assistant", toolCalls: [
+        { name: "Agent", id: id1, arguments: { subagent_type: "agent-A" } },
+        { name: "Agent", id: id2, arguments: { subagent_type: "agent-B" } },
+      ]}),
+      makeTurn({ isSidechain: true, parentToolUseId: id1 }),
+      makeTurn({ isSidechain: true, parentToolUseId: id2 }),
+    ];
+
+    const result = buildAgentNetwork(turns);
+    expect(result.edges.some((e) => e.from === "main" && e.to === "agent-A")).toBe(true);
+    expect(result.edges.some((e) => e.from === "main" && e.to === "agent-B")).toBe(true);
+  });
+});

--- a/tests/concurrencyTimeline.test.ts
+++ b/tests/concurrencyTimeline.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { buildConcurrencyTimeline } from "@/lib/usage/concurrencyTimeline";
+import type { UsageTurn } from "@/lib/usage/types";
+
+function makeTurn(overrides: Partial<UsageTurn>): UsageTurn {
+  return {
+    timestamp: new Date().toISOString(),
+    sessionId: "sess1",
+    projectSlug: "proj",
+    projectDirName: "proj",
+    model: "claude-sonnet-4-6",
+    role: "assistant",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    toolCalls: [],
+    ...overrides,
+  };
+}
+
+describe("buildConcurrencyTimeline", () => {
+  it("returns empty bars for session with no subagents", () => {
+    const turns = [
+      makeTurn({ role: "user" }),
+      makeTurn({ role: "assistant" }),
+    ];
+    const result = buildConcurrencyTimeline(turns);
+    expect(result.bars).toHaveLength(0);
+  });
+
+  it("produces main bar + one subagent bar for single sidechain", () => {
+    const agentToolUseId = "tool-001";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        toolCalls: [{ name: "Agent", id: agentToolUseId, arguments: { subagent_type: "code-reviewer" } }],
+        timestamp: "2026-01-01T10:00:00.000Z",
+      }),
+      makeTurn({
+        isSidechain: true,
+        parentToolUseId: agentToolUseId,
+        timestamp: "2026-01-01T10:01:00.000Z",
+      }),
+      makeTurn({
+        isSidechain: true,
+        parentToolUseId: agentToolUseId,
+        timestamp: "2026-01-01T10:02:00.000Z",
+      }),
+    ];
+
+    const result = buildConcurrencyTimeline(turns);
+    expect(result.bars.length).toBe(2);
+
+    const mainBar = result.bars.find((b) => b.nodeId === "__main__");
+    expect(mainBar).toBeDefined();
+    expect(mainBar!.agentName).toBe("main");
+
+    const agentBar = result.bars.find((b) => b.nodeId === agentToolUseId);
+    expect(agentBar).toBeDefined();
+    expect(agentBar!.agentName).toBe("code-reviewer");
+    expect(agentBar!.turnCount).toBe(2);
+  });
+
+  it("uses JSONL fallback when timestamps are missing", () => {
+    const agentToolUseId = "tool-002";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        toolCalls: [{ name: "Agent", id: agentToolUseId, arguments: { subagent_type: "explore" } }],
+        timestamp: "",
+      }),
+      makeTurn({ isSidechain: true, parentToolUseId: agentToolUseId, timestamp: "" }),
+    ];
+
+    const result = buildConcurrencyTimeline(turns);
+    expect(result.usedFallback).toBe(true);
+    expect(result.bars.length).toBeGreaterThan(0);
+  });
+
+  it("handles parallel subagents and produces correct bar count", () => {
+    const id1 = "tool-p1";
+    const id2 = "tool-p2";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        toolCalls: [
+          { name: "Agent", id: id1, arguments: { subagent_type: "agent-A" } },
+          { name: "Agent", id: id2, arguments: { subagent_type: "agent-B" } },
+        ],
+        timestamp: "2026-01-01T10:00:00.000Z",
+      }),
+      makeTurn({ isSidechain: true, parentToolUseId: id1, timestamp: "2026-01-01T10:01:00.000Z" }),
+      makeTurn({ isSidechain: true, parentToolUseId: id2, timestamp: "2026-01-01T10:01:30.000Z" }),
+      makeTurn({ timestamp: "2026-01-01T10:03:00.000Z" }),
+    ];
+
+    const result = buildConcurrencyTimeline(turns);
+    // main + 2 sidechains
+    expect(result.bars.length).toBe(3);
+  });
+
+  it("orphan sidechain (no parent in agentByToolUseId) gets generic name", () => {
+    const turns = [
+      makeTurn({ isSidechain: true, parentToolUseId: "orphan-id", timestamp: "2026-01-01T10:00:00.000Z" }),
+    ];
+    const result = buildConcurrencyTimeline(turns);
+    const orphan = result.bars.find((b) => b.nodeId === "orphan-id");
+    expect(orphan).toBeDefined();
+    expect(orphan!.agentName).toBe("subagent");
+  });
+
+  it("virtual main bar covers full session span", () => {
+    const id1 = "tool-m1";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        toolCalls: [{ name: "Agent", id: id1, arguments: { subagent_type: "helper" } }],
+        timestamp: "2026-01-01T10:00:00.000Z",
+      }),
+      makeTurn({ isSidechain: true, parentToolUseId: id1, timestamp: "2026-01-01T10:05:00.000Z" }),
+      makeTurn({ timestamp: "2026-01-01T10:10:00.000Z" }),
+    ];
+
+    const result = buildConcurrencyTimeline(turns);
+    const mainBar = result.bars.find((b) => b.nodeId === "__main__");
+    expect(mainBar).toBeDefined();
+    expect(mainBar!.startPct).toBeCloseTo(0, 0);
+    expect(mainBar!.endPct).toBeCloseTo(100, 0);
+  });
+});

--- a/tests/errorPropagation.test.ts
+++ b/tests/errorPropagation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+
+// We test the pure buildErrorPropagation logic indirectly by testing the
+// underlying buildGraph + depth accumulation logic, since the full function
+// requires real JSONL files. We verify the aggregation logic directly by
+// constructing mock graph data paths via unit-level assertions.
+
+// Direct unit test for the error-tallying in buildGraph output consumed by buildErrorPropagation
+import { buildGraph } from "@/lib/usage/orchestrationGraph";
+import type { UsageTurn } from "@/lib/usage/types";
+
+function makeTurn(overrides: Partial<UsageTurn>): UsageTurn {
+  return {
+    timestamp: new Date().toISOString(),
+    sessionId: "sess1",
+    projectSlug: "proj",
+    projectDirName: "proj",
+    model: "claude-sonnet-4-6",
+    role: "assistant",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    toolCalls: [],
+    ...overrides,
+  };
+}
+
+describe("error propagation data layer (via buildGraph)", () => {
+  it("correctly marks error nodes", () => {
+    const toolUseId = "err-001";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        toolCalls: [{ name: "Agent", id: toolUseId, arguments: { subagent_type: "coder" } }],
+      }),
+      makeTurn({
+        isSidechain: true,
+        parentToolUseId: toolUseId,
+        isError: true,
+      }),
+    ];
+
+    const graph = buildGraph(turns);
+    const node = graph.nodes.find((n) => n.id === toolUseId);
+    expect(node).toBeDefined();
+    expect(node!.status).toBe("error");
+  });
+
+  it("depth 0 = root agents", () => {
+    const id1 = "err-002";
+    const turns = [
+      makeTurn({ role: "assistant", toolCalls: [{ name: "Agent", id: id1, arguments: { subagent_type: "root-agent" } }] }),
+      makeTurn({ isSidechain: true, parentToolUseId: id1 }),
+    ];
+
+    const graph = buildGraph(turns);
+    const rootNode = graph.nodes.find((n) => n.id === id1);
+    expect(rootNode!.depth).toBe(0);
+  });
+
+  it("nested agent gets depth 1", () => {
+    const parentId = "err-003";
+    const childId = "err-004";
+    const turns = [
+      // Main spawns parent
+      makeTurn({ role: "assistant", toolCalls: [{ name: "Agent", id: parentId, arguments: { subagent_type: "parent" } }] }),
+      // Parent sidechain turn that spawns child
+      makeTurn({
+        isSidechain: true,
+        parentToolUseId: parentId,
+        toolCalls: [{ name: "Agent", id: childId, arguments: { subagent_type: "child" } }],
+      }),
+      // Child sidechain turn
+      makeTurn({ isSidechain: true, parentToolUseId: childId }),
+    ];
+
+    const graph = buildGraph(turns);
+    const parentNode = graph.nodes.find((n) => n.id === parentId);
+    const childNode = graph.nodes.find((n) => n.id === childId);
+    expect(parentNode!.depth).toBe(0);
+    expect(childNode!.depth).toBe(1);
+  });
+
+  it("multiple sessions produce independent graphs (no cross-contamination)", () => {
+    const id1 = "err-005";
+    const id2 = "err-006";
+
+    const turns1 = [
+      makeTurn({ sessionId: "s1", role: "assistant", toolCalls: [{ name: "Agent", id: id1, arguments: { subagent_type: "agent1" } }] }),
+      makeTurn({ sessionId: "s1", isSidechain: true, parentToolUseId: id1 }),
+    ];
+    const turns2 = [
+      makeTurn({ sessionId: "s2", role: "assistant", toolCalls: [{ name: "Agent", id: id2, arguments: { subagent_type: "agent2" } }] }),
+      makeTurn({ sessionId: "s2", isSidechain: true, parentToolUseId: id2 }),
+    ];
+
+    const g1 = buildGraph(turns1);
+    const g2 = buildGraph(turns2);
+
+    expect(g1.nodes.every((n) => n.id !== id2)).toBe(true);
+    expect(g2.nodes.every((n) => n.id !== id1)).toBe(true);
+  });
+});

--- a/tests/modelDelegation.test.ts
+++ b/tests/modelDelegation.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { buildModelDelegation } from "@/lib/usage/modelDelegation";
+import type { UsageTurn } from "@/lib/usage/types";
+
+function makeTurn(overrides: Partial<UsageTurn>): UsageTurn {
+  return {
+    timestamp: new Date().toISOString(),
+    sessionId: "sess1",
+    projectSlug: "proj",
+    projectDirName: "proj",
+    model: "claude-sonnet-4-6",
+    role: "assistant",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    toolCalls: [],
+    ...overrides,
+  };
+}
+
+describe("buildModelDelegation", () => {
+  it("returns empty report when no sidechains", () => {
+    const turns = [makeTurn({ role: "user" }), makeTurn({})];
+    const result = buildModelDelegation(turns);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it("produces single edge for one delegation", () => {
+    const toolUseId = "tuid-001";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        model: "claude-opus-4-7",
+        toolCalls: [{ name: "Agent", id: toolUseId, arguments: { subagent_type: "coder" } }],
+      }),
+      makeTurn({
+        isSidechain: true,
+        parentToolUseId: toolUseId,
+        model: "claude-haiku-4-5",
+        inputTokens: 200,
+        outputTokens: 100,
+      }),
+    ];
+
+    const result = buildModelDelegation(turns);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].from).toBe("claude-opus-4-7");
+    expect(result.edges[0].to).toBe("claude-haiku-4-5");
+    expect(result.edges[0].count).toBe(1);
+    expect(result.edges[0].tokens).toBe(300);
+    expect(result.parentModels).toContain("claude-opus-4-7");
+    expect(result.childModels).toContain("claude-haiku-4-5");
+  });
+
+  it("aggregates multiple sidechain turns on same edge", () => {
+    const toolUseId = "tuid-002";
+    const turns = [
+      makeTurn({
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        toolCalls: [{ name: "Agent", id: toolUseId, arguments: { subagent_type: "helper" } }],
+      }),
+      makeTurn({ isSidechain: true, parentToolUseId: toolUseId, model: "claude-haiku-4-5", inputTokens: 50, outputTokens: 25 }),
+      makeTurn({ isSidechain: true, parentToolUseId: toolUseId, model: "claude-haiku-4-5", inputTokens: 50, outputTokens: 25 }),
+    ];
+
+    const result = buildModelDelegation(turns);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].count).toBe(2);
+    expect(result.edges[0].tokens).toBe(150);
+  });
+
+  it("produces multiple edges for different delegations", () => {
+    const id1 = "tuid-003";
+    const id2 = "tuid-004";
+    const turns = [
+      makeTurn({ role: "assistant", model: "claude-opus-4-7", toolCalls: [{ name: "Agent", id: id1, arguments: { subagent_type: "a" } }] }),
+      makeTurn({ isSidechain: true, parentToolUseId: id1, model: "claude-haiku-4-5" }),
+      makeTurn({ role: "assistant", model: "claude-opus-4-7", toolCalls: [{ name: "Agent", id: id2, arguments: { subagent_type: "b" } }] }),
+      makeTurn({ isSidechain: true, parentToolUseId: id2, model: "claude-sonnet-4-6" }),
+    ];
+
+    const result = buildModelDelegation(turns);
+    expect(result.edges).toHaveLength(2);
+  });
+
+  it("ignores sidechain turns with no matching parent", () => {
+    const turns = [
+      makeTurn({ isSidechain: true, parentToolUseId: "missing-id", model: "claude-haiku-4-5" }),
+    ];
+    const result = buildModelDelegation(turns);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it("handles same-model self-delegation", () => {
+    const toolUseId = "tuid-self";
+    const turns = [
+      makeTurn({ role: "assistant", model: "claude-opus-4-7", toolCalls: [{ name: "Agent", id: toolUseId, arguments: { subagent_type: "sub" } }] }),
+      makeTurn({ isSidechain: true, parentToolUseId: toolUseId, model: "claude-opus-4-7" }),
+    ];
+    const result = buildModelDelegation(turns);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].from).toBe(result.edges[0].to);
+  });
+});

--- a/tests/modelHelpers.test.ts
+++ b/tests/modelHelpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { modelFamily, shortModelName } from "@/lib/usage/modelHelpers";
+
+describe("modelFamily", () => {
+  it("identifies opus", () => {
+    expect(modelFamily("claude-opus-4-7")).toBe("opus");
+    expect(modelFamily("claude-opus-4-7-20250514")).toBe("opus");
+  });
+
+  it("identifies sonnet", () => {
+    expect(modelFamily("claude-sonnet-4-6")).toBe("sonnet");
+    expect(modelFamily("claude-sonnet-3-5-20241022")).toBe("sonnet");
+  });
+
+  it("identifies haiku", () => {
+    expect(modelFamily("claude-haiku-4-5-20251001")).toBe("haiku");
+  });
+
+  it("falls back to other for unknown", () => {
+    expect(modelFamily("gpt-4o")).toBe("other");
+    expect(modelFamily("")).toBe("other");
+    expect(modelFamily(null)).toBe("other");
+    expect(modelFamily(undefined)).toBe("other");
+  });
+
+  it("is case-insensitive", () => {
+    expect(modelFamily("Claude-Opus-4-7")).toBe("opus");
+    expect(modelFamily("SONNET")).toBe("sonnet");
+  });
+});
+
+describe("shortModelName", () => {
+  it("strips claude- prefix", () => {
+    expect(shortModelName("claude-sonnet-4-6")).toBe("sonnet-4-6");
+  });
+
+  it("strips trailing YYYYMMDD build tag", () => {
+    expect(shortModelName("claude-opus-4-7-20250514")).toBe("opus-4-7");
+  });
+
+  it("strips both prefix and build tag", () => {
+    expect(shortModelName("claude-haiku-4-5-20251001")).toBe("haiku-4-5");
+  });
+
+  it("handles models without the prefix", () => {
+    expect(shortModelName("gpt-4o")).toBe("gpt-4o");
+  });
+
+  it("returns unknown for falsy input", () => {
+    expect(shortModelName(null)).toBe("unknown");
+    expect(shortModelName(undefined)).toBe("unknown");
+    expect(shortModelName("")).toBe("unknown");
+  });
+});

--- a/tests/relPath.test.ts
+++ b/tests/relPath.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { relPath } from "@/components/viz/relPath";
+
+describe("relPath", () => {
+  it("returns src/ subtree when present", () => {
+    expect(relPath("C:/dev/my-app/src/components/Foo.tsx")).toBe("src/components/Foo.tsx");
+  });
+
+  it("handles Windows backslash paths", () => {
+    expect(relPath("C:\\dev\\my-app\\src\\lib\\utils.ts")).toBe("src/lib/utils.ts");
+  });
+
+  it("falls back to last segment when no /src/", () => {
+    expect(relPath("/home/user/project/package.json")).toBe("package.json");
+  });
+
+  it("returns the full path when no slash at all", () => {
+    expect(relPath("package.json")).toBe("package.json");
+  });
+
+  it("handles deep nested src paths", () => {
+    expect(relPath("/repo/src/app/api/sessions/[id]/route.ts")).toBe("src/app/api/sessions/[id]/route.ts");
+  });
+});


### PR DESCRIPTION
## Summary

Wave 6.2 ships the remaining 5 D3 visualizations from the Cluster O + G backlog, building on the D3 framework established in Wave 6.1.

- **Concurrency Timeline (#207)** — Gantt-style horizontal bars on session detail showing main agent + each subagent over session duration. Falls back to turn-index proportions when wall-clock timestamps are missing. New tab "Concurrency" (gated on subagents).
- **Error Propagation Map (#209)** — Cross-session bar chart of error rates by subagent hierarchy depth (red→purple gradient), top error-prone agents, and tool error breakdown. New tab "Errors" on project detail.
- **Model Delegation Flow (#211)** — Two-column Bezier flow: primary models (left) → subagent models (right). Curve thickness = delegation count; opacity = token volume. New tab "Delegation".
- **Agent Network Graph (#213)** — D3 force-directed graph of agent communication within a session. Node radius = message volume; directed arrows = delegation edges. New tab "Network".
- **File Coupling Arc (#212)** — Replaces bar list in Hot Files panel "File Coupling" section when ≥4 files are present. Quadratic Bezier arcs; click a file node to highlight incident arcs.

### New infrastructure

- `findSessionFile()` in `parser.ts` — canonical JSONL directory walker; all 4 per-session lookup sites now use it (was copy-pasted in each)
- `useReportFetch<T>` hook — shared fetch/loading/error state for all viz components
- `agentPalette.ts` — shared 8-color agent palette + depth gradient + model family colors
- `relPath.ts` — extracted path shortener

### API routes

| Route | TTL | Cache key |
|---|---|---|
| `GET /api/sessions/[id]/concurrency-timeline` | 60s | sessionId |
| `GET /api/sessions/[id]/model-delegation` | 60s | sessionId |
| `GET /api/sessions/[id]/agent-network` | 60s | sessionId |
| `GET /api/projects/[slug]/error-propagation` | 5min | slug + max JSONL mtime |

### Quality / efficiency (from /simplify pass)

- SVG marker ID collision in `AgentNetworkGraph` fixed: `useId()` replaces node-count fake hash
- `OrchestrationDAG` migrated to shared `agentPalette.ts` (was diverged with its own private 6-color array)
- `errorPropagation.ts` serial JSONL loop batched to `Promise.all` in chunks of 10
- O(n²) `turns.indexOf(t)` in concurrency timeline fallback replaced with Map lookup

## Test plan

- [ ] 1290 tests passing, typecheck clean (verified pre-push)
- [ ] Open a session with 5+ subagents → verify Concurrency, Delegation, Network tabs appear and render
- [ ] Open a session without subagents → verify those 3 tabs are absent
- [ ] Open project detail with mixed session errors → verify Errors tab renders depth chart
- [ ] Open Hot Files tab on a project with ≥4 coupling pairs → verify arc diagram replaces bar list
- [ ] Open Hot Files tab on a project with <4 pairs → verify bar list fallback still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)