### PR TITLE
feat(wave7.1b): starring, distillation, Markdown export — schema v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 7.1b — Cluster P (partial): starring, distillation, Markdown export.** TODOs #169, #195, #233.
+  - **Session starring (#169).** Star button on session detail nav row (amber toggle); POST `/api/sessions/[sessionId]/star` toggles `starred_at` (timestamp-as-presence). Starred sessions show a gold star indicator in the sessions list. "Starred" filter toggle in SessionsBrowser toolbar filters to starred sessions only. `starred_at TEXT` column added in schema v8.
+  - **JSONL distillation (#195).** "Distill" button on session detail calls the configured LLM endpoint with a structured prompt (Goal / Approach / Outcome / Key files). Distillation text and timestamp persisted to `sessions.distilled_text` + `sessions.distilled_at` (schema v8). Distillation panel renders below the stats strip when present. "Re-distill" regenerates on demand. Reuses the same secretsStore + autoTitle LLM pattern.
+  - **Markdown export (#233).** "Export" button opens a modal with section checkboxes (Conversation timeline, File operations, Subagents) and an optional turn-limit input. Client-side Markdown generation triggers a `.md` download via `URL.createObjectURL`; no new API route needed.
+  - **Schema v8.** `sessions.starred_at TEXT`, `sessions.distilled_at TEXT`, `sessions.distilled_text TEXT`. Idempotent ALTER TABLE + `CREATE INDEX IF NOT EXISTS sessions_starred`. `DERIVED_VERSION` stays at 6.
 - **Wave 7.1a — Cluster P (partial): notifications + terminal + auto-title.** TODOs #92, #93, #171, #168.
   - **Web push notifications (#92).** VAPID keys lazy-generated on first `/api/notifications/push/vapid-public-key` request and stored in `~/.minder/vapid-keys.json`. Browser subscriptions stored in new `push_subscriptions` SQLite table. Settings → Notifications: permission button, subscribe/unsubscribe, per-device revoke, send-test-push button. 410 Gone responses automatically remove expired subscriptions. Dedup window: 5 minutes per channel+event+payload hash in `notification_log` table.
   - **Telegram notification bridge (#93).** Bot setup wizard in Settings → Integrations (bot token saved to `~/.minder/secrets.json`, chat ID in config). Plain-text messages truncated at 4000 chars. Test connection button. Dedup via shared `notification_log` table.

--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -1,5 +1,154 @@
 # Insights
 
+<!-- insight:51d0d0244c19 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T11:43:17.528Z -->
+## ★ Insight
+`serverExternalPackages` (formerly `experimental.serverComponentsExternalPackages` in Next.js <15) tells the bundler to skip packaging a module and instead emit a runtime `require()`. Native addons like `better-sqlite3` must always be listed here — webpack has no way to cross-compile `.node` binaries. The same applies to `web-push` which webpack also can't resolve cleanly in some environments.
+
+---
+
+<!-- insight:75c9b503e130 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T11:41:41.910Z -->
+## ★ Insight
+All 8 simplify fixes applied: single-pass SQL in star route (eliminates double DB open + full session load), Promise.all parallelization in distill route, de-duped `isAnthropic` via re-export, correct unconditional useEffect assignments (unstar now clears state), `downloadBlob` reuse (fixes detached anchor + synchronous revoke), `formatCost` in export, `filter(Boolean)` + lookup object for role labels, `resumeBtnBase` spread on 3 buttons, `checkboxRowStyle` at module scope, and `onToggle={setStarredAt}` direct pass.
+
+---
+
+<!-- insight:d9c3c58702c7 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T11:38:48.452Z -->
+## ★ Insight
+The distill route's structure means `readConfig()` can be parallelized with `getSessionDetail()` via `Promise.all` — wasting one cheap config read on cache hits is far better than paying the sequential latency on every real LLM call. The star route has a more serious issue: it opens the DB twice (directly + via `getSessionDetail`) and loads the entire session JSONL just to check one nullable column.
+
+---
+
+<!-- insight:f6c846ac909c | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T04:09:45.960Z -->
+## ★ Insight
+The `title` route pattern (POST = mutate + return, GET = read-only) is exactly right for the star route too. Toggle semantics (set if null, clear if set) means a single POST does everything without separate set/unset endpoints.
+
+---
+
+<!-- insight:a9623c144afd | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T04:07:40.602Z -->
+## ★ Insight
+Timestamp-as-presence is a clean boolean alternative for nullable user-action timestamps: a NULL `starred_at` means "not starred," an ISO8601 value means "starred at this time." No separate boolean column needed, and you get the star date for free.
+
+---
+
+<!-- insight:d02df508b537 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T04:06:24.257Z -->
+## ★ Insight
+The data layer follows a strict "SELECT columns explicitly → typed interface → push() call" pattern. Adding new columns means updating 4 places in lockstep: the SQL SELECT, the `SessionRow` interface, the `result.push()` call, and `SessionSummary` type. This rigidity makes column additions safe — the TypeScript compiler will catch any gaps.
+
+---
+
+<!-- insight:ee20a0c4d774 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T03:57:05.029Z -->
+## ★ Insight
+The `S` object acts as a shared style token map — a micro design-system that avoids duplicating the same inline style objects across 4 sibling components. Rather than a CSS module (which Next.js supports natively), the team chose a plain TS object for co-location and easy spreading (`{ ...S.btn, color: "red" }`).
+
+---
+
+<!-- insight:1008b23b7a32 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T03:24:34.992Z -->
+## ★ Insight
+These bugs cluster into three categories: dedup correctness (eventKey stability, shouldSend gate), credential lifecycle (deleteSecret vs empty-string), and surface-area reduction (filter sensitive DB columns, scope vs URL in SW registration). The fix for maintenance.ts is subtle — SQLite's `datetime()` function normalizes both sides to the same format before comparison, making ISO8601 vs SQLite datetime lexicographic comparison reliable.
+
+---
+
+<!-- insight:a84f3bd87c96 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T02:17:56.018Z -->
+## ★ Insight
+The dispatcher uses fire-and-forget per channel (`void dispatchManualStepAdded(change)`) to ensure one channel failing (e.g. Telegram rate limit) doesn't block the watcher's core responsibility — recording the change in-memory. This is the "bulkhead" pattern applied to notification delivery.
+
+---
+
+<!-- insight:d4e6c2d52800 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T02:12:45.801Z -->
+## ★ Insight
+The split-button pattern (primary action + dropdown secondary) is a UX pattern that promotes the most common action while keeping alternatives discoverable. Here we're making "Open in terminal" primary since it's the Wave 7 feature, but keeping "Copy command" accessible for users in environments where terminal launch fails (WSL, SSH, etc.).
+
+---
+
+<!-- insight:48d519949d04 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T02:05:16.937Z -->
+## ★ Insight
+The SettingsPage uses a render-switch pattern: each section key maps to a `<SectionComponent>`. This is the right pattern for settings pages with heterogeneous sections — each section component owns its own state, fetch hooks, and mutation calls. The pattern means new sections can be added without touching any existing ones. The learning moment here: the "swap a placeholder for a real component" motion is fast because the slot was reserved in advance (the IA was final from Wave 5).
+
+---
+
+<!-- insight:468f62a73cee | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T01:55:53.301Z -->
+## ★ Insight
+The secrets store pattern here isolates all credential I/O into one module: `getSecret` caches at module scope (reloads on next server restart but not on every request), `setSecret` always flushes to disk via the atomic-write helper (preventing partial writes), and `listSecretMetadata` returns only key names without values. This means the Settings UI can show "API key configured" without the server ever serializing the actual token into a JSON response.
+
+---
+
+<!-- insight:4ce695deee1e | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T01:52:46.404Z -->
+## ★ Insight
+Web push works through a 3-party handshake: (1) the browser subscribes to a push service using your VAPID public key, (2) the push service returns an endpoint URL + encryption keys specific to that browser, (3) your server uses the VAPID private key to sign push messages sent to those endpoints. The VAPID keys are long-lived (months/years) while push subscriptions are ephemeral — they expire or get 410 Gone when users clear browser data. This is why the 410 cleanup path matters: without it, your `push_subscriptions` table accumulates dead rows that waste work on every send.
+
+---
+
+<!-- insight:77e437ab7eed | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T01:49:23.372Z -->
+## ★ Insight
+The v5 migration pattern is the cleanest model: read `PRAGMA table_info(sessions)` into an array, check `cols.some(c => c.name === "…")` before each `ALTER TABLE`. This makes migrations idempotent — they can run on both fresh DBs (where schema.sql already has the column) and upgraded DBs (where it doesn't). The new v7 follows the same pattern for `generated_title`, then uses `CREATE TABLE IF NOT EXISTS` for the two brand-new tables, which is inherently idempotent.
+
+---
+
+<!-- insight:67dd580f8762 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T01:40:59.830Z -->
+## ★ Insight
+Two design decisions worth flagging here: (1) Splitting Telegram credentials so that `chatId` lives in `MinderConfig` (returned by `GET /api/config`) but `botToken` lives in `~/.minder/secrets.json` mirrors how the auto-title key is stored. The unifying principle: anything a `GET` of the public-facing config endpoint should never echo goes into `secrets.json`. (2) The "manual-step-added end-to-end wiring" is small (~30 min) but turns this session from "infrastructure ships, no real fire path" into a usable feature on day one. Without it, users would only have test-buttons to validate that anything works.
+
+---
+
+<!-- insight:e73d7a33f6aa | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T01:32:22.427Z -->
+## ★ Insight
+One simplification I'm folding in: terminal launch (#171) can **skip `node-pty` entirely**. The plan said "node-pty or platform-specific spawning" — `node-pty` is for *attaching to* a PTY, but the goal is "open a new terminal window with `claude --resume <id>`". The terminal *is* the PTY. Platform-specific spawn (`wt.exe -d` on Windows, `osascript` on macOS, `gnome-terminal --` on Linux) is far lighter than adding a native-binding dep with Windows-prebuild headaches. Project Minder already has `better-sqlite3` as the one native dep — keeping it that way is worth the small platform-detection cost.
+
+---
+
+<!-- insight:2be368e48319 | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T01:26:49.452Z -->
+## ★ Insight
+Three load-bearing findings to share before scope decision: (1) the plan's `MinderConfig` placeholders for `telegram`, `terminal`, `pricingRules`, etc. are **already on the type** (Wave 1 added them) — but PATCH `/api/config` doesn't validate them yet; (2) Project Minder has **never made a server-side LLM call** — auto-title would be the first; the only precedent is the GitHub Actions PR responder script using naked `fetch` to api.anthropic.com (no SDK); (3) Project Minder has **no interactive process spawn** anywhere — `processManager.ts` is non-interactive `["ignore","pipe","pipe"]` stdio. Terminal launch is greenfield and would likely add `node-pty` to `optionalDependencies` (same shape as `better-sqlite3`).
+
+---
+
+<!-- insight:bcb297306e7c | session:9ba38536-655d-48e7-a0ee-9251b042e956 | 2026-05-07T01:22:05.973Z -->
+## ★ Insight
+Cluster P spans 8 distinct features that touch very different subsystems: push notifications (new VAPID flow + service worker), Telegram (HTTP bot + SQLite dedup table), terminal launch (Windows-specific spawn), auto-title (LLM HTTP call + DB column), starring (localStorage + JSON file), export (Markdown serializer), distillation (JSONL backup + rewrite), and screenshot-to-react (bundled MCP). The thread connecting them is the **Settings page sections** that ship empty since Wave 1 and the **session detail surface** that exposes per-session buttons.
+
+---
+
+<!-- insight:4a179f47df13 | session:fe5d826a-7afe-43fb-9298-c47d98dee2c6 | 2026-05-07T01:06:10.629Z -->
+## ★ Insight
+The nested-subagent name bug is a classic graph traversal gap: the two-pass pattern only crawls the "main thread" (depth 0 turns), so any Agent call spawned from a sidechain (depth 1+) never adds its `tool_use_id → name` mapping to the lookup table. The fix for `concurrencyTimeline` and `modelDelegation` is simply removing the `isSidechain` guard from Pass 1. For `agentNetwork`, the cleaner fix is to use `buildGraph()`'s already-traversed node map — it already handles all depths.
+
+---
+
+<!-- insight:5df2572caf89 | session:fe5d826a-7afe-43fb-9298-c47d98dee2c6 | 2026-05-06T23:28:14.921Z -->
+## ★ Insight
+D3 force simulations are stateful — calling `simulation.stop()` in the `useEffect` cleanup is critical. Under React 18 Strict Mode, effects fire twice in development; without cleanup, you'd end up with two running simulations, both mutating the same node/link objects, causing double-speed animation and potential re-mount crashes.
+
+---
+
+<!-- insight:991cab18113b | session:fe5d826a-7afe-43fb-9298-c47d98dee2c6 | 2026-05-06T23:27:40.953Z -->
+## ★ Insight
+The Bezier delegation flow doesn't use `D3Container`'s `Axes` — it's a manual layout. Each "column" of model nodes is positioned at fixed x coordinates (left = parent models, right = child models), with node heights proportional to total tokens delegated through them. This is a functional pattern common in Sankey-adjacent viz: **separate layout computation from rendering** so you can compute all positions in a single pass before drawing anything.
+
+---
+
+<!-- insight:51fd5ac511d1 | session:fe5d826a-7afe-43fb-9298-c47d98dee2c6 | 2026-05-06T23:26:34.791Z -->
+## ★ Insight
+For the Gantt-style bars, we're computing `startPct`/`endPct` on the server so the component gets clean 0-100 percentages — separating the "time math" from the "pixel math". This means `D3Container`'s `width` scales naturally with no extra transforms needed in the SVG.
+
+---
+
+<!-- insight:87eb907cea9c | session:fe5d826a-7afe-43fb-9298-c47d98dee2c6 | 2026-05-06T23:24:09.018Z -->
+## ★ Insight
+Three key patterns from Wave 6.1 to carry into all 5 components:
+1. **Two-pass graph** — first build `agentByToolUseId` from main-thread `Agent` tool calls, then group sidechain turns by `parentToolUseId`. Reusing `buildGraph()` from `orchestrationGraph.ts` avoids reimplementing this for 3 of the 5 viz.
+2. **`globalThis` cache singletons** — all API routes share the same in-memory cache across hot reloads via `globalThis.__xyzCache`. 60s TTL for per-session routes, 5-min + mtime-key for per-project routes.
+3. **`next/dynamic({ ssr: false })`** — the 150KB d3 bundle is already a separate Turbopack chunk; every new viz gets its own dynamic import so they don't all land in the same chunk boundary.
+
+---
+
+<!-- insight:6b910670a915 | session:fe5d826a-7afe-43fb-9298-c47d98dee2c6 | 2026-05-06T23:19:01.371Z -->
+## ★ Insight
+- **Render-prop D3 wrappers are the pattern**: Wave 6.1's `D3Container` exposes `{width, height, showTooltip, hideTooltip}` via children-as-function. This separates SVG chrome (sizing, tooltip portal, ResizeObserver) from chart-specific logic. Every new viz inherits responsive behavior for free.
+- **Two-pass `parentToolUseID` walks**: `orchestrationGraph.ts` builds `agentByToolUseId` first from main-thread Agent calls, then walks sidechain turns. This same pattern unlocks `ConcurrencyTimeline`, `ModelDelegation`, and `AgentNetwork` — all reuse the lookup table.
+- **Cache pattern is uniform**: per-session routes use `globalThis.__<resource>Cache` with 60s TTL + evict-on-set; per-project routes key by slug + max-mtime with 5-min TTL. Wave 6.2's 4 new routes follow whichever fits.
+
+---
+
 <!-- insight:1373ca6b3ecc | session:4bb141a4-1a4c-4794-a32a-b6bb351076ba | 2026-05-06T11:46:38.999Z -->
 ## ★ Insight
 The `SqlResultsTable` architecture issue is a classic virtualizer gotcha: splitting the header and body into separate `overflow: auto` containers means horizontal scrolling is independent. The fix is to make the header `position: sticky; top: 0` inside the same scroll container that the virtualizer uses — sticky elements scroll horizontally with the container but pin vertically.

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react", "date-fns"],
   },
+  // Native addons and packages with dynamic requires must not be bundled.
+  // better-sqlite3 uses a .node binary; web-push is pulled into the same
+  // module graph via dispatcher → sender → connection.
+  serverExternalPackages: ["better-sqlite3", "web-push"],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@tanstack/react-virtual": "^3.13.24",
+        "better-sqlite3": "^12.9.0",
         "chokidar": "^4.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/src/app/api/sessions/[sessionId]/distill/route.ts
+++ b/src/app/api/sessions/[sessionId]/distill/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db/connection";
+import { getSessionDetail } from "@/lib/data";
+import { distillSession } from "@/lib/llm/distill";
+import { LLMError } from "@/lib/llm/autoTitle";
+import { readConfig } from "@/lib/config";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+  const body = await request.json().catch(() => ({}));
+  const regenerate = body?.regenerate === true;
+
+  const { detail } = await getSessionDetail(sessionId);
+  if (!detail) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (detail.distilledText && !regenerate) {
+    return NextResponse.json({ text: detail.distilledText, distilledAt: detail.distilledAt, cached: true });
+  }
+
+  const config = await readConfig();
+  const turns = (detail.timeline ?? [])
+    .filter((e) => e.type === "user" || e.type === "assistant")
+    .map((e) => ({ role: e.type as "user" | "assistant", content: e.content }));
+
+  try {
+    const { text } = await distillSession({
+      endpoint: config.autoTitle?.endpoint,
+      model: config.autoTitle?.model,
+      turns,
+    });
+
+    const distilledAt = new Date().toISOString();
+    const db = await getDb();
+    if (db) {
+      db.prepare(
+        "UPDATE sessions SET distilled_text = ?, distilled_at = ? WHERE session_id = ?"
+      ).run(text, distilledAt, sessionId);
+    }
+
+    return NextResponse.json({ text, distilledAt, cached: false });
+  } catch (err) {
+    if (err instanceof LLMError) {
+      return NextResponse.json({ error: err.message }, { status: err.status >= 400 ? err.status : 502 });
+    }
+    return NextResponse.json({ error: String(err) }, { status: 502 });
+  }
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+  const { detail } = await getSessionDetail(sessionId);
+  if (!detail) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+  return NextResponse.json({
+    text: detail.distilledText ?? null,
+    distilledAt: detail.distilledAt ?? null,
+  });
+}

--- a/src/app/api/sessions/[sessionId]/distill/route.ts
+++ b/src/app/api/sessions/[sessionId]/distill/route.ts
@@ -13,7 +13,7 @@ export async function POST(
   const body = await request.json().catch(() => ({}));
   const regenerate = body?.regenerate === true;
 
-  const { detail } = await getSessionDetail(sessionId);
+  const [{ detail }, config] = await Promise.all([getSessionDetail(sessionId), readConfig()]);
   if (!detail) {
     return NextResponse.json({ error: "Session not found" }, { status: 404 });
   }
@@ -21,8 +21,6 @@ export async function POST(
   if (detail.distilledText && !regenerate) {
     return NextResponse.json({ text: detail.distilledText, distilledAt: detail.distilledAt, cached: true });
   }
-
-  const config = await readConfig();
   const turns = (detail.timeline ?? [])
     .filter((e) => e.type === "user" || e.type === "assistant")
     .map((e) => ({ role: e.type as "user" | "assistant", content: e.content }));

--- a/src/app/api/sessions/[sessionId]/star/route.ts
+++ b/src/app/api/sessions/[sessionId]/star/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db/connection";
+import { getSessionDetail } from "@/lib/data";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+
+  const db = await getDb();
+  if (!db) {
+    return NextResponse.json({ error: "Database unavailable" }, { status: 503 });
+  }
+
+  const { detail } = await getSessionDetail(sessionId);
+  if (!detail) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  const nowStarred = !detail.starredAt;
+  const starredAt = nowStarred ? new Date().toISOString() : null;
+  db.prepare("UPDATE sessions SET starred_at = ? WHERE session_id = ?").run(starredAt, sessionId);
+
+  return NextResponse.json({ starred: nowStarred, starredAt: starredAt ?? undefined });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+  const { detail } = await getSessionDetail(sessionId);
+  if (!detail) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+  return NextResponse.json({ starred: !!detail.starredAt, starredAt: detail.starredAt ?? null });
+}

--- a/src/app/api/sessions/[sessionId]/star/route.ts
+++ b/src/app/api/sessions/[sessionId]/star/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/db/connection";
-import { getSessionDetail } from "@/lib/data";
 
 export async function POST(
   _request: NextRequest,
@@ -13,12 +12,14 @@ export async function POST(
     return NextResponse.json({ error: "Database unavailable" }, { status: 503 });
   }
 
-  const { detail } = await getSessionDetail(sessionId);
-  if (!detail) {
+  const row = db
+    .prepare("SELECT starred_at FROM sessions WHERE session_id = ?")
+    .get(sessionId) as { starred_at: string | null } | undefined;
+  if (!row) {
     return NextResponse.json({ error: "Session not found" }, { status: 404 });
   }
 
-  const nowStarred = !detail.starredAt;
+  const nowStarred = !row.starred_at;
   const starredAt = nowStarred ? new Date().toISOString() : null;
   db.prepare("UPDATE sessions SET starred_at = ? WHERE session_id = ?").run(starredAt, sessionId);
 
@@ -30,9 +31,18 @@ export async function GET(
   { params }: { params: Promise<{ sessionId: string }> }
 ) {
   const { sessionId } = await params;
-  const { detail } = await getSessionDetail(sessionId);
-  if (!detail) {
+
+  const db = await getDb();
+  if (!db) {
+    return NextResponse.json({ error: "Database unavailable" }, { status: 503 });
+  }
+
+  const row = db
+    .prepare("SELECT starred_at FROM sessions WHERE session_id = ?")
+    .get(sessionId) as { starred_at: string | null } | undefined;
+  if (!row) {
     return NextResponse.json({ error: "Session not found" }, { status: 404 });
   }
-  return NextResponse.json({ starred: !!detail.starredAt, starredAt: detail.starredAt ?? null });
+
+  return NextResponse.json({ starred: !!row.starred_at, starredAt: row.starred_at ?? null });
 }

--- a/src/app/api/sessions/[sessionId]/star/route.ts
+++ b/src/app/api/sessions/[sessionId]/star/route.ts
@@ -12,18 +12,22 @@ export async function POST(
     return NextResponse.json({ error: "Database unavailable" }, { status: 503 });
   }
 
+  // Atomic toggle: CASE WHEN inside a single UPDATE ... RETURNING avoids the
+  // read-then-write race when two requests arrive concurrently (double-click,
+  // two tabs). RETURNING yields no rows when WHERE matches nothing → 404.
+  const newStarredAt = new Date().toISOString();
   const row = db
-    .prepare("SELECT starred_at FROM sessions WHERE session_id = ?")
-    .get(sessionId) as { starred_at: string | null } | undefined;
+    .prepare(
+      "UPDATE sessions SET starred_at = CASE WHEN starred_at IS NULL THEN ? ELSE NULL END " +
+      "WHERE session_id = ? RETURNING starred_at"
+    )
+    .get(newStarredAt, sessionId) as { starred_at: string | null } | undefined;
+
   if (!row) {
     return NextResponse.json({ error: "Session not found" }, { status: 404 });
   }
 
-  const nowStarred = !row.starred_at;
-  const starredAt = nowStarred ? new Date().toISOString() : null;
-  db.prepare("UPDATE sessions SET starred_at = ? WHERE session_id = ?").run(starredAt, sessionId);
-
-  return NextResponse.json({ starred: nowStarred, starredAt: starredAt ?? undefined });
+  return NextResponse.json({ starred: !!row.starred_at, starredAt: row.starred_at ?? undefined });
 }
 
 export async function GET(

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -43,6 +43,13 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { Modal } from "@/components/ui/modal";
+import { downloadBlob } from "@/lib/downloadBlob";
+
+const checkboxRowStyle: React.CSSProperties = {
+  display: "flex", alignItems: "center", gap: "8px",
+  fontSize: "0.8rem", color: "var(--text-primary)", cursor: "pointer",
+  padding: "6px 0",
+};
 
 const resumeBtnBase: React.CSSProperties = {
   display: "inline-flex", alignItems: "center", gap: "5px",
@@ -264,15 +271,11 @@ function DistillButton({
       disabled={loading}
       title={hasDistillation ? "Re-distill session" : "Distill session with LLM"}
       style={{
-        display: "inline-flex", alignItems: "center", gap: "5px",
-        padding: "5px 11px",
-        fontSize: "0.72rem", fontFamily: "var(--font-body)",
+        ...resumeBtnBase,
         color: "var(--text-muted)",
-        background: "var(--bg-surface)",
-        border: "1px solid var(--border-subtle)",
-        borderRadius: "var(--radius)", cursor: loading ? "not-allowed" : "pointer",
+        borderRadius: "var(--radius)",
+        cursor: loading ? "not-allowed" : "pointer",
         opacity: loading ? 0.6 : 1,
-        lineHeight: 1, flexShrink: 0,
       }}
     >
       <BookOpen style={{ width: "11px", height: "11px" }} />
@@ -318,23 +321,18 @@ function ExportModal({
       `**Date:** ${date}`,
       data.gitBranch ? `**Branch:** ${data.gitBranch}` : "",
       `**Duration:** ${data.durationMs ? formatDuration(data.durationMs) : "—"}`,
-      `**Cost:** ${data.costEstimate >= 0.01 ? `$${data.costEstimate.toFixed(3)}` : `$${data.costEstimate.toFixed(4)}`}`,
+      `**Cost:** ${formatCost(data.costEstimate)}`,
       `**Session ID:** \`${data.sessionId}\``,
       "",
-    ].filter((l) => l !== undefined);
+    ].filter(Boolean);
 
     if (sections.has("timeline")) {
       const limit = parseInt(turnLimit, 10);
       const events = isNaN(limit) || limit <= 0 ? data.timeline : data.timeline.slice(0, limit);
       lines.push("---", "", "## Conversation", "");
+      const roleLabels: Record<string, string> = { user: "User", assistant: "Assistant", error: "Error", thinking: "Thinking" };
       for (const ev of events) {
-        const role =
-          ev.type === "user" ? "User"
-          : ev.type === "assistant" ? "Assistant"
-          : ev.type === "error" ? "Error"
-          : ev.type === "thinking" ? "Thinking"
-          : ev.type === "tool_use" ? `Tool: ${ev.toolName ?? "unknown"}`
-          : ev.type;
+        const role = ev.type === "tool_use" ? `Tool: ${ev.toolName ?? "unknown"}` : (roleLabels[ev.type] ?? ev.type);
         const ts = ev.timestamp ? ` _(${new Date(ev.timestamp).toLocaleTimeString()})_` : "";
         lines.push(`### ${role}${ts}`, "", ev.content, "");
       }
@@ -360,22 +358,9 @@ function ExportModal({
   }
 
   function handleDownload() {
-    const md = buildMarkdown();
-    const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `session-${data.sessionId.slice(0, 8)}.md`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(buildMarkdown(), `session-${data.sessionId.slice(0, 8)}.md`, "text/markdown;charset=utf-8");
     onClose();
   }
-
-  const checkboxStyle: React.CSSProperties = {
-    display: "flex", alignItems: "center", gap: "8px",
-    fontSize: "0.8rem", color: "var(--text-primary)", cursor: "pointer",
-    padding: "6px 0",
-  };
 
   return (
     <Modal open={open} onClose={onClose} title="Export session as Markdown" maxWidthClass="max-w-sm">
@@ -383,7 +368,7 @@ function ExportModal({
         <div>
           <div style={{ fontSize: "0.72rem", color: "var(--text-muted)", marginBottom: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em" }}>Sections to include</div>
           {(["timeline", "files", "subagents"] as ExportSection[]).map((s) => (
-            <label key={s} style={checkboxStyle}>
+            <label key={s} style={checkboxRowStyle}>
               <input
                 type="checkbox"
                 checked={sections.has(s)}
@@ -469,15 +454,11 @@ function GenerateTitleButton({
       disabled={loading}
       title={hasTitle ? "Regenerate title" : "Generate title with LLM"}
       style={{
-        display: "inline-flex", alignItems: "center", gap: "5px",
-        padding: "5px 11px",
-        fontSize: "0.72rem", fontFamily: "var(--font-body)",
+        ...resumeBtnBase,
         color: "var(--text-muted)",
-        background: "var(--bg-surface)",
-        border: "1px solid var(--border-subtle)",
-        borderRadius: "var(--radius)", cursor: loading ? "not-allowed" : "pointer",
+        borderRadius: "var(--radius)",
+        cursor: loading ? "not-allowed" : "pointer",
         opacity: loading ? 0.6 : 1,
-        lineHeight: 1, flexShrink: 0,
       }}
     >
       <Zap style={{ width: "11px", height: "11px" }} />
@@ -586,10 +567,10 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
   useDocumentTitle(data ? (data.projectPath?.split(/[\\/]/).pop() ?? "Session") : "Session");
 
   useEffect(() => {
-    if (data?.generatedTitle) setGeneratedTitle(data.generatedTitle);
-    if (data?.starredAt) setStarredAt(data.starredAt);
-    if (data?.distilledText) setDistilledText(data.distilledText);
-    if (data?.distilledAt) setDistilledAt(data.distilledAt);
+    setGeneratedTitle(data?.generatedTitle);
+    setStarredAt(data?.starredAt);
+    setDistilledText(data?.distilledText);
+    setDistilledAt(data?.distilledAt);
   }, [data?.generatedTitle, data?.starredAt, data?.distilledText, data?.distilledAt]);
 
   const handleTitleGenerated = useCallback((title: string) => setGeneratedTitle(title), []);
@@ -679,7 +660,7 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
         <StarButton
           sessionId={sessionId}
           starredAt={starredAt}
-          onToggle={(newStarredAt) => setStarredAt(newStarredAt)}
+          onToggle={setStarredAt}
         />
         <DistillButton
           sessionId={sessionId}
@@ -694,16 +675,7 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
         <button
           onClick={() => setExportModalOpen(true)}
           title="Export session as Markdown"
-          style={{
-            display: "inline-flex", alignItems: "center", gap: "5px",
-            padding: "5px 11px",
-            fontSize: "0.72rem", fontFamily: "var(--font-body)",
-            color: "var(--text-muted)",
-            background: "var(--bg-surface)",
-            border: "1px solid var(--border-subtle)",
-            borderRadius: "var(--radius)", cursor: "pointer",
-            lineHeight: 1, flexShrink: 0,
-          }}
+          style={{ ...resumeBtnBase, color: "var(--text-muted)", borderRadius: "var(--radius)", cursor: "pointer" }}
         >
           <FileDown style={{ width: "11px", height: "11px" }} />
           Export

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -37,8 +37,12 @@ import {
   Zap,
   Terminal,
   Check,
+  Star,
+  FileDown,
+  BookOpen,
 } from "lucide-react";
 import Link from "next/link";
+import { Modal } from "@/components/ui/modal";
 
 const resumeBtnBase: React.CSSProperties = {
   display: "inline-flex", alignItems: "center", gap: "5px",
@@ -162,6 +166,266 @@ function ResumeButton({ sessionId }: { sessionId: string }) {
         </div>
       )}
     </div>
+  );
+}
+
+// ── Star button ───────────────────────────────────────────────────────────────
+function StarButton({
+  sessionId,
+  starredAt,
+  onToggle,
+}: {
+  sessionId: string;
+  starredAt: string | undefined;
+  onToggle: (newStarredAt: string | undefined) => void;
+}) {
+  const { showToast } = useToast();
+  const [busy, setBusy] = useState(false);
+  const isStarred = !!starredAt;
+
+  async function handleToggle() {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/star`, { method: "POST" });
+      const d = await res.json();
+      if (res.ok) {
+        onToggle(d.starredAt as string | undefined);
+      } else {
+        showToast("Star failed", d.error ?? res.statusText);
+      }
+    } catch (e: unknown) {
+      showToast("Star failed", e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleToggle}
+      disabled={busy}
+      title={isStarred ? "Unstar session" : "Star session"}
+      style={{
+        display: "inline-flex", alignItems: "center", gap: "5px",
+        padding: "5px 11px",
+        fontSize: "0.72rem", fontFamily: "var(--font-body)",
+        color: isStarred ? "var(--accent)" : "var(--text-muted)",
+        background: isStarred ? "var(--accent-bg)" : "var(--bg-surface)",
+        border: `1px solid ${isStarred ? "var(--accent-border)" : "var(--border-subtle)"}`,
+        borderRadius: "var(--radius)", cursor: busy ? "not-allowed" : "pointer",
+        opacity: busy ? 0.6 : 1,
+        lineHeight: 1, flexShrink: 0,
+        transition: "color 0.15s, background 0.15s, border-color 0.15s",
+      }}
+    >
+      <Star style={{ width: "11px", height: "11px", fill: isStarred ? "currentColor" : "none" }} />
+      {isStarred ? "Starred" : "Star"}
+    </button>
+  );
+}
+
+// ── Distill button ────────────────────────────────────────────────────────────
+function DistillButton({
+  sessionId,
+  hasDistillation,
+  onDistilled,
+}: {
+  sessionId: string;
+  hasDistillation: boolean;
+  onDistilled: (text: string, distilledAt: string) => void;
+}) {
+  const { showToast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  async function handleDistill() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/distill`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ regenerate: hasDistillation }),
+      });
+      const d = await res.json();
+      if (res.ok && d.text) {
+        onDistilled(d.text as string, d.distilledAt as string);
+      } else {
+        showToast("Distillation failed", d.error ?? res.statusText);
+      }
+    } catch (e: unknown) {
+      showToast("Distillation failed", e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleDistill}
+      disabled={loading}
+      title={hasDistillation ? "Re-distill session" : "Distill session with LLM"}
+      style={{
+        display: "inline-flex", alignItems: "center", gap: "5px",
+        padding: "5px 11px",
+        fontSize: "0.72rem", fontFamily: "var(--font-body)",
+        color: "var(--text-muted)",
+        background: "var(--bg-surface)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "var(--radius)", cursor: loading ? "not-allowed" : "pointer",
+        opacity: loading ? 0.6 : 1,
+        lineHeight: 1, flexShrink: 0,
+      }}
+    >
+      <BookOpen style={{ width: "11px", height: "11px" }} />
+      {loading ? "Distilling…" : hasDistillation ? "Re-distill" : "Distill"}
+    </button>
+  );
+}
+
+// ── Export modal ──────────────────────────────────────────────────────────────
+type ExportSection = "timeline" | "files" | "subagents";
+
+function ExportModal({
+  open,
+  onClose,
+  data,
+  generatedTitle,
+}: {
+  open: boolean;
+  onClose: () => void;
+  data: import("@/lib/types").SessionDetail;
+  generatedTitle: string | undefined;
+}) {
+  const [sections, setSections] = useState<Set<ExportSection>>(
+    new Set(["timeline", "files", "subagents"])
+  );
+  const [turnLimit, setTurnLimit] = useState<string>("");
+
+  function toggleSection(s: ExportSection) {
+    setSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s); else next.add(s);
+      return next;
+    });
+  }
+
+  function buildMarkdown(): string {
+    const title = generatedTitle ?? data.sessionId.slice(0, 16);
+    const date = data.startTime ? new Date(data.startTime).toLocaleString() : "Unknown date";
+    const lines: string[] = [
+      `# Session: ${title}`,
+      "",
+      `**Project:** ${data.projectName}`,
+      `**Date:** ${date}`,
+      data.gitBranch ? `**Branch:** ${data.gitBranch}` : "",
+      `**Duration:** ${data.durationMs ? formatDuration(data.durationMs) : "—"}`,
+      `**Cost:** ${data.costEstimate >= 0.01 ? `$${data.costEstimate.toFixed(3)}` : `$${data.costEstimate.toFixed(4)}`}`,
+      `**Session ID:** \`${data.sessionId}\``,
+      "",
+    ].filter((l) => l !== undefined);
+
+    if (sections.has("timeline")) {
+      const limit = parseInt(turnLimit, 10);
+      const events = isNaN(limit) || limit <= 0 ? data.timeline : data.timeline.slice(0, limit);
+      lines.push("---", "", "## Conversation", "");
+      for (const ev of events) {
+        const role =
+          ev.type === "user" ? "User"
+          : ev.type === "assistant" ? "Assistant"
+          : ev.type === "error" ? "Error"
+          : ev.type === "thinking" ? "Thinking"
+          : ev.type === "tool_use" ? `Tool: ${ev.toolName ?? "unknown"}`
+          : ev.type;
+        const ts = ev.timestamp ? ` _(${new Date(ev.timestamp).toLocaleTimeString()})_` : "";
+        lines.push(`### ${role}${ts}`, "", ev.content, "");
+      }
+    }
+
+    if (sections.has("files") && data.fileOperations.length > 0) {
+      lines.push("---", "", "## File Operations", "");
+      for (const op of data.fileOperations) {
+        lines.push(`- **${op.operation}**: \`${op.path}\``);
+      }
+      lines.push("");
+    }
+
+    if (sections.has("subagents") && data.subagents.length > 0) {
+      lines.push("---", "", "## Subagents", "");
+      for (const sub of data.subagents) {
+        lines.push(`- **${sub.type}** — ${sub.description ?? "—"}`);
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n");
+  }
+
+  function handleDownload() {
+    const md = buildMarkdown();
+    const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `session-${data.sessionId.slice(0, 8)}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+    onClose();
+  }
+
+  const checkboxStyle: React.CSSProperties = {
+    display: "flex", alignItems: "center", gap: "8px",
+    fontSize: "0.8rem", color: "var(--text-primary)", cursor: "pointer",
+    padding: "6px 0",
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Export session as Markdown" maxWidthClass="max-w-sm">
+      <div style={{ padding: "20px", display: "flex", flexDirection: "column", gap: "16px" }}>
+        <div>
+          <div style={{ fontSize: "0.72rem", color: "var(--text-muted)", marginBottom: "10px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em" }}>Sections to include</div>
+          {(["timeline", "files", "subagents"] as ExportSection[]).map((s) => (
+            <label key={s} style={checkboxStyle}>
+              <input
+                type="checkbox"
+                checked={sections.has(s)}
+                onChange={() => toggleSection(s)}
+                style={{ width: "14px", height: "14px", accentColor: "var(--accent)" }}
+              />
+              {s === "timeline" ? "Conversation timeline" : s === "files" ? "File operations" : "Subagents"}
+            </label>
+          ))}
+        </div>
+        {sections.has("timeline") && (
+          <div>
+            <div style={{ fontSize: "0.72rem", color: "var(--text-muted)", marginBottom: "6px", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em" }}>Turn limit</div>
+            <input
+              type="number"
+              min={1}
+              value={turnLimit}
+              onChange={(e) => setTurnLimit(e.target.value)}
+              placeholder={`All (${data.timeline.length} events)`}
+              style={{
+                width: "100%", boxSizing: "border-box", padding: "6px 10px",
+                borderRadius: "var(--radius)", border: "1px solid var(--border-default)",
+                background: "var(--surface-2, transparent)", color: "var(--text-primary)",
+                fontSize: "0.82rem", fontFamily: "var(--font-body)",
+              }}
+            />
+          </div>
+        )}
+        <button
+          onClick={handleDownload}
+          disabled={sections.size === 0}
+          style={{
+            padding: "8px 16px", fontSize: "0.8rem", fontWeight: 600,
+            background: sections.size === 0 ? "var(--surface-2)" : "var(--accent)",
+            color: sections.size === 0 ? "var(--text-muted)" : "#fff",
+            border: "none", borderRadius: "var(--radius)", cursor: sections.size === 0 ? "not-allowed" : "pointer",
+          }}
+        >
+          Download .md
+        </button>
+      </div>
+    </Modal>
   );
 }
 
@@ -314,12 +578,19 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
   const { data, loading } = useSessionDetail(sessionId);
   const [activeTab, setActiveTab] = useState<TabKey>("timeline");
   const [docModalOpen, setDocModalOpen] = useState(false);
+  const [exportModalOpen, setExportModalOpen] = useState(false);
   const [generatedTitle, setGeneratedTitle] = useState<string | undefined>(undefined);
+  const [starredAt, setStarredAt] = useState<string | undefined>(undefined);
+  const [distilledText, setDistilledText] = useState<string | undefined>(undefined);
+  const [distilledAt, setDistilledAt] = useState<string | undefined>(undefined);
   useDocumentTitle(data ? (data.projectPath?.split(/[\\/]/).pop() ?? "Session") : "Session");
 
   useEffect(() => {
     if (data?.generatedTitle) setGeneratedTitle(data.generatedTitle);
-  }, [data?.generatedTitle]);
+    if (data?.starredAt) setStarredAt(data.starredAt);
+    if (data?.distilledText) setDistilledText(data.distilledText);
+    if (data?.distilledAt) setDistilledAt(data.distilledAt);
+  }, [data?.generatedTitle, data?.starredAt, data?.distilledText, data?.distilledAt]);
 
   const handleTitleGenerated = useCallback((title: string) => setGeneratedTitle(title), []);
 
@@ -405,13 +676,46 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
           {data.sessionId.slice(0, 16)}…
         </span>
         <div style={{ flex: 1 }} />
+        <StarButton
+          sessionId={sessionId}
+          starredAt={starredAt}
+          onToggle={(newStarredAt) => setStarredAt(newStarredAt)}
+        />
+        <DistillButton
+          sessionId={sessionId}
+          hasDistillation={!!distilledText}
+          onDistilled={(text, at) => { setDistilledText(text); setDistilledAt(at); }}
+        />
         <GenerateTitleButton
           sessionId={sessionId}
           hasTitle={!!generatedTitle}
           onTitleGenerated={handleTitleGenerated}
         />
+        <button
+          onClick={() => setExportModalOpen(true)}
+          title="Export session as Markdown"
+          style={{
+            display: "inline-flex", alignItems: "center", gap: "5px",
+            padding: "5px 11px",
+            fontSize: "0.72rem", fontFamily: "var(--font-body)",
+            color: "var(--text-muted)",
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)",
+            borderRadius: "var(--radius)", cursor: "pointer",
+            lineHeight: 1, flexShrink: 0,
+          }}
+        >
+          <FileDown style={{ width: "11px", height: "11px" }} />
+          Export
+        </button>
         <ResumeButton sessionId={sessionId} />
       </div>
+      <ExportModal
+        open={exportModalOpen}
+        onClose={() => setExportModalOpen(false)}
+        data={data}
+        generatedTitle={generatedTitle}
+      />
 
       {/* ── Header block ────────────────────────────────────────────────────── */}
       <div style={{
@@ -556,6 +860,35 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
           />
         ))}
       </div>
+
+      {/* ── Distillation panel ──────────────────────────────────────────────── */}
+      {distilledText && (
+        <div style={{
+          padding: "16px 20px",
+          background: "var(--bg-surface)",
+          border: "1px solid var(--border-subtle)",
+          borderTop: "none",
+          display: "flex", flexDirection: "column", gap: "8px",
+        }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+            <BookOpen style={{ width: "12px", height: "12px", color: "var(--text-muted)" }} />
+            <span style={{ fontSize: "0.72rem", fontWeight: 600, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>
+              Distillation
+            </span>
+            {distilledAt && (
+              <span style={{ fontSize: "0.68rem", color: "var(--text-muted)", marginLeft: "auto" }}>
+                {new Date(distilledAt).toLocaleDateString()}
+              </span>
+            )}
+          </div>
+          <pre style={{
+            fontSize: "0.76rem", color: "var(--text-secondary)", lineHeight: 1.65,
+            fontFamily: "var(--font-body)", margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word",
+          }}>
+            {distilledText}
+          </pre>
+        </div>
+      )}
 
       {/* ── Tab section ─────────────────────────────────────────────────────── */}
       <div style={{

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -714,7 +714,7 @@ export function SessionsBrowser() {
         }
       }
     });
-  }, [data, search, sortBy, searchState]);
+  }, [data, search, sortBy, searchState, starredOnly]);
 
   const projectGroups = useMemo(
     () => groupByProject ? buildProjectGroups(filtered) : [],

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -19,6 +19,7 @@ import {
   Terminal,
   Check,
   Pencil,
+  Star,
 } from "lucide-react";
 import Link from "next/link";
 import { StatusDot } from "./ui/StatusDot";
@@ -328,6 +329,11 @@ function SessionRow({
             </span>
           )}
           <StatusDot status={session.status} size={8} />
+          {session.starredAt && (
+            <span title={`Starred ${new Date(session.starredAt).toLocaleDateString()}`} style={{ display: "inline-flex", flexShrink: 0, marginTop: "2px" }}>
+              <Star style={{ width: "10px", height: "10px", color: "var(--accent)", fill: "var(--accent)" }} />
+            </span>
+          )}
           {session.recaps && session.recaps.length > 0 && (
             <span style={{
               fontSize: "0.6rem", fontFamily: "var(--font-mono)",
@@ -634,6 +640,7 @@ export function SessionsBrowser() {
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = useState<SortOption>("recent");
   const [groupByProject, setGroupByProject] = useState(true);
+  const [starredOnly, setStarredOnly] = useState(false);
   const [collapsedSlugs, setCollapsedSlugs] = useState<Set<string>>(new Set());
   const [searchState, setSearchState] = useState<SearchState>({ kind: "idle" });
 
@@ -676,6 +683,9 @@ export function SessionsBrowser() {
 
   const filtered = useMemo(() => {
     let result = data;
+    if (starredOnly) {
+      result = result.filter((s) => !!s.starredAt);
+    }
     const trimmed = search.trim();
     if (trimmed) {
       const q = trimmed.toLowerCase();
@@ -831,6 +841,16 @@ export function SessionsBrowser() {
             </button>
           ))}
         </div>
+
+        {/* Starred filter */}
+        <button
+          onClick={() => setStarredOnly((v) => !v)}
+          title={starredOnly ? "Show all sessions" : "Show starred only"}
+          style={{ display: "inline-flex", alignItems: "center", gap: "5px", padding: "5px 11px", fontSize: "0.72rem", fontFamily: "var(--font-body)", letterSpacing: "0.03em", color: starredOnly ? "var(--accent)" : "var(--text-secondary)", background: starredOnly ? "var(--accent-bg)" : "var(--bg-surface)", border: `1px solid ${starredOnly ? "var(--accent-border)" : "var(--border-subtle)"}`, borderRadius: "var(--radius)", cursor: "pointer", transition: "background 0.1s, color 0.1s, border-color 0.1s", lineHeight: 1, flexShrink: 0 }}
+        >
+          <Star style={{ width: "10px", height: "10px", fill: starredOnly ? "currentColor" : "none" }} />
+          Starred
+        </button>
 
         {/* Group by project toggle */}
         <button

--- a/src/components/settings/TerminalSection.tsx
+++ b/src/components/settings/TerminalSection.tsx
@@ -55,8 +55,8 @@ export function TerminalSection({
     <section>
       <h2 style={S.sectionTitle}>Terminal</h2>
       <p style={S.desc}>
-        Configure which terminal application to use when opening sessions. Project Minder auto-detects your platform's
-        default; use the override for custom terminal emulators.
+        Configure which terminal application to use when opening sessions. Project Minder auto-detects your
+        platform&apos;s default; use the override for custom terminal emulators.
       </p>
 
       <div style={S.card}>

--- a/src/lib/data/sessionDetailFromDb.ts
+++ b/src/lib/data/sessionDetailFromDb.ts
@@ -109,6 +109,9 @@ interface SessionRow {
   has_thinking: number;
   cli_version: string | null;
   generated_title: string | null;
+  starred_at: string | null;
+  distilled_at: string | null;
+  distilled_text: string | null;
 }
 
 interface TurnRow {
@@ -171,7 +174,8 @@ export function loadSessionDetailFromDb(
               input_tokens, output_tokens, cache_create_tokens, cache_read_tokens,
               cost_usd, has_one_shot, verified_task_count, one_shot_task_count,
               git_branch, initial_prompt, last_prompt,
-              has_thinking, cli_version, generated_title
+              has_thinking, cli_version, generated_title,
+              starred_at, distilled_at, distilled_text
        FROM sessions
        WHERE session_id = ?`
     )
@@ -263,6 +267,9 @@ export function loadSessionDetailFromDb(
     hasThinking: session.has_thinking === 1 || undefined,
     cliVersion: session.cli_version ?? undefined,
     generatedTitle: session.generated_title ?? undefined,
+    starredAt: session.starred_at ?? undefined,
+    distilledAt: session.distilled_at ?? undefined,
+    distilledText: session.distilled_text ?? undefined,
     timeline,
     fileOperations: aggregates.fileOperations,
     subagents: aggregates.subagents,

--- a/src/lib/data/sessionsListFromDb.ts
+++ b/src/lib/data/sessionsListFromDb.ts
@@ -128,6 +128,9 @@ interface SessionRow {
   has_resume_anomaly: number;
   compact_boundary_count: number;
   generated_title: string | null;
+  starred_at: string | null;
+  distilled_at: string | null;
+  distilled_text: string | null;
 }
 
 interface ToolCountRow {
@@ -181,7 +184,7 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
             git_branch, initial_prompt, last_prompt,
             slug, continued_from_session_id,
             has_thinking, cli_version, has_resume_anomaly, compact_boundary_count,
-            generated_title
+            generated_title, starred_at, distilled_at, distilled_text
      FROM sessions
      ORDER BY end_ts DESC`
   ).all() as SessionRow[];
@@ -321,6 +324,9 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
       hasResumeAnomaly: h.has_resume_anomaly === 1 || undefined,
       compactBoundaryCount: h.compact_boundary_count || undefined,
       generatedTitle: h.generated_title ?? undefined,
+      starredAt: h.starred_at ?? undefined,
+      distilledAt: h.distilled_at ?? undefined,
+      distilledText: h.distilled_text ?? undefined,
     });
   }
 

--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -34,9 +34,12 @@ import type DatabaseT from "better-sqlite3";
 let Database: typeof DatabaseT | null = null;
 let loadError: Error | null = null;
 try {
-  // Dynamic require so the import can fail without breaking the module graph.
+  // Use a computed name to prevent webpack/Turbopack from statically tracing
+  // this require — they can't follow a non-literal argument. The try/catch
+  // handles the runtime case when the native binary isn't available (e.g. no
+  // prebuilt for the current Node version).
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  Database = require("better-sqlite3");
+  Database = require(["better", "sqlite3"].join("-"));
 } catch (err) {
   loadError = err as Error;
 }

--- a/src/lib/db/connection.ts
+++ b/src/lib/db/connection.ts
@@ -38,7 +38,6 @@ try {
   // this require — they can't follow a non-literal argument. The try/catch
   // handles the runtime case when the native binary isn't available (e.g. no
   // prebuilt for the current Node version).
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   Database = require(["better", "sqlite3"].join("-"));
 } catch (err) {
   loadError = err as Error;

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -238,6 +238,26 @@ const MIGRATIONS: Migration[] = [
       ).run();
     },
   },
+  {
+    version: 8,
+    name: "wave7.1b: starred_at + distilled_at + distilled_text",
+    up: (db) => {
+      const sessionCols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>;
+      const colNames = sessionCols.map((c) => c.name);
+      if (!colNames.includes("starred_at")) {
+        db.prepare("ALTER TABLE sessions ADD COLUMN starred_at TEXT").run();
+      }
+      if (!colNames.includes("distilled_at")) {
+        db.prepare("ALTER TABLE sessions ADD COLUMN distilled_at TEXT").run();
+      }
+      if (!colNames.includes("distilled_text")) {
+        db.prepare("ALTER TABLE sessions ADD COLUMN distilled_text TEXT").run();
+      }
+      db.prepare(
+        "CREATE INDEX IF NOT EXISTS sessions_starred ON sessions(starred_at) WHERE starred_at IS NOT NULL"
+      ).run();
+    },
+  },
 ];
 
 function resolveSchemaPath(): string {

--- a/src/lib/db/schema.sql
+++ b/src/lib/db/schema.sql
@@ -107,7 +107,11 @@ CREATE TABLE sessions (
   derived_version       INTEGER NOT NULL DEFAULT 0,
   indexed_at_ms         INTEGER NOT NULL,
   -- Wave 7.1 columns (schema v7):
-  generated_title       TEXT
+  generated_title       TEXT,
+  -- Wave 7.1b columns (schema v8):
+  starred_at            TEXT,
+  distilled_at          TEXT,
+  distilled_text        TEXT
 );
 
 CREATE INDEX sessions_by_project_end      ON sessions(project_slug, end_ts DESC);
@@ -115,6 +119,7 @@ CREATE INDEX sessions_by_end_ts      ON sessions(end_ts DESC);
 CREATE INDEX sessions_by_mtime       ON sessions(file_mtime_ms DESC);
 CREATE INDEX sessions_by_slug        ON sessions(slug) WHERE slug IS NOT NULL;
 CREATE INDEX sessions_by_generated_title ON sessions(generated_title) WHERE generated_title IS NOT NULL;
+CREATE INDEX sessions_starred ON sessions(starred_at) WHERE starred_at IS NOT NULL;
 
 -- ─── push_subscriptions ──────────────────────────────────────────────────
 -- Web push endpoint registrations. One row per browser subscription.

--- a/src/lib/llm/autoTitle.ts
+++ b/src/lib/llm/autoTitle.ts
@@ -28,7 +28,7 @@ export class LLMError extends Error {
   }
 }
 
-function isAnthropic(endpoint: string): boolean {
+export function isAnthropic(endpoint: string): boolean {
   return endpoint.includes("anthropic.com");
 }
 

--- a/src/lib/llm/distill.ts
+++ b/src/lib/llm/distill.ts
@@ -1,0 +1,94 @@
+import "server-only";
+import { getSecret } from "./secretsStore";
+import { DEFAULT_ENDPOINT, DEFAULT_MODEL } from "./defaults";
+import { LLMError } from "./autoTitle";
+import type { TitleTurn } from "./autoTitle";
+
+const MAX_TURN_CHARS = 800;
+const MAX_DISTILL_TOKENS = 512;
+
+const SYSTEM_PROMPT = `You are summarizing a Claude Code session. Produce a structured distillation with these sections:
+
+**Goal** — 1-2 sentences: what was being attempted.
+**Approach** — 2-4 bullet points: how it was tackled.
+**Outcome** — 1-2 sentences: what was achieved or left incomplete.
+**Key files** — bullet list of files created or significantly modified (if any).
+
+Be concise and factual. Focus on what happened, not general observations about coding.`;
+
+export interface DistillOpts {
+  endpoint?: string;
+  model?: string;
+  turns: TitleTurn[];
+}
+
+function isAnthropic(endpoint: string): boolean {
+  return endpoint.includes("anthropic.com");
+}
+
+function buildUserMessage(turns: TitleTurn[]): string {
+  const samples = turns.slice(0, 20).map((t) => {
+    const label = t.role === "user" ? "User" : "Assistant";
+    return `${label}: ${t.content.slice(0, MAX_TURN_CHARS)}`;
+  });
+  if (samples.length === 0) return "Empty session.";
+  return "Session transcript:\n\n" + samples.join("\n\n");
+}
+
+export async function distillSession(opts: DistillOpts): Promise<{ text: string }> {
+  const endpoint = opts.endpoint ?? DEFAULT_ENDPOINT;
+  const model = opts.model ?? DEFAULT_MODEL;
+  const apiKey = await getSecret("llm.api_key");
+  if (!apiKey) throw new LLMError("LLM API key not configured", 400);
+
+  const userContent = buildUserMessage(opts.turns);
+
+  if (isAnthropic(endpoint)) {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: MAX_DISTILL_TOKENS,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: userContent }],
+      }),
+    });
+    if (!res.ok) {
+      const err = await res.text().catch(() => res.statusText);
+      throw new LLMError(`Anthropic API error: ${err}`, res.status);
+    }
+    const data = await res.json();
+    const text = (data.content?.[0]?.text ?? "").trim();
+    if (!text) throw new LLMError("Empty distillation from Anthropic", 502);
+    return { text };
+  }
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: MAX_DISTILL_TOKENS,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userContent },
+      ],
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.text().catch(() => res.statusText);
+    throw new LLMError(`LLM API error: ${err}`, res.status);
+  }
+  const data = await res.json();
+  const text = (data.choices?.[0]?.message?.content ?? "").trim();
+  if (!text) throw new LLMError("Empty distillation from LLM", 502);
+  return { text };
+}

--- a/src/lib/llm/distill.ts
+++ b/src/lib/llm/distill.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { getSecret } from "./secretsStore";
 import { DEFAULT_ENDPOINT, DEFAULT_MODEL } from "./defaults";
-import { LLMError } from "./autoTitle";
+import { LLMError, isAnthropic } from "./autoTitle";
 import type { TitleTurn } from "./autoTitle";
 
 const MAX_TURN_CHARS = 800;
@@ -20,10 +20,6 @@ export interface DistillOpts {
   endpoint?: string;
   model?: string;
   turns: TitleTurn[];
-}
-
-function isAnthropic(endpoint: string): boolean {
-  return endpoint.includes("anthropic.com");
 }
 
 function buildUserMessage(turns: TitleTurn[]): string {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -419,6 +419,12 @@ export interface SessionSummary {
   compactBoundaryCount?: number;
   /** LLM-generated concise title (Wave 7.1). Stored in `sessions.generated_title`. */
   generatedTitle?: string;
+  /** ISO8601 timestamp when this session was starred, or undefined if not starred. */
+  starredAt?: string;
+  /** ISO8601 timestamp when distillation was last run. */
+  distilledAt?: string;
+  /** LLM-generated distillation of the session (Wave 7.1b). */
+  distilledText?: string;
 }
 
 export interface TimelineEvent {

--- a/tests/dbMigrations.test.ts
+++ b/tests/dbMigrations.test.ts
@@ -81,8 +81,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     // but each still bumps the schema_version stamp. Note that v3
     // ALSO sets `meta.needs_reconcile_after_v3 = 1` even on fresh DBs;
     // that's harmless because the indexer's first reconcile clears it.
-    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6]);
-    expect(result.schemaVersion).toBe(6);
+    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(result.schemaVersion).toBe(8);
 
     const db = await conn.getDb();
     expect(db).not.toBeNull();
@@ -104,7 +104,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
     expect(result.appliedMigrations).toEqual([]);
-    expect(result.schemaVersion).toBe(6);
+    expect(result.schemaVersion).toBe(8);
     second.conn.closeDb();
   });
 
@@ -134,7 +134,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
 
     expect(result.available).toBe(true);
     expect(result.quarantined).not.toBeNull();
-    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
 
     // The schema ran on the rebuilt empty DB.
     const db = await conn.getDb();
@@ -164,7 +164,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     expect(result.error).toBeNull();
     expect(result.available).toBe(true);
     expect(result.quarantined).not.toBeNull();
-    expect(result.schemaVersion).toBe(6);
+    expect(result.schemaVersion).toBe(8);
     second.conn.closeDb();
   });
 
@@ -218,8 +218,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6]);
-    expect(result.schemaVersion).toBe(6);
+    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6, 7, 8]);
+    expect(result.schemaVersion).toBe(8);
 
     const db2 = await second.conn.getDb();
     const colsRecovered = db2!
@@ -254,8 +254,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([3, 4, 5, 6]);
-    expect(result.schemaVersion).toBe(6);
+    expect(result.appliedMigrations).toEqual([3, 4, 5, 6, 7, 8]);
+    expect(result.schemaVersion).toBe(8);
 
     const db2 = await second.conn.getDb();
     expect(db2).not.toBeNull();


### PR DESCRIPTION
## Summary

- **Starring**: single `POST /api/sessions/[sessionId]/star` toggles `starred_at` (timestamp-as-presence pattern); amber star button in session detail nav row; starred filter in `SessionsBrowser`
- **LLM distillation**: `POST /api/sessions/[sessionId]/distill` calls the configured autoTitle endpoint with a structured Goal/Approach/Outcome prompt; result persisted to `distilled_text`; displayed as a panel below the stats strip
- **Markdown export**: user-selectable sections (timeline, files, subagents) + optional turn limit via modal; client-side blob download via `downloadBlob` utility
- **Schema v8**: `sessions.starred_at`, `sessions.distilled_at`, `sessions.distilled_text` columns via idempotent v8 migration
- **Bundler fix**: computed `require()` arg in `connection.ts` defeats webpack/Turbopack static analysis of `better-sqlite3` (optional native dep with no Node 26 prebuilt); `serverExternalPackages` added for belt-and-suspenders
- **Simplify pass**: star route uses direct SQL instead of full `getSessionDetail`; distill route parallelizes `getSessionDetail` + `readConfig`; `isAnthropic` de-duplicated via export; `useEffect` truthy guards removed (unstar now clears state); `resumeBtnBase` spread on 3 buttons; `downloadBlob` reuse; `formatCost` in export markdown

## Test plan

- [ ] typecheck clean (`npm run typecheck`)
- [ ] 1173 tests pass (`npm test`)
- [ ] Star a session → amber button + `starred_at` in DB; unstar → clears; starred filter in browser shows only starred rows
- [ ] Distill a session → panel appears below stats; re-distill → updates; missing API key → toast error
- [ ] Export → modal opens; uncheck a section → absent from .md; turn limit → truncates timeline; Download → file saves correctly
- [ ] Dev server shows no `better-sqlite3` module-not-found warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)