### PR TITLE
feat(wave8.1a): OTEL ingest + setup wizard, schema v9 (Cluster R, TODO #94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 8.1a — Cluster R: OTEL ingest + setup wizard.** TODO #94.
+  - **`POST /api/otel/v1/logs`** — OTLP/HTTP JSON logs receiver. Parses `resourceLogs → scopeLogs → logRecords`, persists events to `otel_events`. Per-record try/catch for partial-success semantics; returns `{ partialSuccess: { rejectedLogRecords, errorMessage } }` per OTLP spec.
+  - **`POST /api/otel/v1/metrics`** — OTLP/HTTP JSON metrics receiver. Parses `resourceMetrics → scopeMetrics → metrics`, persists to new `otel_metrics` table. Returns `{ partialSuccess: { rejectedDataPoints } }`.
+  - **`GET/POST /api/integrations/otel`** — Install/remove OTEL env vars in `~/.claude/settings.json`. Writes `CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`, `OTEL_LOG_TOOL_DETAILS=1`. Atomic COW write with configHistory snapshot.
+  - **Settings → Integrations → OpenTelemetry card.** Endpoint field, Install / Remove buttons, live status indicator. Restart Claude Code after install for env vars to take effect.
+  - **Schema v9.** New `otel_metrics` table: `metric_name`, `metric_type` (counter/gauge), `value`, `session_id`, `model`, `attrs_json`. Indexes on `(metric_name, ts)` and `(session_id)`. `CREATE TABLE IF NOT EXISTS` for idempotency on existing DBs.
+  - **`MinderConfig.otel`** sub-object: `endpoint?: string`. Not a feature flag — configuration, not a subsystem on/off.
+  - Help documentation at **Settings → Integrations → OpenTelemetry** (`/help/otel`).
 - **Wave 7.2 — Cluster Q: Hook Server Lite.** TODO #86.
   - **`POST /api/hooks`** receives Claude Code lifecycle event payloads (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `PreCompact`, `SessionEnd`). Validates required fields, resolves `cwd` → project slug via scan cache with subdirectory matching, pushes to an in-memory ring buffer (50-event cap per slug) on a `globalThis` singleton.
   - **Live activity badges on project cards.** A green **live** pulse dot appears on cards whose project has had a hook event in the last 30 seconds. An amber **input** badge appears when Claude is awaiting permission (`Notification` hook). Both update within the existing 5-second pulse poll cycle — no additional polling interval.

--- a/docs/help/otel.md
+++ b/docs/help/otel.md
@@ -1,0 +1,70 @@
+# OpenTelemetry (OTEL)
+
+Project Minder can receive real-time telemetry events from Claude Code via the
+OpenTelemetry Protocol (OTLP). When enabled, Claude Code streams tool events,
+API calls, and cost metrics directly to Project Minder's local ingest endpoint.
+
+## What OTEL unlocks
+
+- **Edit acceptance tracking** — see per-tool accept/reject rates for write
+  operations (Edit, Write, MultiEdit) across your sessions (coming in a future
+  update).
+- **Tool latency** — p50/p95/max latency per tool, so you can see which tools
+  are slow (coming in a future update).
+- **Cost metrics stream** — structured per-session token and cost data directly
+  from Claude Code's billing pipeline, not recomputed from JSONL.
+
+## Setup
+
+1. Open **Settings → Integrations → OpenTelemetry**.
+2. Leave the endpoint as the default (`http://localhost:4100/api/otel`) unless
+   Project Minder runs behind a reverse proxy.
+3. Click **Install**. Project Minder writes four environment variables into
+   `~/.claude/settings.json`:
+
+   | Variable | Value |
+   |---|---|
+   | `CLAUDE_CODE_ENABLE_TELEMETRY` | `1` |
+   | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4100/api/otel` (or your custom endpoint) |
+   | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/json` |
+   | `OTEL_LOG_TOOL_DETAILS` | `1` |
+
+4. **Restart Claude Code** for the env vars to take effect. Claude Code reads
+   `settings.json` at startup.
+
+## Disabling
+
+Click **Remove** in Settings → Integrations → OpenTelemetry. Project Minder
+removes the four env vars from `~/.claude/settings.json` and leaves all other
+configuration untouched. Restart Claude Code to stop the telemetry stream.
+
+## Privacy
+
+All telemetry data stays local. The OTLP endpoint is only reachable inside
+your machine (default `localhost:4100`). No data is sent to Anthropic or any
+third party by Project Minder. Claude Code itself may send telemetry to
+Anthropic independent of this configuration — see Anthropic's privacy policy
+for details.
+
+## Wire format
+
+Project Minder's OTLP receiver accepts **HTTP JSON only**
+(`OTEL_EXPORTER_OTLP_PROTOCOL=http/json`). The default OTel SDK protocol is
+protobuf; the `http/json` override is mandatory and is set automatically by
+the installer.
+
+Two endpoints are registered:
+
+| Endpoint | Data |
+|---|---|
+| `POST /api/otel/v1/logs` | Tool events, API requests, session lifecycle |
+| `POST /api/otel/v1/metrics` | Token usage, cost, session count |
+
+Both implement the OTLP partial-success contract: a malformed individual
+record is rejected without dropping the rest of the batch.
+
+## Storage
+
+Events land in the `otel_events` table in `~/.minder/index.db`. Metrics land
+in `otel_metrics`. The schema uses a generic `payload_json` column for events
+so detectors can be added in future waves without migrating existing rows.

--- a/public/help/otel.md
+++ b/public/help/otel.md
@@ -1,0 +1,70 @@
+# OpenTelemetry (OTEL)
+
+Project Minder can receive real-time telemetry events from Claude Code via the
+OpenTelemetry Protocol (OTLP). When enabled, Claude Code streams tool events,
+API calls, and cost metrics directly to Project Minder's local ingest endpoint.
+
+## What OTEL unlocks
+
+- **Edit acceptance tracking** — see per-tool accept/reject rates for write
+  operations (Edit, Write, MultiEdit) across your sessions (coming in a future
+  update).
+- **Tool latency** — p50/p95/max latency per tool, so you can see which tools
+  are slow (coming in a future update).
+- **Cost metrics stream** — structured per-session token and cost data directly
+  from Claude Code's billing pipeline, not recomputed from JSONL.
+
+## Setup
+
+1. Open **Settings → Integrations → OpenTelemetry**.
+2. Leave the endpoint as the default (`http://localhost:4100/api/otel`) unless
+   Project Minder runs behind a reverse proxy.
+3. Click **Install**. Project Minder writes four environment variables into
+   `~/.claude/settings.json`:
+
+   | Variable | Value |
+   |---|---|
+   | `CLAUDE_CODE_ENABLE_TELEMETRY` | `1` |
+   | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4100/api/otel` (or your custom endpoint) |
+   | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/json` |
+   | `OTEL_LOG_TOOL_DETAILS` | `1` |
+
+4. **Restart Claude Code** for the env vars to take effect. Claude Code reads
+   `settings.json` at startup.
+
+## Disabling
+
+Click **Remove** in Settings → Integrations → OpenTelemetry. Project Minder
+removes the four env vars from `~/.claude/settings.json` and leaves all other
+configuration untouched. Restart Claude Code to stop the telemetry stream.
+
+## Privacy
+
+All telemetry data stays local. The OTLP endpoint is only reachable inside
+your machine (default `localhost:4100`). No data is sent to Anthropic or any
+third party by Project Minder. Claude Code itself may send telemetry to
+Anthropic independent of this configuration — see Anthropic's privacy policy
+for details.
+
+## Wire format
+
+Project Minder's OTLP receiver accepts **HTTP JSON only**
+(`OTEL_EXPORTER_OTLP_PROTOCOL=http/json`). The default OTel SDK protocol is
+protobuf; the `http/json` override is mandatory and is set automatically by
+the installer.
+
+Two endpoints are registered:
+
+| Endpoint | Data |
+|---|---|
+| `POST /api/otel/v1/logs` | Tool events, API requests, session lifecycle |
+| `POST /api/otel/v1/metrics` | Token usage, cost, session count |
+
+Both implement the OTLP partial-success contract: a malformed individual
+record is rejected without dropping the rest of the batch.
+
+## Storage
+
+Events land in the `otel_events` table in `~/.minder/index.db`. Metrics land
+in `otel_metrics`. The schema uses a generic `payload_json` column for events
+so detectors can be added in future waves without migrating existing rows.

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -220,9 +220,11 @@ export async function PATCH(request: NextRequest) {
         return NextResponse.json({ error: "otel.endpoint must be a string" }, { status: 400 });
       }
       try {
-        new URL(endpoint as string);
+        const u = new URL(endpoint as string);
+        const isLocalhost = u.hostname === "localhost" || u.hostname === "127.0.0.1";
+        if (u.protocol !== "https:" && !(u.protocol === "http:" && isLocalhost)) throw new Error();
       } catch {
-        return NextResponse.json({ error: "otel.endpoint must be a valid URL" }, { status: 400 });
+        return NextResponse.json({ error: "otel.endpoint must be an HTTPS URL (or http://localhost)" }, { status: 400 });
       }
     }
     patches.push((c) => {

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -206,6 +206,33 @@ export async function PATCH(request: NextRequest) {
     });
   }
 
+  if (body.otel !== undefined) {
+    if (
+      typeof body.otel !== "object" ||
+      body.otel === null ||
+      Array.isArray(body.otel)
+    ) {
+      return NextResponse.json({ error: "otel must be an object" }, { status: 400 });
+    }
+    const { endpoint } = body.otel as Record<string, unknown>;
+    if (endpoint !== undefined) {
+      if (typeof endpoint !== "string") {
+        return NextResponse.json({ error: "otel.endpoint must be a string" }, { status: 400 });
+      }
+      try {
+        new URL(endpoint as string);
+      } catch {
+        return NextResponse.json({ error: "otel.endpoint must be a valid URL" }, { status: 400 });
+      }
+    }
+    patches.push((c) => {
+      c.otel = {
+        ...(c.otel ?? {}),
+        ...(endpoint !== undefined ? { endpoint: endpoint as string } : {}),
+      };
+    });
+  }
+
   if (patches.length === 0) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
   }

--- a/src/app/api/integrations/otel/route.ts
+++ b/src/app/api/integrations/otel/route.ts
@@ -37,9 +37,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         ? endpoint.trim()
         : DEFAULT_ENDPOINT;
     try {
-      new URL(ep);
+      const u = new URL(ep);
+      const isLocalhost = u.hostname === "localhost" || u.hostname === "127.0.0.1";
+      if (u.protocol !== "https:" && !(u.protocol === "http:" && isLocalhost)) throw new Error();
     } catch {
-      return NextResponse.json({ error: "endpoint must be a valid URL" }, { status: 400 });
+      return NextResponse.json({ error: "endpoint must be an HTTPS URL (or http://localhost)" }, { status: 400 });
     }
     try {
       await installOtelEnv(ep);

--- a/src/app/api/integrations/otel/route.ts
+++ b/src/app/api/integrations/otel/route.ts
@@ -1,0 +1,65 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getOtelInstallStatus,
+  installOtelEnv,
+  removeOtelEnv,
+} from "@/lib/otelSettings";
+
+const DEFAULT_ENDPOINT = "http://localhost:4100/api/otel";
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const status = await getOtelInstallStatus();
+    return NextResponse.json(status);
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json({ error: "Body must be an object" }, { status: 400 });
+  }
+
+  const { action, endpoint } = body as Record<string, unknown>;
+
+  if (action === "install") {
+    const ep =
+      typeof endpoint === "string" && endpoint.trim().length > 0
+        ? endpoint.trim()
+        : DEFAULT_ENDPOINT;
+    try {
+      new URL(ep);
+    } catch {
+      return NextResponse.json({ error: "endpoint must be a valid URL" }, { status: 400 });
+    }
+    try {
+      await installOtelEnv(ep);
+      return NextResponse.json(await getOtelInstallStatus());
+    } catch (err) {
+      return NextResponse.json({ error: (err as Error).message }, { status: 500 });
+    }
+  }
+
+  if (action === "remove") {
+    try {
+      await removeOtelEnv();
+      return NextResponse.json(await getOtelInstallStatus());
+    } catch (err) {
+      return NextResponse.json({ error: (err as Error).message }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json(
+    { error: 'action must be "install" or "remove"' },
+    { status: 400 },
+  );
+}

--- a/src/app/api/otel/v1/logs/route.ts
+++ b/src/app/api/otel/v1/logs/route.ts
@@ -55,21 +55,25 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   for (const rl of resourceLogs) {
     if (typeof rl !== "object" || rl === null) continue;
     const resource = (rl as { resource?: OtlpResource }).resource;
-    const scopeLogs = (rl as { scopeLogs?: unknown[] }).scopeLogs ?? [];
+    const rawSl = (rl as { scopeLogs?: unknown }).scopeLogs;
+    const scopeLogs = Array.isArray(rawSl) ? rawSl : [];
 
     for (const sl of scopeLogs) {
       if (typeof sl !== "object" || sl === null) continue;
-      const logRecords = (sl as { logRecords?: unknown[] }).logRecords ?? [];
+      const rawLr = (sl as { logRecords?: unknown }).logRecords;
+      const logRecords = Array.isArray(rawLr) ? rawLr : [];
 
       const { errors: batchErrors } = await ingestLogBatch(logRecords as OtlpLogRecord[], resource);
       rejected += batchErrors.length;
-      errors.push(...batchErrors);
+      for (const e of batchErrors) {
+        if (errors.length < 5) errors.push(e);
+      }
     }
   }
 
   const partialSuccess =
     rejected > 0
-      ? { rejectedLogRecords: rejected, errorMessage: errors.slice(0, 5).join("; ") }
+      ? { rejectedLogRecords: rejected, errorMessage: errors.join("; ") }
       : { rejectedLogRecords: 0 };
 
   return NextResponse.json({ partialSuccess });

--- a/src/app/api/otel/v1/logs/route.ts
+++ b/src/app/api/otel/v1/logs/route.ts
@@ -1,0 +1,81 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { ingestLog, isOtelDbReady } from "@/lib/db/otelIngest";
+import type { OtlpLogRecord, OtlpResource } from "@/lib/db/otelIngest";
+
+// OTLP/HTTP JSON logs receiver.
+//
+// Claude Code's OTel SDK appends /v1/logs to whatever base endpoint is
+// configured.  Wizard sets OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4100/api/otel
+// and OTEL_EXPORTER_OTLP_PROTOCOL=http/json, so traffic arrives here.
+//
+// Per-record try/catch implements the OTLP partial-success contract: one
+// malformed record does not drop the rest of the batch.  Response shape
+// follows the OTLP spec (exportLogsServiceResponse):
+//
+//   { partialSuccess: { rejectedLogRecords: N, errorMessage: "..." } }
+//
+// A 200 with rejectedLogRecords=0 means full success.
+// A 200 with rejectedLogRecords>0 means partial success.
+// Non-200 means the entire batch was rejected (e.g. DB unavailable).
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isOtelDbReady()) {
+    return NextResponse.json(
+      { error: "OTEL storage not available" },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null || !("resourceLogs" in body)) {
+    return NextResponse.json(
+      { error: "Expected {resourceLogs: [...]} envelope" },
+      { status: 400 },
+    );
+  }
+
+  const resourceLogs = (body as { resourceLogs: unknown }).resourceLogs;
+  if (!Array.isArray(resourceLogs)) {
+    return NextResponse.json(
+      { error: "resourceLogs must be an array" },
+      { status: 400 },
+    );
+  }
+
+  let rejected = 0;
+  const errors: string[] = [];
+
+  for (const rl of resourceLogs) {
+    if (typeof rl !== "object" || rl === null) continue;
+    const resource = (rl as { resource?: OtlpResource }).resource;
+    const scopeLogs = (rl as { scopeLogs?: unknown[] }).scopeLogs ?? [];
+
+    for (const sl of scopeLogs) {
+      if (typeof sl !== "object" || sl === null) continue;
+      const logRecords = (sl as { logRecords?: unknown[] }).logRecords ?? [];
+
+      for (const lr of logRecords) {
+        try {
+          await ingestLog(lr as OtlpLogRecord, resource);
+        } catch (err) {
+          rejected++;
+          errors.push((err as Error).message);
+        }
+      }
+    }
+  }
+
+  const partialSuccess =
+    rejected > 0
+      ? { rejectedLogRecords: rejected, errorMessage: errors.slice(0, 5).join("; ") }
+      : { rejectedLogRecords: 0 };
+
+  return NextResponse.json({ partialSuccess });
+}

--- a/src/app/api/otel/v1/logs/route.ts
+++ b/src/app/api/otel/v1/logs/route.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { NextRequest, NextResponse } from "next/server";
-import { ingestLog, isOtelDbReady } from "@/lib/db/otelIngest";
+import { ingestLogBatch, isOtelDbReady } from "@/lib/db/otelIngest";
 import type { OtlpLogRecord, OtlpResource } from "@/lib/db/otelIngest";
 
 // OTLP/HTTP JSON logs receiver.
@@ -61,14 +61,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       if (typeof sl !== "object" || sl === null) continue;
       const logRecords = (sl as { logRecords?: unknown[] }).logRecords ?? [];
 
-      for (const lr of logRecords) {
-        try {
-          await ingestLog(lr as OtlpLogRecord, resource);
-        } catch (err) {
-          rejected++;
-          errors.push((err as Error).message);
-        }
-      }
+      const { errors: batchErrors } = await ingestLogBatch(logRecords as OtlpLogRecord[], resource);
+      rejected += batchErrors.length;
+      errors.push(...batchErrors);
     }
   }
 

--- a/src/app/api/otel/v1/metrics/route.ts
+++ b/src/app/api/otel/v1/metrics/route.ts
@@ -50,18 +50,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   for (const rm of resourceMetrics) {
     if (typeof rm !== "object" || rm === null) continue;
     const resource = (rm as { resource?: OtlpResource }).resource;
-    const scopeMetrics = (rm as { scopeMetrics?: unknown[] }).scopeMetrics ?? [];
+    const raw = (rm as { scopeMetrics?: unknown }).scopeMetrics;
+    const scopeMetrics = Array.isArray(raw) ? raw : [];
 
     for (const sm of scopeMetrics) {
       if (typeof sm !== "object" || sm === null) continue;
-      const metrics = (sm as { metrics?: unknown[] }).metrics ?? [];
+      const rawM = (sm as { metrics?: unknown }).metrics;
+      const metrics = Array.isArray(rawM) ? rawM : [];
 
       for (const metric of metrics) {
         try {
-          await ingestMetric(metric as OtlpMetric, resource);
+          const { rejected: r } = await ingestMetric(metric as OtlpMetric, resource);
+          rejected += r;
         } catch (err) {
           rejected++;
-          errors.push((err as Error).message);
+          if (errors.length < 5) errors.push((err as Error).message);
         }
       }
     }
@@ -69,7 +72,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const partialSuccess =
     rejected > 0
-      ? { rejectedDataPoints: rejected, errorMessage: errors.slice(0, 5).join("; ") }
+      ? { rejectedDataPoints: rejected, errorMessage: errors.join("; ") }
       : { rejectedDataPoints: 0 };
 
   return NextResponse.json({ partialSuccess });

--- a/src/app/api/otel/v1/metrics/route.ts
+++ b/src/app/api/otel/v1/metrics/route.ts
@@ -1,0 +1,76 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { ingestMetric, isOtelDbReady } from "@/lib/db/otelIngest";
+import type { OtlpMetric, OtlpResource } from "@/lib/db/otelIngest";
+
+// OTLP/HTTP JSON metrics receiver.
+//
+// Same base-endpoint as the logs receiver — wizard sets
+// OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4100/api/otel and the SDK
+// appends /v1/metrics.
+//
+// Implements the same partial-success contract as /v1/logs but for metrics
+// (exportMetricsServiceResponse):
+//
+//   { partialSuccess: { rejectedDataPoints: N, errorMessage: "..." } }
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isOtelDbReady()) {
+    return NextResponse.json(
+      { error: "OTEL storage not available" },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body !== "object" || body === null || !("resourceMetrics" in body)) {
+    return NextResponse.json(
+      { error: "Expected {resourceMetrics: [...]} envelope" },
+      { status: 400 },
+    );
+  }
+
+  const resourceMetrics = (body as { resourceMetrics: unknown }).resourceMetrics;
+  if (!Array.isArray(resourceMetrics)) {
+    return NextResponse.json(
+      { error: "resourceMetrics must be an array" },
+      { status: 400 },
+    );
+  }
+
+  let rejected = 0;
+  const errors: string[] = [];
+
+  for (const rm of resourceMetrics) {
+    if (typeof rm !== "object" || rm === null) continue;
+    const resource = (rm as { resource?: OtlpResource }).resource;
+    const scopeMetrics = (rm as { scopeMetrics?: unknown[] }).scopeMetrics ?? [];
+
+    for (const sm of scopeMetrics) {
+      if (typeof sm !== "object" || sm === null) continue;
+      const metrics = (sm as { metrics?: unknown[] }).metrics ?? [];
+
+      for (const metric of metrics) {
+        try {
+          await ingestMetric(metric as OtlpMetric, resource);
+        } catch (err) {
+          rejected++;
+          errors.push((err as Error).message);
+        }
+      }
+    }
+  }
+
+  const partialSuccess =
+    rejected > 0
+      ? { rejectedDataPoints: rejected, errorMessage: errors.slice(0, 5).join("; ") }
+      : { rejectedDataPoints: 0 };
+
+  return NextResponse.json({ partialSuccess });
+}

--- a/src/components/settings/IntegrationsSection.tsx
+++ b/src/components/settings/IntegrationsSection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { MinderConfig } from "@/lib/types";
 import { S } from "./styles";
+import { OtelSection } from "./OtelSection";
 
 export function IntegrationsSection({
   config,
@@ -68,7 +69,9 @@ export function IntegrationsSection({
   return (
     <section>
       <h2 style={S.sectionTitle}>Integrations</h2>
-      <p style={S.desc}>Connect external notification channels. Telegram bot bridge (Wave 7). OTEL and others coming in Wave 8.</p>
+      <p style={S.desc}>Connect external services. Telegram for notifications; OTEL for real-time Claude Code telemetry.</p>
+
+      <OtelSection config={config} onConfigChange={onConfigChange} />
 
       <div style={S.card}>
         <div style={{ fontWeight: 600, fontSize: "0.85rem", color: "var(--text-primary)", marginBottom: "12px" }}>

--- a/src/components/settings/OtelSection.tsx
+++ b/src/components/settings/OtelSection.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { MinderConfig } from "@/lib/types";
+import { S } from "./styles";
+
+interface OtelStatus {
+  installed: boolean;
+  endpoint: string | null;
+}
+
+const DEFAULT_ENDPOINT = "http://localhost:4100/api/otel";
+
+export function OtelSection({
+  config,
+  onConfigChange,
+}: {
+  config: MinderConfig | null;
+  onConfigChange: (patch: Partial<MinderConfig>) => Promise<void>;
+}) {
+  const [status, setStatus] = useState<OtelStatus | null>(null);
+  const [endpoint, setEndpoint] = useState(config?.otel?.endpoint ?? DEFAULT_ENDPOINT);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ text: string; ok: boolean } | null>(null);
+
+  useEffect(() => {
+    fetch("/api/integrations/otel")
+      .then((r) => r.json())
+      .then((d) => setStatus(d as OtelStatus))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    setEndpoint(config?.otel?.endpoint ?? DEFAULT_ENDPOINT);
+  }, [config?.otel?.endpoint]);
+
+  async function callApi(action: "install" | "remove"): Promise<OtelStatus> {
+    const res = await fetch("/api/integrations/otel", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action, endpoint: action === "install" ? endpoint : undefined }),
+    });
+    const data = (await res.json()) as OtelStatus & { error?: string };
+    if (!res.ok) throw new Error(data.error ?? `${action} failed`);
+    return data;
+  }
+
+  async function handleInstall() {
+    setBusy(true); setMsg(null);
+    try {
+      const next = await callApi("install");
+      setStatus(next);
+      await onConfigChange({ otel: { endpoint } });
+      setMsg({ text: "OTEL env vars written to ~/.claude/settings.json. Restart Claude Code for them to take effect.", ok: true });
+    } catch (err) {
+      setMsg({ text: (err as Error).message, ok: false });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRemove() {
+    setBusy(true); setMsg(null);
+    try {
+      const next = await callApi("remove");
+      setStatus(next);
+      setMsg({ text: "OTEL env vars removed.", ok: true });
+    } catch (err) {
+      setMsg({ text: (err as Error).message, ok: false });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const installedElsewhere =
+    status?.installed && status.endpoint !== null && status.endpoint !== endpoint;
+
+  return (
+    <div style={S.card}>
+      <div style={{ fontWeight: 600, fontSize: "0.85rem", color: "var(--text-primary)", marginBottom: "12px" }}>
+        OpenTelemetry (OTEL)
+      </div>
+
+      <div style={{ ...S.muted, marginBottom: "16px" }}>
+        Receive real-time tool events and cost metrics from Claude Code via the OTEL pipeline.
+        Enables edit-acceptance tracking and per-tool latency dashboards in a future update.
+      </div>
+
+      {/* Status indicator */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "16px" }}>
+        <span style={{
+          display: "inline-block", width: "8px", height: "8px", borderRadius: "50%",
+          background: status?.installed ? "var(--status-active-text)" : "var(--border-default)",
+          flexShrink: 0,
+        }} />
+        <span style={S.label}>
+          {status === null
+            ? "Checking…"
+            : status.installed
+            ? `Configured — receiving at ${status.endpoint}`
+            : "Not configured"}
+        </span>
+      </div>
+
+      {installedElsewhere && (
+        <div style={{
+          fontSize: "0.74rem", color: "var(--accent)", background: "var(--accent-bg)",
+          border: "1px solid var(--accent-border)", borderRadius: "var(--radius)",
+          padding: "8px 12px", marginBottom: "12px",
+        }}>
+          OTEL is configured with a different endpoint ({status!.endpoint}). Click Install to update.
+        </div>
+      )}
+
+      {/* Endpoint field */}
+      <div style={{ marginBottom: "16px" }}>
+        <div style={{ ...S.label, marginBottom: "4px" }}>Receiver endpoint</div>
+        <input
+          type="text"
+          style={S.input}
+          value={endpoint}
+          onChange={(e) => setEndpoint(e.target.value)}
+          placeholder={DEFAULT_ENDPOINT}
+        />
+        <div style={{ ...S.muted, marginTop: "4px" }}>
+          Claude Code appends <code style={{ fontFamily: "var(--font-mono)" }}>/v1/logs</code> and{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>/v1/metrics</code> to this base URL.
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "12px" }}>
+        <button
+          style={{
+            ...S.btn,
+            background: "var(--info)", color: "#fff", borderColor: "var(--info)",
+            opacity: (status?.installed && !installedElsewhere) || busy ? 0.4 : 1,
+          }}
+          disabled={(status?.installed && !installedElsewhere) || busy}
+          onClick={handleInstall}
+        >
+          {busy ? "Working…" : status?.installed && installedElsewhere ? "Reinstall" : "Install"}
+        </button>
+        <button
+          style={{
+            ...S.btn,
+            color: "var(--status-error-text)", borderColor: "var(--status-error-border)",
+            opacity: (!status?.installed || busy) ? 0.4 : 1,
+          }}
+          disabled={!status?.installed || busy}
+          onClick={handleRemove}
+        >
+          Remove
+        </button>
+      </div>
+
+      {msg && (
+        <div style={{
+          fontSize: "0.74rem", marginBottom: "12px",
+          color: msg.ok ? "var(--status-active-text)" : "var(--status-error-text)",
+        }}>
+          {msg.text}
+        </div>
+      )}
+
+      {/* Setup note */}
+      <div style={{
+        padding: "10px 12px", borderRadius: "var(--radius)",
+        background: "var(--surface-2, transparent)", fontSize: "0.74rem",
+        color: "var(--text-muted)", lineHeight: 1.6,
+      }}>
+        <strong style={{ color: "var(--text-secondary)" }}>Setup:</strong>{" "}
+        Click Install to write four env vars into{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>~/.claude/settings.json</code>:
+        {" "}<code style={{ fontFamily: "var(--font-mono)" }}>CLAUDE_CODE_ENABLE_TELEMETRY=1</code>,
+        {" "}<code style={{ fontFamily: "var(--font-mono)" }}>OTEL_EXPORTER_OTLP_ENDPOINT</code>,
+        {" "}<code style={{ fontFamily: "var(--font-mono)" }}>OTEL_EXPORTER_OTLP_PROTOCOL=http/json</code>, and
+        {" "}<code style={{ fontFamily: "var(--font-mono)" }}>OTEL_LOG_TOOL_DETAILS=1</code>.{" "}
+        Restart Claude Code for the vars to take effect. All telemetry data stays local.
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/OtelSection.tsx
+++ b/src/components/settings/OtelSection.tsx
@@ -49,8 +49,8 @@ export function OtelSection({
     setBusy(true); setMsg(null);
     try {
       const next = await callApi("install");
-      setStatus(next);
       await onConfigChange({ otel: { endpoint } });
+      setStatus(next);
       setMsg({ text: "OTEL env vars written to ~/.claude/settings.json. Restart Claude Code for them to take effect.", ok: true });
     } catch (err) {
       setMsg({ text: (err as Error).message, ok: false });
@@ -74,6 +74,8 @@ export function OtelSection({
 
   const installedElsewhere =
     status?.installed && status.endpoint !== null && status.endpoint !== endpoint;
+  const alreadyInstalled = !!status?.installed && !installedElsewhere;
+  const installLabel = busy ? "Working…" : installedElsewhere ? "Reinstall" : "Install";
 
   return (
     <div style={S.card}>
@@ -134,12 +136,12 @@ export function OtelSection({
           style={{
             ...S.btn,
             background: "var(--info)", color: "#fff", borderColor: "var(--info)",
-            opacity: (status?.installed && !installedElsewhere) || busy ? 0.4 : 1,
+            opacity: alreadyInstalled || busy ? 0.4 : 1,
           }}
-          disabled={(status?.installed && !installedElsewhere) || busy}
+          disabled={alreadyInstalled || busy}
           onClick={handleInstall}
         >
-          {busy ? "Working…" : status?.installed && installedElsewhere ? "Reinstall" : "Install"}
+          {installLabel}
         </button>
         <button
           style={{

--- a/src/components/settings/OtelSection.tsx
+++ b/src/components/settings/OtelSection.tsx
@@ -49,8 +49,10 @@ export function OtelSection({
     setBusy(true); setMsg(null);
     try {
       const next = await callApi("install");
-      await onConfigChange({ otel: { endpoint } });
+      const actualEndpoint = next.endpoint ?? endpoint;
+      await onConfigChange({ otel: { endpoint: actualEndpoint } });
       setStatus(next);
+      if (actualEndpoint !== endpoint) setEndpoint(actualEndpoint);
       setMsg({ text: "OTEL env vars written to ~/.claude/settings.json. Restart Claude Code for them to take effect.", ok: true });
     } catch (err) {
       setMsg({ text: (err as Error).message, ok: false });

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -258,6 +258,33 @@ const MIGRATIONS: Migration[] = [
       ).run();
     },
   },
+  {
+    version: 9,
+    name: "wave8.1a: otel_metrics table",
+    up: (db) => {
+      // CREATE TABLE IF NOT EXISTS is idempotent: fresh DBs that ran the
+      // full schema.sql in v1 (which already includes otel_metrics) will
+      // silently no-op here.
+      db.prepare(`
+        CREATE TABLE IF NOT EXISTS otel_metrics (
+          id           INTEGER PRIMARY KEY,
+          ts           INTEGER NOT NULL,
+          session_id   TEXT,
+          metric_name  TEXT NOT NULL,
+          metric_type  TEXT NOT NULL CHECK (metric_type IN ('counter', 'gauge')),
+          value        REAL NOT NULL,
+          model        TEXT,
+          attrs_json   TEXT
+        )
+      `).run();
+      db.prepare(
+        "CREATE INDEX IF NOT EXISTS otel_metrics_by_name ON otel_metrics(metric_name, ts)"
+      ).run();
+      db.prepare(
+        "CREATE INDEX IF NOT EXISTS otel_metrics_by_session ON otel_metrics(session_id) WHERE session_id IS NOT NULL"
+      ).run();
+    },
+  },
 ];
 
 function resolveSchemaPath(): string {

--- a/src/lib/db/otelIngest.ts
+++ b/src/lib/db/otelIngest.ts
@@ -178,6 +178,63 @@ export async function ingestMetric(
   txn();
 }
 
+// ─── Batch log ingest ─────────────────────────────────────────────────────
+
+/**
+ * Persist a batch of OTLP log records to `otel_events` in a single transaction.
+ *
+ * Validates each record independently and collects errors; valid records are
+ * committed together (one fsync per batch instead of one per record).  Returns
+ * the per-record error messages so the route can build a partial-success response.
+ */
+export async function ingestLogBatch(
+  records: OtlpLogRecord[],
+  resource: OtlpResource | undefined,
+): Promise<{ errors: string[] }> {
+  const db = await getDb();
+  if (!db) throw new Error("DB unavailable");
+
+  const defaultSessionId = sessionFromResource(resource);
+  const stmt = prepCached(
+    db,
+    `INSERT INTO otel_events (ts, session_id, event_name, payload_json)
+     VALUES (?, ?, ?, ?)`,
+  );
+
+  const rows: [string, string | null, string, string][] = [];
+  const errors: string[] = [];
+
+  for (const record of records) {
+    try {
+      const ts = nanoToMs(record.timeUnixNano ?? record.observedTimeUnixNano);
+      if (ts === null) throw new Error("Missing or invalid timeUnixNano");
+
+      const attrs = attrMap(record.attributes);
+      const eventName =
+        (attrs.get("event.name") as string | undefined) ??
+        record.body?.stringValue ??
+        "unknown";
+      const sessionId = (attrs.get("session.id") as string | undefined) ?? defaultSessionId;
+
+      const payloadAttrs: Record<string, unknown> = {};
+      for (const [k, v] of attrs) payloadAttrs[k] = v;
+      const payloadJson = JSON.stringify({ ts, body: record.body?.stringValue, attrs: payloadAttrs });
+
+      rows.push([new Date(ts).toISOString(), sessionId, eventName, payloadJson]);
+    } catch (err) {
+      errors.push((err as Error).message);
+    }
+  }
+
+  if (rows.length > 0) {
+    db.transaction(() => {
+      for (const row of rows) stmt.run(...row);
+    })();
+  }
+
+  return { errors };
+}
+
 // ─── Guard helper ─────────────────────────────────────────────────────────
 
 export function isOtelDbReady(): boolean {

--- a/src/lib/db/otelIngest.ts
+++ b/src/lib/db/otelIngest.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { getDb, prepCached, isDbAvailable } from "./connection";
+import { getDb, prepCached, isDriverLoaded } from "./connection";
 
 // OTLP attribute value helper types.  The JSON encoding wraps every value in
 // a typed union: {stringValue}, {intValue}, {doubleValue}, {boolValue}.
@@ -102,7 +102,6 @@ export async function ingestLog(
 
   const sessionId = (attrs.get("session.id") as string | undefined) ?? sessionFromResource(resource);
 
-  // Build a compact payload object: all attributes minus large redundant fields.
   const payloadAttrs: Record<string, unknown> = {};
   for (const [k, v] of attrs) payloadAttrs[k] = v;
 
@@ -126,18 +125,16 @@ export async function ingestLog(
 export async function ingestMetric(
   metric: OtlpMetric,
   resource: OtlpResource | undefined,
-): Promise<void> {
+): Promise<{ rejected: number }> {
   const db = await getDb();
   if (!db) throw new Error("DB unavailable");
 
   const metricName = metric.name;
   if (!metricName) throw new Error("Metric missing name");
 
-  const dataPoints: OtlpDataPoint[] = [
-    ...(metric.sum?.dataPoints ?? []),
-    ...(metric.gauge?.dataPoints ?? []),
-  ];
-  if (dataPoints.length === 0) return;
+  if (metric.sum && metric.gauge) throw new Error(`Metric ${metricName} has both sum and gauge — invalid OTLP shape`);
+  const dataPoints: OtlpDataPoint[] = metric.gauge?.dataPoints ?? metric.sum?.dataPoints ?? [];
+  if (dataPoints.length === 0) return { rejected: 0 };
 
   const metricType: "counter" | "gauge" = metric.gauge ? "gauge" : "counter";
   const defaultSessionId = sessionFromResource(resource);
@@ -148,10 +145,11 @@ export async function ingestMetric(
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
   );
 
-  const txn = db.transaction(() => {
+  let rejected = 0;
+  db.transaction(() => {
     for (const dp of dataPoints) {
       const ts = nanoToMs(dp.timeUnixNano);
-      if (ts === null) continue;
+      if (ts === null) { rejected++; continue; }
 
       const attrs = attrMap(dp.attributes);
       const sessionId = (attrs.get("session.id") as string | undefined) ?? defaultSessionId;
@@ -163,9 +161,8 @@ export async function ingestMetric(
           : dp.asInt !== undefined
           ? Number(dp.asInt)
           : null;
-      if (value === null || !Number.isFinite(value)) continue;
+      if (value === null || !Number.isFinite(value)) { rejected++; continue; }
 
-      // Serialize residual attributes (drop session.id and model — promoted).
       const residual: Record<string, unknown> = {};
       for (const [k, v] of attrs) {
         if (k !== "session.id" && k !== "model") residual[k] = v;
@@ -174,8 +171,8 @@ export async function ingestMetric(
 
       insertStmt.run(ts, sessionId, metricName, metricType, value, model, attrsJson);
     }
-  });
-  txn();
+  })();
+  return { rejected };
 }
 
 // ─── Batch log ingest ─────────────────────────────────────────────────────
@@ -238,5 +235,5 @@ export async function ingestLogBatch(
 // ─── Guard helper ─────────────────────────────────────────────────────────
 
 export function isOtelDbReady(): boolean {
-  return isDbAvailable();
+  return isDriverLoaded();
 }

--- a/src/lib/db/otelIngest.ts
+++ b/src/lib/db/otelIngest.ts
@@ -1,0 +1,185 @@
+import "server-only";
+import { getDb, prepCached, isDbAvailable } from "./connection";
+
+// OTLP attribute value helper types.  The JSON encoding wraps every value in
+// a typed union: {stringValue}, {intValue}, {doubleValue}, {boolValue}.
+interface AttrValue {
+  stringValue?: string;
+  intValue?: string | number;
+  doubleValue?: number;
+  boolValue?: boolean;
+}
+
+interface OtlpAttribute {
+  key: string;
+  value: AttrValue;
+}
+
+// ─── Public OTLP JSON shapes ──────────────────────────────────────────────
+
+export interface OtlpResource {
+  attributes?: OtlpAttribute[];
+}
+
+export interface OtlpLogRecord {
+  timeUnixNano?: string | number;
+  observedTimeUnixNano?: string | number;
+  body?: { stringValue?: string };
+  attributes?: OtlpAttribute[];
+}
+
+export interface OtlpDataPoint {
+  timeUnixNano?: string | number;
+  startTimeUnixNano?: string | number;
+  asDouble?: number;
+  asInt?: string | number;
+  attributes?: OtlpAttribute[];
+}
+
+export interface OtlpMetric {
+  name: string;
+  description?: string;
+  sum?: {
+    dataPoints?: OtlpDataPoint[];
+    isMonotonic?: boolean;
+  };
+  gauge?: {
+    dataPoints?: OtlpDataPoint[];
+  };
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────
+
+function attrMap(attrs: OtlpAttribute[] | undefined): Map<string, unknown> {
+  const m = new Map<string, unknown>();
+  if (!attrs) return m;
+  for (const a of attrs) {
+    const v = a.value;
+    if (v.stringValue !== undefined) m.set(a.key, v.stringValue);
+    else if (v.boolValue !== undefined) m.set(a.key, v.boolValue);
+    else if (v.intValue !== undefined) m.set(a.key, Number(v.intValue));
+    else if (v.doubleValue !== undefined) m.set(a.key, v.doubleValue);
+  }
+  return m;
+}
+
+function nanoToMs(nano: string | number | undefined): number | null {
+  if (nano === undefined || nano === null) return null;
+  const n = Number(nano);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n / 1_000_000);
+}
+
+function sessionFromResource(resource: OtlpResource | undefined): string | null {
+  const attrs = attrMap(resource?.attributes);
+  const s = attrs.get("session.id");
+  return typeof s === "string" && s.length > 0 ? s : null;
+}
+
+// ─── Log record ingest ────────────────────────────────────────────────────
+
+/**
+ * Persist a single OTLP log record to `otel_events`.
+ *
+ * Throws on hard failures (DB not available, schema bug) — the caller wraps
+ * per-record calls in a try/catch to implement partial-success semantics.
+ */
+export async function ingestLog(
+  record: OtlpLogRecord,
+  resource: OtlpResource | undefined,
+): Promise<void> {
+  const db = await getDb();
+  if (!db) throw new Error("DB unavailable");
+
+  const ts = nanoToMs(record.timeUnixNano ?? record.observedTimeUnixNano);
+  if (ts === null) throw new Error("Missing or invalid timeUnixNano");
+
+  const attrs = attrMap(record.attributes);
+  const eventName =
+    (attrs.get("event.name") as string | undefined) ??
+    record.body?.stringValue ??
+    "unknown";
+
+  const sessionId = (attrs.get("session.id") as string | undefined) ?? sessionFromResource(resource);
+
+  // Build a compact payload object: all attributes minus large redundant fields.
+  const payloadAttrs: Record<string, unknown> = {};
+  for (const [k, v] of attrs) payloadAttrs[k] = v;
+
+  const payloadJson = JSON.stringify({ ts, body: record.body?.stringValue, attrs: payloadAttrs });
+
+  prepCached(
+    db,
+    `INSERT INTO otel_events (ts, session_id, event_name, payload_json)
+     VALUES (?, ?, ?, ?)`,
+  ).run(new Date(ts).toISOString(), sessionId, eventName, payloadJson);
+}
+
+// ─── Metric data point ingest ─────────────────────────────────────────────
+
+/**
+ * Persist a single OTLP metric (all its data points) to `otel_metrics`.
+ *
+ * Wrapped in a transaction so either all data points for a metric write or
+ * none do on error.  Throws on hard failure.
+ */
+export async function ingestMetric(
+  metric: OtlpMetric,
+  resource: OtlpResource | undefined,
+): Promise<void> {
+  const db = await getDb();
+  if (!db) throw new Error("DB unavailable");
+
+  const metricName = metric.name;
+  if (!metricName) throw new Error("Metric missing name");
+
+  const dataPoints: OtlpDataPoint[] = [
+    ...(metric.sum?.dataPoints ?? []),
+    ...(metric.gauge?.dataPoints ?? []),
+  ];
+  if (dataPoints.length === 0) return;
+
+  const metricType: "counter" | "gauge" = metric.gauge ? "gauge" : "counter";
+  const defaultSessionId = sessionFromResource(resource);
+
+  const insertStmt = prepCached(
+    db,
+    `INSERT INTO otel_metrics (ts, session_id, metric_name, metric_type, value, model, attrs_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const txn = db.transaction(() => {
+    for (const dp of dataPoints) {
+      const ts = nanoToMs(dp.timeUnixNano);
+      if (ts === null) continue;
+
+      const attrs = attrMap(dp.attributes);
+      const sessionId = (attrs.get("session.id") as string | undefined) ?? defaultSessionId;
+      const model = (attrs.get("model") as string | undefined) ?? null;
+
+      const value =
+        dp.asDouble !== undefined
+          ? dp.asDouble
+          : dp.asInt !== undefined
+          ? Number(dp.asInt)
+          : null;
+      if (value === null || !Number.isFinite(value)) continue;
+
+      // Serialize residual attributes (drop session.id and model — promoted).
+      const residual: Record<string, unknown> = {};
+      for (const [k, v] of attrs) {
+        if (k !== "session.id" && k !== "model") residual[k] = v;
+      }
+      const attrsJson = Object.keys(residual).length ? JSON.stringify(residual) : null;
+
+      insertStmt.run(ts, sessionId, metricName, metricType, value, model, attrsJson);
+    }
+  });
+  txn();
+}
+
+// ─── Guard helper ─────────────────────────────────────────────────────────
+
+export function isOtelDbReady(): boolean {
+  return isDbAvailable();
+}

--- a/src/lib/db/schema.sql
+++ b/src/lib/db/schema.sql
@@ -407,6 +407,26 @@ CREATE TABLE otel_events (
 CREATE INDEX otel_events_by_session ON otel_events(session_id, ts);
 CREATE INDEX otel_events_by_name_ts ON otel_events(event_name, ts);
 
+-- ─── otel_metrics ─────────────────────────────────────────────────────────
+-- Normalized metric data points from the OTEL metrics pipeline.  One row per
+-- data point — counters and gauges share the table, distinguished by
+-- metric_type.  `attrs_json` holds any additional attributes not promoted to
+-- a top-level column (e.g. token type, billing category).
+
+CREATE TABLE IF NOT EXISTS otel_metrics (
+  id           INTEGER PRIMARY KEY,
+  ts           INTEGER NOT NULL,
+  session_id   TEXT,
+  metric_name  TEXT NOT NULL,
+  metric_type  TEXT NOT NULL CHECK (metric_type IN ('counter', 'gauge')),
+  value        REAL NOT NULL,
+  model        TEXT,
+  attrs_json   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS otel_metrics_by_name ON otel_metrics(metric_name, ts);
+CREATE INDEX IF NOT EXISTS otel_metrics_by_session ON otel_metrics(session_id) WHERE session_id IS NOT NULL;
+
 -- ─── indexer_runs ─────────────────────────────────────────────────────────
 -- Heartbeat / audit trail for the indexer worker. Lets the read-side
 -- answer "is the indexer alive? when did it last run? what failed?"

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -24,7 +24,6 @@ export const helpMapping: Record<string, string> = {
   '/settings/terminal': 'terminal',
   '/settings/auto-title': 'auto-title',
   '/settings/live-activity': 'live-activity',
-  '/settings/otel': 'otel',
   '/plans': 'plans',
   '/hooks': 'hooks',
   '/plugins': 'plugins',

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -24,6 +24,7 @@ export const helpMapping: Record<string, string> = {
   '/settings/terminal': 'terminal',
   '/settings/auto-title': 'auto-title',
   '/settings/live-activity': 'live-activity',
+  '/settings/otel': 'otel',
   '/plans': 'plans',
   '/hooks': 'hooks',
   '/plugins': 'plugins',
@@ -85,6 +86,7 @@ export const helpSlugs = [
   'telegram',
   'terminal',
   'auto-title',
+  'otel',
 ] as const
 
 export type HelpSlug = (typeof helpSlugs)[number]

--- a/src/lib/hooks/applyLiveActivity.ts
+++ b/src/lib/hooks/applyLiveActivity.ts
@@ -26,7 +26,9 @@ interface HookEntry {
 async function readUserSettings(targetPath: string): Promise<Record<string, unknown>> {
   try {
     const raw = await fs.readFile(targetPath, "utf-8");
-    return tryParseJsonc<Record<string, unknown>>(raw) ?? {};
+    const parsed = tryParseJsonc<Record<string, unknown>>(raw);
+    if (parsed === null) throw new Error(`${targetPath} is malformed JSON — fix the file before retrying`);
+    return parsed;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
     throw err;

--- a/src/lib/otelSettings.ts
+++ b/src/lib/otelSettings.ts
@@ -1,0 +1,91 @@
+import "server-only";
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+import { withFileLock, writeFileAtomic } from "@/lib/atomicWrite";
+import { recordPreWrite } from "@/lib/configHistory";
+import { tryParseJsonc } from "@/lib/scanner/util/jsonc";
+
+const USER_SETTINGS_PATH = path.join(os.homedir(), ".claude", "settings.json");
+
+// The four env vars that constitute a Project Minder OTEL installation.
+// Absence of OTEL_EXPORTER_OTLP_PROTOCOL=http/json causes the SDK to default
+// to protobuf, which our ingest endpoint does not support.
+const OTEL_ENV_KEYS = [
+  "CLAUDE_CODE_ENABLE_TELEMETRY",
+  "OTEL_EXPORTER_OTLP_ENDPOINT",
+  "OTEL_EXPORTER_OTLP_PROTOCOL",
+  "OTEL_LOG_TOOL_DETAILS",
+] as const;
+
+async function readUserSettings(p: string): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.readFile(p, "utf-8");
+    return tryParseJsonc<Record<string, unknown>>(raw) ?? {};
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+export interface OtelInstallStatus {
+  installed: boolean;
+  endpoint: string | null;
+}
+
+/**
+ * Returns the current OTEL install status by reading ~/.claude/settings.json.
+ * "Installed" means all four env vars are present.
+ */
+export async function getOtelInstallStatus(): Promise<OtelInstallStatus> {
+  const doc = await readUserSettings(USER_SETTINGS_PATH);
+  const env = (doc.env ?? {}) as Record<string, unknown>;
+  const installed = OTEL_ENV_KEYS.every((k) => typeof env[k] === "string" && (env[k] as string).length > 0);
+  const endpoint = typeof env["OTEL_EXPORTER_OTLP_ENDPOINT"] === "string"
+    ? (env["OTEL_EXPORTER_OTLP_ENDPOINT"] as string)
+    : null;
+  return { installed, endpoint };
+}
+
+/**
+ * Write OTEL env vars into ~/.claude/settings.json.
+ * Idempotent — re-running with the same endpoint just overwrites with the same values.
+ * Atomic write with COW snapshot.
+ */
+export async function installOtelEnv(endpoint: string): Promise<void> {
+  await withFileLock(USER_SETTINGS_PATH, async () => {
+    const doc = await readUserSettings(USER_SETTINGS_PATH);
+    if (!doc.env || typeof doc.env !== "object") doc.env = {};
+    const env = doc.env as Record<string, string>;
+    env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1";
+    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint;
+    env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/json";
+    env["OTEL_LOG_TOOL_DETAILS"] = "1";
+    await recordPreWrite(USER_SETTINGS_PATH, { label: "installOtelEnv" });
+    await fs.mkdir(path.dirname(USER_SETTINGS_PATH), { recursive: true });
+    await writeFileAtomic(USER_SETTINGS_PATH, JSON.stringify(doc, null, 2) + "\n");
+  });
+}
+
+/**
+ * Remove Project Minder OTEL env vars from ~/.claude/settings.json.
+ * Leaves any other env vars untouched. No-op if already absent.
+ * Atomic write with COW snapshot.
+ */
+export async function removeOtelEnv(): Promise<void> {
+  await withFileLock(USER_SETTINGS_PATH, async () => {
+    const doc = await readUserSettings(USER_SETTINGS_PATH);
+    if (!doc.env || typeof doc.env !== "object") return;
+    const env = doc.env as Record<string, unknown>;
+    let changed = false;
+    for (const key of OTEL_ENV_KEYS) {
+      if (key in env) {
+        delete env[key];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    await recordPreWrite(USER_SETTINGS_PATH, { label: "removeOtelEnv" });
+    await writeFileAtomic(USER_SETTINGS_PATH, JSON.stringify(doc, null, 2) + "\n");
+  });
+}

--- a/src/lib/otelSettings.ts
+++ b/src/lib/otelSettings.ts
@@ -21,7 +21,9 @@ const OTEL_ENV_KEYS = [
 async function readUserSettings(p: string): Promise<Record<string, unknown>> {
   try {
     const raw = await fs.readFile(p, "utf-8");
-    return tryParseJsonc<Record<string, unknown>>(raw) ?? {};
+    const parsed = tryParseJsonc<Record<string, unknown>>(raw);
+    if (parsed === null) throw new Error(`${p} is malformed JSON — fix the file before retrying`);
+    return parsed;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
     throw err;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -325,8 +325,6 @@ export interface MinderConfig {
   };
   /** OTEL ingest config. Wave 8 (R) honors. */
   otel?: {
-    /** Whether the OTEL env vars are installed in ~/.claude/settings.json. Computed at status-check time; not written to .minder.json. */
-    enabled?: boolean;
     /** OTLP base endpoint written into OTEL_EXPORTER_OTLP_ENDPOINT (default: http://localhost:4100/api/otel). */
     endpoint?: string;
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -323,6 +323,13 @@ export interface MinderConfig {
     /** Hook event names to register. Defaults to SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Notification, Stop. */
     events?: HookEventName[];
   };
+  /** OTEL ingest config. Wave 8 (R) honors. */
+  otel?: {
+    /** Whether the OTEL env vars are installed in ~/.claude/settings.json. Computed at status-check time; not written to .minder.json. */
+    enabled?: boolean;
+    /** OTLP base endpoint written into OTEL_EXPORTER_OTLP_ENDPOINT (default: http://localhost:4100/api/otel). */
+    endpoint?: string;
+  };
   /** Per-model pricing overrides. Wave 8 (S) honors. */
   pricingRules?: PricingRule[];
 }

--- a/tests/dbMigrations.test.ts
+++ b/tests/dbMigrations.test.ts
@@ -81,8 +81,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     // but each still bumps the schema_version stamp. Note that v3
     // ALSO sets `meta.needs_reconcile_after_v3 = 1` even on fresh DBs;
     // that's harmless because the indexer's first reconcile clears it.
-    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(result.schemaVersion).toBe(9);
 
     const db = await conn.getDb();
     expect(db).not.toBeNull();
@@ -104,7 +104,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
     expect(result.appliedMigrations).toEqual([]);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     second.conn.closeDb();
   });
 
@@ -164,7 +164,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     expect(result.error).toBeNull();
     expect(result.available).toBe(true);
     expect(result.quarantined).not.toBeNull();
-    expect(result.schemaVersion).toBe(8);
+    expect(result.schemaVersion).toBe(9);
     second.conn.closeDb();
   });
 
@@ -218,8 +218,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6, 7, 8]);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(result.schemaVersion).toBe(9);
 
     const db2 = await second.conn.getDb();
     const colsRecovered = db2!
@@ -254,8 +254,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([3, 4, 5, 6, 7, 8]);
-    expect(result.schemaVersion).toBe(8);
+    expect(result.appliedMigrations).toEqual([3, 4, 5, 6, 7, 8, 9]);
+    expect(result.schemaVersion).toBe(9);
 
     const db2 = await second.conn.getDb();
     expect(db2).not.toBeNull();

--- a/tests/fixtures/otlp-logs.json
+++ b/tests/fixtures/otlp-logs.json
@@ -1,0 +1,70 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "session.id", "value": { "stringValue": "test-session-abc123" } },
+          { "key": "telemetry.sdk.name", "value": { "stringValue": "opentelemetry" } },
+          { "key": "telemetry.sdk.language", "value": { "stringValue": "nodejs" } }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": { "name": "claude-code", "version": "1.0.0" },
+          "logRecords": [
+            {
+              "timeUnixNano": "1746000000000000000",
+              "observedTimeUnixNano": "1746000000100000000",
+              "body": { "stringValue": "tool_result" },
+              "attributes": [
+                { "key": "event.name", "value": { "stringValue": "tool_result" } },
+                { "key": "tool_name", "value": { "stringValue": "Read" } },
+                { "key": "tool_use_id", "value": { "stringValue": "toolu_read_001" } },
+                { "key": "tool_result.is_error", "value": { "boolValue": false } },
+                { "key": "tool_parameters", "value": { "stringValue": "{\"file_path\": \"/foo/bar.ts\"}" } }
+              ]
+            },
+            {
+              "timeUnixNano": "1746000001000000000",
+              "observedTimeUnixNano": "1746000001100000000",
+              "body": { "stringValue": "tool_decision" },
+              "attributes": [
+                { "key": "event.name", "value": { "stringValue": "tool_decision" } },
+                { "key": "tool_name", "value": { "stringValue": "Edit" } },
+                { "key": "tool_use_id", "value": { "stringValue": "toolu_edit_001" } },
+                { "key": "tool_decision.was_accepted", "value": { "boolValue": true } }
+              ]
+            },
+            {
+              "timeUnixNano": "1746000002000000000",
+              "observedTimeUnixNano": "1746000002100000000",
+              "body": { "stringValue": "api_request" },
+              "attributes": [
+                { "key": "event.name", "value": { "stringValue": "api_request" } },
+                { "key": "model", "value": { "stringValue": "claude-opus-4-7" } },
+                { "key": "input_tokens", "value": { "intValue": "1000" } },
+                { "key": "output_tokens", "value": { "intValue": "500" } }
+              ]
+            },
+            {
+              "timeUnixNano": "1746000003000000000",
+              "body": { "stringValue": "tool_result" },
+              "attributes": [
+                { "key": "event.name", "value": { "stringValue": "tool_result" } },
+                { "key": "tool_name", "value": { "stringValue": "mcp_tool" } },
+                { "key": "tool_use_id", "value": { "stringValue": "toolu_mcp_001" } },
+                { "key": "tool_result.is_error", "value": { "boolValue": false } },
+                { "key": "tool_parameters", "value": { "stringValue": "{\"mcp_server_name\": \"context7\", \"mcp_tool_name\": \"resolve-library-id\", \"query\": \"react\"}" } }
+              ]
+            },
+            {
+              "timeUnixNano": null,
+              "body": null,
+              "attributes": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/otlp-metrics.json
+++ b/tests/fixtures/otlp-metrics.json
@@ -1,0 +1,77 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "session.id", "value": { "stringValue": "test-session-abc123" } }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": { "name": "claude-code" },
+          "metrics": [
+            {
+              "name": "claude_code.token.usage",
+              "description": "Token usage by type",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "timeUnixNano": "1746000000000000000",
+                    "startTimeUnixNano": "1745999000000000000",
+                    "asDouble": 5000,
+                    "attributes": [
+                      { "key": "model", "value": { "stringValue": "claude-opus-4-7" } },
+                      { "key": "type", "value": { "stringValue": "input" } }
+                    ]
+                  },
+                  {
+                    "timeUnixNano": "1746000000000000000",
+                    "startTimeUnixNano": "1745999000000000000",
+                    "asDouble": 2500,
+                    "attributes": [
+                      { "key": "model", "value": { "stringValue": "claude-opus-4-7" } },
+                      { "key": "type", "value": { "stringValue": "output" } }
+                    ]
+                  }
+                ],
+                "aggregationTemporality": 2,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "claude_code.cost.usage",
+              "description": "Cost in USD",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "timeUnixNano": "1746000000000000000",
+                    "startTimeUnixNano": "1745999000000000000",
+                    "asDouble": 0.015,
+                    "attributes": [
+                      { "key": "model", "value": { "stringValue": "claude-opus-4-7" } }
+                    ]
+                  }
+                ],
+                "aggregationTemporality": 2,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "claude_code.session.count",
+              "description": "Active session gauge",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "timeUnixNano": "1746000000000000000",
+                    "asDouble": 1,
+                    "attributes": []
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/otelIngest.test.ts
+++ b/tests/otelIngest.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
+import logsFixture from "./fixtures/otlp-logs.json";
+import metricsFixture from "./fixtures/otlp-metrics.json";
+
+// OTEL ingest integration test. Uses a temp home so it never touches the
+// real ~/.minder/index.db.
+//
+// Pattern mirrors dbIngest.test.ts — describe.skipIf when the native
+// better-sqlite3 binary isn't installed; vi.resetModules() per test to
+// keep the globalThis singleton clean.
+
+let driverAvailable: boolean;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require("better-sqlite3");
+  driverAvailable = true;
+} catch {
+  driverAvailable = false;
+}
+
+interface Reloaded {
+  conn: typeof import("@/lib/db/connection");
+  mig: typeof import("@/lib/db/migrations");
+  otelIngest: typeof import("@/lib/db/otelIngest");
+}
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+
+async function freshTempHome() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "pm-otel-test-"));
+}
+
+async function reloadModules(home: string): Promise<Reloaded> {
+  vi.resetModules();
+  delete (globalThis as { __minderDb?: unknown }).__minderDb;
+  vi.spyOn(os, "homedir").mockReturnValue(home);
+  const conn = await import("@/lib/db/connection");
+  const mig = await import("@/lib/db/migrations");
+  const otelIngest = await import("@/lib/db/otelIngest");
+  return { conn, mig, otelIngest };
+}
+
+beforeEach(async () => {
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  tmpHome = await freshTempHome();
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  try {
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe.skipIf(!driverAvailable)("otelIngest", () => {
+  async function setupDb(home: string): Promise<Reloaded> {
+    const modules = await reloadModules(home);
+    await modules.mig.initDb();
+    return modules;
+  }
+
+  it("inserts log records into otel_events", async () => {
+    const { conn, otelIngest } = await setupDb(tmpHome);
+    const db = await conn.getDb();
+    expect(db).not.toBeNull();
+
+    const resource = logsFixture.resourceLogs[0].resource as Parameters<typeof otelIngest.ingestLog>[1];
+    const records = logsFixture.resourceLogs[0].scopeLogs[0].logRecords;
+
+    // The fixture has 4 valid records + 1 malformed (null timeUnixNano).
+    let rejected = 0;
+    for (const record of records) {
+      try {
+        await otelIngest.ingestLog(record as Parameters<typeof otelIngest.ingestLog>[0], resource);
+      } catch {
+        rejected++;
+      }
+    }
+
+    expect(rejected).toBe(1); // the null-timeUnixNano record
+
+    const rows = db!.prepare("SELECT * FROM otel_events ORDER BY ts").all() as Array<{
+      ts: string; session_id: string | null; event_name: string; payload_json: string;
+    }>;
+    expect(rows).toHaveLength(4);
+    expect(rows[0].event_name).toBe("tool_result");
+    expect(rows[1].event_name).toBe("tool_decision");
+    expect(rows[2].event_name).toBe("api_request");
+    expect(rows[3].event_name).toBe("tool_result");
+  });
+
+  it("extracts session_id from resource attributes", async () => {
+    const { conn, otelIngest } = await setupDb(tmpHome);
+    const db = await conn.getDb();
+
+    const resource = logsFixture.resourceLogs[0].resource as Parameters<typeof otelIngest.ingestLog>[1];
+    const record = logsFixture.resourceLogs[0].scopeLogs[0].logRecords[0];
+    await otelIngest.ingestLog(record as Parameters<typeof otelIngest.ingestLog>[0], resource);
+
+    const row = db!.prepare("SELECT session_id FROM otel_events LIMIT 1").get() as { session_id: string };
+    expect(row.session_id).toBe("test-session-abc123");
+  });
+
+  it("stores MCP tool attributes in payload_json", async () => {
+    const { conn, otelIngest } = await setupDb(tmpHome);
+    const db = await conn.getDb();
+
+    const resource = logsFixture.resourceLogs[0].resource as Parameters<typeof otelIngest.ingestLog>[1];
+    // mcp_tool record is index 3
+    const mcpRecord = logsFixture.resourceLogs[0].scopeLogs[0].logRecords[3];
+    await otelIngest.ingestLog(mcpRecord as Parameters<typeof otelIngest.ingestLog>[0], resource);
+
+    const row = db!.prepare("SELECT payload_json FROM otel_events LIMIT 1").get() as { payload_json: string };
+    const payload = JSON.parse(row.payload_json) as { attrs: Record<string, unknown> };
+    // tool_parameters should be in attrs so downstream consumers can extract mcp_server_name
+    expect(payload.attrs["tool_parameters"]).toContain("context7");
+  });
+
+  it("malformed record (null timeUnixNano) throws without corrupting valid records", async () => {
+    const { conn, otelIngest } = await setupDb(tmpHome);
+    const db = await conn.getDb();
+
+    const resource = logsFixture.resourceLogs[0].resource as Parameters<typeof otelIngest.ingestLog>[1];
+    const malformed = logsFixture.resourceLogs[0].scopeLogs[0].logRecords[4]; // null timeUnixNano
+    const valid = logsFixture.resourceLogs[0].scopeLogs[0].logRecords[0];
+
+    await otelIngest.ingestLog(valid as Parameters<typeof otelIngest.ingestLog>[0], resource);
+    await expect(
+      otelIngest.ingestLog(malformed as Parameters<typeof otelIngest.ingestLog>[0], resource),
+    ).rejects.toThrow();
+
+    const count = (db!.prepare("SELECT COUNT(*) as c FROM otel_events").get() as { c: number }).c;
+    expect(count).toBe(1); // valid record persisted; malformed record did not corrupt it
+  });
+
+  it("inserts metric data points into otel_metrics", async () => {
+    const { conn, otelIngest } = await setupDb(tmpHome);
+    const db = await conn.getDb();
+
+    const resource = metricsFixture.resourceMetrics[0].resource as Parameters<typeof otelIngest.ingestMetric>[1];
+    const metrics = metricsFixture.resourceMetrics[0].scopeMetrics[0].metrics;
+    for (const metric of metrics) {
+      await otelIngest.ingestMetric(metric as Parameters<typeof otelIngest.ingestMetric>[0], resource);
+    }
+
+    const rows = db!.prepare("SELECT * FROM otel_metrics ORDER BY ts, metric_name").all() as Array<{
+      metric_name: string; metric_type: string; value: number; model: string | null; session_id: string | null;
+    }>;
+    // 2 token.usage data points + 1 cost.usage + 1 session.count = 4 rows
+    expect(rows).toHaveLength(4);
+
+    const tokenRows = rows.filter((r) => r.metric_name === "claude_code.token.usage");
+    expect(tokenRows).toHaveLength(2);
+    expect(tokenRows[0].metric_type).toBe("counter");
+    expect(tokenRows[0].model).toBe("claude-opus-4-7");
+
+    const costRow = rows.find((r) => r.metric_name === "claude_code.cost.usage");
+    expect(costRow).toBeDefined();
+    expect(costRow!.value).toBeCloseTo(0.015);
+
+    const sessionRow = rows.find((r) => r.metric_name === "claude_code.session.count");
+    expect(sessionRow).toBeDefined();
+    expect(sessionRow!.metric_type).toBe("gauge");
+  });
+
+  it("metric with no data points is a no-op", async () => {
+    const { conn, otelIngest } = await setupDb(tmpHome);
+    const db = await conn.getDb();
+
+    const emptyMetric = { name: "claude_code.empty", sum: { dataPoints: [] } };
+    await otelIngest.ingestMetric(emptyMetric as Parameters<typeof otelIngest.ingestMetric>[0], undefined);
+
+    const count = (db!.prepare("SELECT COUNT(*) as c FROM otel_metrics").get() as { c: number }).c;
+    expect(count).toBe(0);
+  });
+
+  it("isOtelDbReady returns true after initDb", async () => {
+    const { otelIngest } = await setupDb(tmpHome);
+    expect(otelIngest.isOtelDbReady()).toBe(true);
+  });
+});

--- a/tests/otelIngest.test.ts
+++ b/tests/otelIngest.test.ts
@@ -101,6 +101,7 @@ describe.skipIf(!driverAvailable)("otelIngest", () => {
     expect(rows[1].event_name).toBe("tool_decision");
     expect(rows[2].event_name).toBe("api_request");
     expect(rows[3].event_name).toBe("tool_result");
+    conn.closeDb();
   });
 
   it("extracts session_id from resource attributes", async () => {
@@ -113,6 +114,7 @@ describe.skipIf(!driverAvailable)("otelIngest", () => {
 
     const row = db!.prepare("SELECT session_id FROM otel_events LIMIT 1").get() as { session_id: string };
     expect(row.session_id).toBe("test-session-abc123");
+    conn.closeDb();
   });
 
   it("stores MCP tool attributes in payload_json", async () => {
@@ -128,6 +130,7 @@ describe.skipIf(!driverAvailable)("otelIngest", () => {
     const payload = JSON.parse(row.payload_json) as { attrs: Record<string, unknown> };
     // tool_parameters should be in attrs so downstream consumers can extract mcp_server_name
     expect(payload.attrs["tool_parameters"]).toContain("context7");
+    conn.closeDb();
   });
 
   it("malformed record (null timeUnixNano) throws without corrupting valid records", async () => {
@@ -145,6 +148,7 @@ describe.skipIf(!driverAvailable)("otelIngest", () => {
 
     const count = (db!.prepare("SELECT COUNT(*) as c FROM otel_events").get() as { c: number }).c;
     expect(count).toBe(1); // valid record persisted; malformed record did not corrupt it
+    conn.closeDb();
   });
 
   it("inserts metric data points into otel_metrics", async () => {
@@ -175,6 +179,7 @@ describe.skipIf(!driverAvailable)("otelIngest", () => {
     const sessionRow = rows.find((r) => r.metric_name === "claude_code.session.count");
     expect(sessionRow).toBeDefined();
     expect(sessionRow!.metric_type).toBe("gauge");
+    conn.closeDb();
   });
 
   it("metric with no data points is a no-op", async () => {
@@ -186,10 +191,12 @@ describe.skipIf(!driverAvailable)("otelIngest", () => {
 
     const count = (db!.prepare("SELECT COUNT(*) as c FROM otel_metrics").get() as { c: number }).c;
     expect(count).toBe(0);
+    conn.closeDb();
   });
 
-  it("isOtelDbReady returns true after initDb", async () => {
-    const { otelIngest } = await setupDb(tmpHome);
+  it("isOtelDbReady returns true when the driver is loaded", async () => {
+    const { conn, otelIngest } = await setupDb(tmpHome);
     expect(otelIngest.isOtelDbReady()).toBe(true);
+    conn.closeDb();
   });
 });


### PR DESCRIPTION
## Summary

- **`POST /api/otel/v1/logs`** — OTLP/HTTP JSON logs receiver. Parses `resourceLogs → scopeLogs → logRecords`, persists to `otel_events`. Per-record try/catch for partial-success semantics.
- **`POST /api/otel/v1/metrics`** — OTLP/HTTP JSON metrics receiver. Persists to new `otel_metrics` table (schema v9).
- **`GET/POST /api/integrations/otel`** — install/remove four OTEL env vars in `~/.claude/settings.json` atomically (COW + configHistory snapshot).
- **Settings → Integrations → OpenTelemetry card** — endpoint field, Install/Remove buttons, live status indicator. Restart Claude Code after install.
- **Schema v9** — `otel_metrics` table. Idempotent `CREATE TABLE IF NOT EXISTS`.
- **`MinderConfig.otel`** sub-object for endpoint preference (not a feature flag).
- **7 new `otelIngest` tests** — log ingest, session_id extraction, MCP attribute persistence, malformed-record isolation, metric ingest, empty no-op, DB availability guard.

Cards (EditAcceptanceCard, ToolLatencyCard) come in 8.1b after real OTEL data has accumulated.

## Test plan

- [ ] `npm run typecheck` passes (0 errors)
- [ ] `npm test` — 1341 passing, 1 skipped
- [ ] Settings → Integrations → OTEL: click Install → verify `~/.claude/settings.json` contains 4 env vars
- [ ] Click Remove → verify env vars cleaned up, other settings intact
- [ ] POST malformed OTLP batch to `/api/otel/v1/logs` → 200 with `partialSuccess.rejectedLogRecords >= 1`
- [ ] Enable OTEL, restart Claude Code, run a command → rows appear in `otel_events`

Generated with [Claude Code](https://claude.com/claude-code)