### PR TITLE
feat(wave8.2a): currency display + pricing rules editor (Cluster S, TODO #79 #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 8.2a — Cluster S: Currency display + pricing rule overrides.** TODO #79, #80.
+  - **Display currency preference** (Settings → Cost). Choose from 30 ISO 4217 currencies powered by the Frankfurter API. Exchange rates cached 24 h in `~/.minder/exchange-rates.json`; last-good fallback on network failure. Zero-decimal currencies (JPY, KRW, IDR) rendered without fractional part.
+  - **Centralized `formatCost` / `formatCostCompact`** in `src/lib/format.ts`. All five components (`UsageDashboard`, `SessionsBrowser`, `SessionDetailView`, `ProjectSessions`, `StatsDashboard`) now import from format.ts rather than repeating identical inline functions. Both functions accept optional `(currency, fxRate)` args; defaults preserve USD behaviour.
+  - **`useCurrency()` hook** (`src/hooks/useCurrency.ts`). Fetches `/api/config` + `/api/integrations/fx` once per page mount; provides `{ currency, fxRate }` to all cost-displaying components.
+  - **`GET /api/integrations/fx`** — returns `{ base: "USD", rates, fetchedAt }` from the 24 h Frankfurter cache. Used by the CostSection UI to show the live rate next to the currency picker.
+  - **Per-model pricing rule overrides** (Settings → Cost, below the currency picker). `*` wildcard patterns; longest match wins; four rate fields (input, output, cache-read, cache-write in USD/M tokens); Reset to defaults clears all rules. New rules take effect on the next session ingest without a server restart.
+  - **`src/lib/usage/pricingRules.ts`** — `matchPricingRule` (longest-wins glob) + `applyPricingOverlay` (per-field merge). `costCalculator.getModelPricing` now applies the overlay before returning.
+  - **`src/lib/fxRates.ts`** — Frankfurter fetch + 24 h disk cache, abort-on-timeout, last-good fallback.
+  - **PATCH `/api/config`** now validates and persists `currency` (allowlist) and `pricingRules` (array shape + range checks). On `pricingRules` change, calls `setPricingRules()` to warm the globalThis cache immediately.
+  - **Help doc** `cost.md` (Settings → Cost context help).
+
 - **Wave 8.1b — Cluster R: OTEL consumption UI.** TODO #111, #112.
   - **Telemetry section on `/stats`** with six cards consuming live OTEL data:
     - **EditAcceptanceCard** — per-tool accept/reject bars with acceptance rate. Per-session variant on session detail Tools tab. Source: `tool_decision` events.

--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -1,5 +1,87 @@
 # Insights
 
+<!-- insight:e3abfc2a082f | session:dd13fdd4-1171-47c7-99d6-804a8ac47a84 | 2026-05-08T00:52:56.945Z -->
+## ★ Insight
+Native `<select>` elements resist CSS in a way `<input>` elements don't — browsers apply their OS-level widget rendering unless you opt out via `appearance: none`. Without it, even correctly-set `background` and `color` CSS variables get overridden by the browser's native control paint. The SVG chevron in the `backgroundImage` replaces the native arrow that `appearance: none` removes, keeping the control visually complete.
+
+---
+
+<!-- insight:c93d6f4c9160 | session:dd13fdd4-1171-47c7-99d6-804a8ac47a84 | 2026-05-08T00:24:52.523Z -->
+## ★ Insight
+The `slugTitles: Record<HelpSlug, string>` pattern is an exhaustive mapped type — TypeScript enforces that every member of the `HelpSlug` union has a corresponding key. This means adding a new slug to `helpSlugs` in `help-mapping.ts` *always* causes a typecheck failure in `HelpPanel.tsx` until the title is filled in. It's an intentional completeness gate: you can't ship a help slug without also giving it a display title.
+
+---
+
+<!-- insight:c178297d0b59 | session:dd13fdd4-1171-47c7-99d6-804a8ac47a84 | 2026-05-08T00:03:30.887Z -->
+## ★ Insight
+- **Mirror the LiteLLM cache pattern exactly**: disk cache with TTL check via `stat.mtimeMs`, in-flight promise dedupe, fallback on network error. Same infrastructure, new endpoint.
+- **Module-level `ratesMap` + `fetchedAt`**: sync reads are fast for the hot path (`formatCost`); async warm-up happens once on first `getRate()` call.
+
+---
+
+<!-- insight:2c60425803f1 | session:dd13fdd4-1171-47c7-99d6-804a8ac47a84 | 2026-05-07T23:59:08.332Z -->
+## ★ Insight
+- The `PATCH` route follows a validate-then-mutate pattern with a `patches[]` closure list — no mutation happens unless all validations pass. I'll add `currency` and `pricingRules` following this exact shape.
+- `formatCostCompact` has subtly different thresholds from `formatCost` (0.001 vs 0.01) — the centralized version must preserve this distinction.
+
+---
+
+<!-- insight:96cb007af94e | session:dd13fdd4-1171-47c7-99d6-804a8ac47a84 | 2026-05-07T23:55:22.342Z -->
+## ★ Insight
+- **Pre-existing types pay off**: `MinderConfig` already has `currency?`, `scheduleMode?`, `pricingRules?` typed from a prior wave — zero schema work needed.
+- **Centralize before extending**: `formatCost` is duplicated in 5 components hardcoding `$`. Extracting to `format.ts` first turns a feature add (currency) into a clean refactor.
+- **DERIVED_VERSION auto-bump beats a manual "recost" button**: precedent from Wave 4.2 — re-ingest infra already exists.
+
+---
+
+<!-- insight:b1561c93d153 | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T22:28:54.025Z -->
+## ★ Insight
+The `appendFileSync` on every OTEL POST is doubly problematic: (1) it's synchronous I/O on the hot request path in a Node.js server, blocking the event loop during every Claude Code metric export, and (2) the file grows without bound. The `console.log` on the metrics route has the same problem but lighter weight — it still floods stdout in production where OTEL exporters post every 30–60s.
+
+---
+
+<!-- insight:2ae21244938a | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T22:27:22.147Z -->
+## ★ Insight
+The "today" period fix is a subtle but important correctness issue: rolling 24h and calendar-day boundary produce different results when displayed as a daily bar chart — a rolling window can show two buckets (yesterday + today), while users expect "today" to mean midnight-to-now. Same SQL, different perceived meaning depending on how the UI groups data.
+
+---
+
+<!-- insight:2a2d78cbca16 | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T22:12:04.017Z -->
+## ★ Insight
+The simplify pass found a pattern worth noting: both `getTokenUsage` and `getCacheEfficiency` independently issued the exact same SQL query to `otel_metrics`. This is a classic sign of functions that evolved from copy-paste — they differed only in how they *pivoted* the result rows, not in what they fetched. Extracting `queryRawTokenDays` + `pivotTokenRows` makes the shared mechanism explicit and ensures future filter changes (e.g. adding a project-scoped `session_id` filter) only need one edit.
+
+---
+
+<!-- insight:412ff844b8e0 | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T21:44:16.677Z -->
+## ★ Insight
+The two highest-severity efficiency issues are `getToolLatency` fetching unbounded rows for JS-side percentile computation, and all 6 API routes missing try/catch — both silent failure modes that only manifest at scale or under disk errors.
+
+---
+
+<!-- insight:d3b9d1e67643 | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T21:37:58.265Z -->
+## ★ Insight
+The doc still says "four environment variables" and has the old text marking telemetry cards as "coming in a future update" — both need updating since we just shipped those cards in Phase 2.
+
+---
+
+<!-- insight:a2a2e40405c2 | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T21:29:50.997Z -->
+## ★ Insight
+The `vi.useFakeTimers({ now: ... })` approach is the correct way to test time-dependent logic in Vitest. The key insight: `vi.useFakeTimers()` must be called before the module is loaded (here: before `reloadModules`) because `Date.now()` calls inside the imported module get frozen at the point the fake timer is installed. Wrapping in try/finally ensures `vi.useRealTimers()` always runs even if assertions fail.
+
+---
+
+<!-- insight:5ec294584ae9 | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T21:23:24.015Z -->
+## ★ Insight
+SQLite lacks native `PERCENTILE_CONT` — the typical workaround is a window function trick using `ROW_NUMBER() OVER (ORDER BY value)`, but that requires computing exact row counts first. For datasets where all rows fit in memory (hundreds of hook events, not millions), fetching raw values and computing percentiles in JS is simpler and correct. The sort+index approach used here is O(n log n) and fine for observability data.
+
+---
+
+<!-- insight:476c395a9afd | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T21:22:09.541Z -->
+## ★ Insight
+The OTEL JS SDK serializes different attribute types differently: `intValue` fields become JS numbers in our attrMap (api_request's `input_tokens: 341`), but many event attrs arrive as `stringValue` despite being numeric (`duration_ms: "19"`). This is an SDK-level encoding choice — it matters because SQLite's `JSON_EXTRACT` returns the raw stored type, so math on string-stored numbers requires `CAST(...AS REAL)`.
+
+---
+
 <!-- insight:3c6ffbda371f | session:b0fd2cb0-9bfc-45ea-9cb7-6b14345ada42 | 2026-05-07T21:08:46.483Z -->
 ## ★ Insight
 OpenTelemetry separates **what to export** (`OTEL_METRICS_EXPORTER`, `OTEL_LOGS_EXPORTER`) from **where to send it** (`OTEL_EXPORTER_OTLP_ENDPOINT`). Setting only the endpoint is a no-op — the SDK won't export anything unless the exporter type is explicitly set to `otlp`. This is a common gotcha: env vars are independent and none implies the other.

--- a/docs/help/cost.md
+++ b/docs/help/cost.md
@@ -1,0 +1,48 @@
+# Cost Settings
+
+Configure how project-minder displays costs and how it prices model usage.
+
+## Display Currency
+
+Choose the currency for all cost figures across the dashboard (Usage, Sessions, Stats, and project pages).
+
+- Go to **Settings → Cost**
+- Select a currency from the dropdown (30 currencies supported, powered by the Frankfurter API)
+- The live exchange rate is shown below the selector
+- Costs are stored in USD internally; the conversion is display-only
+
+Exchange rates are cached for 24 hours in `~/.minder/exchange-rates.json`. If the Frankfurter API is unavailable, the last cached rate is used; if no cache exists, costs display in USD.
+
+**Zero-decimal currencies** (JPY, KRW, IDR) show whole numbers with no fractional part.
+
+## Pricing Rule Overrides
+
+Override the per-model rates used to calculate session costs. Useful when Anthropic's published prices differ from what LiteLLM reports, or to model future pricing scenarios.
+
+### Pattern syntax
+
+Use `*` as a wildcard:
+
+| Pattern | Matches |
+|---|---|
+| `claude-opus-4-7` | Exactly that model |
+| `claude-opus-4*` | All Opus 4 variants |
+| `*haiku*` | Any model with "haiku" in the name |
+| `*` | All models |
+
+Longer patterns take priority. If `claude-opus-4*` and `*` both match a model, the Opus rule wins.
+
+### Rate fields
+
+Each rule has four optional rate fields (USD per 1 million tokens). Leave a field blank to keep the LiteLLM default for that pricing dimension:
+
+- **Input $/M** — input/prompt tokens
+- **Output $/M** — output/completion tokens
+- **Cache Read $/M** — tokens served from the prompt cache
+- **Cache Write $/M** — tokens written into the prompt cache
+
+### Important notes
+
+- Rule changes apply to **new session ingest immediately** — no restart required.
+- **Previously indexed session costs are not retroactively recalculated.** If you need historical recost, delete `~/.minder/index.db` (all sessions will be re-indexed on next startup, which may take a few minutes).
+- Click **Reset to defaults** to clear all overrides and return to LiteLLM pricing.

--- a/public/help/cost.md
+++ b/public/help/cost.md
@@ -1,0 +1,48 @@
+# Cost Settings
+
+Configure how project-minder displays costs and how it prices model usage.
+
+## Display Currency
+
+Choose the currency for all cost figures across the dashboard (Usage, Sessions, Stats, and project pages).
+
+- Go to **Settings → Cost**
+- Select a currency from the dropdown (30 currencies supported, powered by the Frankfurter API)
+- The live exchange rate is shown below the selector
+- Costs are stored in USD internally; the conversion is display-only
+
+Exchange rates are cached for 24 hours in `~/.minder/exchange-rates.json`. If the Frankfurter API is unavailable, the last cached rate is used; if no cache exists, costs display in USD.
+
+**Zero-decimal currencies** (JPY, KRW, IDR) show whole numbers with no fractional part.
+
+## Pricing Rule Overrides
+
+Override the per-model rates used to calculate session costs. Useful when Anthropic's published prices differ from what LiteLLM reports, or to model future pricing scenarios.
+
+### Pattern syntax
+
+Use `*` as a wildcard:
+
+| Pattern | Matches |
+|---|---|
+| `claude-opus-4-7` | Exactly that model |
+| `claude-opus-4*` | All Opus 4 variants |
+| `*haiku*` | Any model with "haiku" in the name |
+| `*` | All models |
+
+Longer patterns take priority. If `claude-opus-4*` and `*` both match a model, the Opus rule wins.
+
+### Rate fields
+
+Each rule has four optional rate fields (USD per 1 million tokens). Leave a field blank to keep the LiteLLM default for that pricing dimension:
+
+- **Input $/M** — input/prompt tokens
+- **Output $/M** — output/completion tokens
+- **Cache Read $/M** — tokens served from the prompt cache
+- **Cache Write $/M** — tokens written into the prompt cache
+
+### Important notes
+
+- Rule changes apply to **new session ingest immediately** — no restart required.
+- **Previously indexed session costs are not retroactively recalculated.** If you need historical recost, delete `~/.minder/index.db` (all sessions will be re-indexed on next startup, which may take a few minutes).
+- Click **Reset to defaults** to clear all overrides and return to LiteLLM pricing.

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -2,8 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { readConfig, mutateConfig } from "@/lib/config";
 import { invalidateCache } from "@/lib/cache";
 import { invalidateClaudeConfigRouteCache } from "@/app/api/claude-config/route";
-import { ProjectStatus, MinderConfig, FeatureFlagKey } from "@/lib/types";
+import { ProjectStatus, MinderConfig, FeatureFlagKey, PricingRule } from "@/lib/types";
 import { isFeatureFlagKey } from "@/lib/featureFlags";
+import { setPricingRules } from "@/lib/usage/costCalculator";
+import { VALID_CURRENCIES } from "@/lib/currencies";
 
 // Derived from the MinderConfig union types — update both together if options change
 const VALID_DEFAULT_SORTS: MinderConfig["defaultSort"][] = ["activity", "name", "claude"];
@@ -235,6 +237,47 @@ export async function PATCH(request: NextRequest) {
     });
   }
 
+  if (body.currency !== undefined) {
+    if (typeof body.currency !== "string" || !VALID_CURRENCIES.has(body.currency)) {
+      return NextResponse.json({ error: `currency must be a supported ISO 4217 code (e.g. "EUR", "JPY")` }, { status: 400 });
+    }
+    patches.push((c) => { c.currency = body.currency as string; });
+  }
+
+  let newPricingRules: PricingRule[] | undefined;
+  if (body.pricingRules !== undefined) {
+    if (!Array.isArray(body.pricingRules)) {
+      return NextResponse.json({ error: "pricingRules must be an array" }, { status: 400 });
+    }
+    const rules: PricingRule[] = [];
+    for (let i = 0; i < (body.pricingRules as unknown[]).length; i++) {
+      const r = (body.pricingRules as unknown[])[i];
+      if (typeof r !== "object" || r === null || Array.isArray(r)) {
+        return NextResponse.json({ error: `pricingRules[${i}] must be an object` }, { status: 400 });
+      }
+      const { pattern, inputUsdPerMillion, outputUsdPerMillion, cacheReadUsdPerMillion, cacheCreateUsdPerMillion } =
+        r as Record<string, unknown>;
+      if (typeof pattern !== "string" || pattern.trim().length === 0 || pattern.length > 100) {
+        return NextResponse.json({ error: `pricingRules[${i}].pattern must be a non-empty string ≤ 100 chars` }, { status: 400 });
+      }
+      const rateFields = { inputUsdPerMillion, outputUsdPerMillion, cacheReadUsdPerMillion, cacheCreateUsdPerMillion };
+      for (const [key, val] of Object.entries(rateFields)) {
+        if (val !== undefined && (typeof val !== "number" || !isFinite(val) || val < 0 || val > 10000)) {
+          return NextResponse.json({ error: `pricingRules[${i}].${key} must be a finite number in 0–10000` }, { status: 400 });
+        }
+      }
+      rules.push({
+        pattern: pattern.trim(),
+        ...(inputUsdPerMillion !== undefined ? { inputUsdPerMillion: inputUsdPerMillion as number } : {}),
+        ...(outputUsdPerMillion !== undefined ? { outputUsdPerMillion: outputUsdPerMillion as number } : {}),
+        ...(cacheReadUsdPerMillion !== undefined ? { cacheReadUsdPerMillion: cacheReadUsdPerMillion as number } : {}),
+        ...(cacheCreateUsdPerMillion !== undefined ? { cacheCreateUsdPerMillion: cacheCreateUsdPerMillion as number } : {}),
+      });
+    }
+    patches.push((c) => { c.pricingRules = rules; });
+    newPricingRules = rules;
+  }
+
   if (patches.length === 0) {
     return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
   }
@@ -242,6 +285,7 @@ export async function PATCH(request: NextRequest) {
   const config = await mutateConfig((c) => {
     for (const patch of patches) patch(c);
   });
+  if (newPricingRules !== undefined) setPricingRules(newPricingRules);
   invalidateAll();
   return NextResponse.json({ ok: true, config });
 }

--- a/src/app/api/integrations/fx/route.ts
+++ b/src/app/api/integrations/fx/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { loadFxRates, getRatesSync, getFetchedAt } from "@/lib/fxRates";
+
+export async function GET() {
+  await loadFxRates();
+  return NextResponse.json({
+    base: "USD",
+    rates: getRatesSync(),
+    fetchedAt: getFetchedAt(),
+  });
+}

--- a/src/app/api/otel/v1/logs/route.ts
+++ b/src/app/api/otel/v1/logs/route.ts
@@ -25,8 +25,13 @@ let initPromise: Promise<{ available: boolean }> | null = null;
 async function ensureReady(): Promise<boolean> {
   if (!isOtelDbReady()) return false;
   if (!initPromise) initPromise = initDb();
-  const { available } = await initPromise;
-  return available;
+  try {
+    const { available } = await initPromise;
+    return available;
+  } catch {
+    initPromise = null;
+    return false;
+  }
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -37,6 +37,8 @@ const slugTitles: Record<HelpSlug, string> = {
   telegram: "Telegram Integration",
   terminal: "Terminal Launch",
   "auto-title": "Auto-title",
+  otel: "OpenTelemetry",
+  cost: "Cost Settings",
 };
 
 const iconBtnBase: React.CSSProperties = {

--- a/src/components/ProjectSessions.tsx
+++ b/src/components/ProjectSessions.tsx
@@ -18,6 +18,8 @@ import {
   Layers,
 } from "lucide-react";
 import Link from "next/link";
+import { formatCost } from "@/lib/format";
+import { useCurrency } from "@/hooks/useCurrency";
 
 function formatDuration(ms?: number): string {
   if (!ms) return "—";
@@ -33,12 +35,6 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
-}
-
-function formatCost(n: number): string {
-  if (n >= 1) return `$${n.toFixed(2)}`;
-  if (n >= 0.01) return `$${n.toFixed(3)}`;
-  return `$${n.toFixed(4)}`;
 }
 
 function formatDate(iso?: string): string {
@@ -94,6 +90,7 @@ function sessionLabel(session: SessionSummary): { primary: string; secondary?: s
 export function ProjectSessions({ projectPath }: { projectPath: string }) {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const { currency, fxRate } = useCurrency();
   // Respect user's motion preference for the active ping animation
   const [reducedMotion, setReducedMotion] = useState(false);
 
@@ -167,7 +164,7 @@ export function ProjectSessions({ projectPath }: { projectPath: string }) {
         <StatCard label="Total Time" value={formatDuration(stats!.totalDuration)} icon={<Clock className="h-4 w-4" />} />
         <StatCard label="Messages" value={stats!.totalMessages} icon={<MessageSquare className="h-4 w-4" />} />
         <StatCard label="Tokens" value={formatTokens(stats!.totalTokens)} icon={<Cpu className="h-4 w-4" />} />
-        <StatCard label="Cost" value={formatCost(stats!.totalCost)} icon={<DollarSign className="h-4 w-4" />} />
+        <StatCard label="Cost" value={formatCost(stats!.totalCost, currency, fxRate)} icon={<DollarSign className="h-4 w-4" />} />
         <StatCard label="Errors" value={stats!.totalErrors} icon={<AlertCircle className="h-4 w-4" />} />
       </div>
 

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -47,6 +47,8 @@ import {
 import Link from "next/link";
 import { Modal } from "@/components/ui/modal";
 import { downloadBlob } from "@/lib/downloadBlob";
+import { formatCost } from "@/lib/format";
+import { useCurrency } from "@/hooks/useCurrency";
 
 const checkboxRowStyle: React.CSSProperties = {
   display: "flex", alignItems: "center", gap: "8px",
@@ -78,12 +80,6 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
-}
-
-function formatCost(n: number): string {
-  if (n >= 1) return `$${n.toFixed(2)}`;
-  if (n >= 0.01) return `$${n.toFixed(3)}`;
-  return `$${n.toFixed(4)}`;
 }
 
 // ── Resume / terminal split button ───────────────────────────────────────────
@@ -301,6 +297,7 @@ function ExportModal({
   data: import("@/lib/types").SessionDetail;
   generatedTitle: string | undefined;
 }) {
+  const { currency, fxRate } = useCurrency();
   const [sections, setSections] = useState<Set<ExportSection>>(
     new Set(["timeline", "files", "subagents"])
   );
@@ -324,7 +321,7 @@ function ExportModal({
       `**Date:** ${date}`,
       data.gitBranch ? `**Branch:** ${data.gitBranch}` : "",
       `**Duration:** ${data.durationMs ? formatDuration(data.durationMs) : "—"}`,
-      `**Cost:** ${formatCost(data.costEstimate)}`,
+      `**Cost:** ${formatCost(data.costEstimate, currency, fxRate)}`,
       `**Session ID:** \`${data.sessionId}\``,
       "",
     ].filter(Boolean);
@@ -560,6 +557,7 @@ function TabBar({
 // ── Main view ─────────────────────────────────────────────────────────────────
 export function SessionDetailView({ sessionId }: { sessionId: string }) {
   const { data, loading } = useSessionDetail(sessionId);
+  const { currency, fxRate } = useCurrency();
   const [activeTab, setActiveTab] = useState<TabKey>("timeline");
   const [docModalOpen, setDocModalOpen] = useState(false);
   const [exportModalOpen, setExportModalOpen] = useState(false);
@@ -632,7 +630,7 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
     { label: "Duration",   value: formatDuration(data.durationMs) },
     { label: "Messages",   value: data.messageCount,  detail: `${data.userMessageCount}u · ${data.assistantMessageCount}a` },
     { label: "Tokens",     value: formatTokens(data.inputTokens + data.outputTokens), detail: `${formatTokens(data.inputTokens)} in · ${formatTokens(data.outputTokens)} out` },
-    { label: "Cost",       value: formatCost(data.costEstimate) },
+    { label: "Cost",       value: formatCost(data.costEstimate, currency, fxRate) },
     { label: "Tools",      value: totalTools,          detail: `${Object.keys(data.toolUsage).length} unique` },
     ...(data.errorCount > 0    ? [{ label: "Errors",    value: data.errorCount,    accent: "error" as const }] : []),
     ...(data.subagentCount > 0 ? [{ label: "Subagents", value: data.subagentCount }] : []),

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -24,6 +24,8 @@ import {
 import Link from "next/link";
 import { StatusDot } from "./ui/StatusDot";
 import { FILE_OP_BY_TOOL, isFileWriteOp } from "@/lib/usage/toolNames";
+import { formatCost } from "@/lib/format";
+import { useCurrency } from "@/hooks/useCurrency";
 
 type SortOption = "recent" | "longest" | "tokens" | "oneshot";
 
@@ -40,12 +42,6 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
-}
-
-function formatCost(n: number): string {
-  if (n >= 1) return `$${n.toFixed(2)}`;
-  if (n >= 0.01) return `$${n.toFixed(3)}`;
-  return `$${n.toFixed(4)}`;
 }
 
 function formatDate(iso?: string): string {
@@ -275,6 +271,7 @@ function SessionRow({
   showProject?: boolean;
   search?: string;
 }) {
+  const { currency, fxRate } = useCurrency();
   const totalTools = Object.values(session.toolUsage).reduce((s, c) => s + c, 0);
   const totalEdits = Object.entries(FILE_OP_BY_TOOL)
     .filter(([, op]) => isFileWriteOp(op))
@@ -401,7 +398,7 @@ function SessionRow({
           </span>
           <span style={{ display: "flex", alignItems: "center", gap: "3px", fontSize: "0.68rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
             <DollarSign style={{ width: "10px", height: "10px" }} />
-            {formatCost(session.costEstimate)}
+            {formatCost(session.costEstimate, currency, fxRate)}
           </span>
           <span style={{ display: "flex", alignItems: "center", gap: "3px", fontSize: "0.68rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
             <Wrench style={{ width: "10px", height: "10px" }} />
@@ -549,6 +546,7 @@ function SectionHeader({
   collapsed: boolean;
   onToggle: () => void;
 }) {
+  const { currency, fxRate } = useCurrency();
   return (
     <div
       style={{
@@ -593,7 +591,7 @@ function SectionHeader({
       </span>
 
       <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "var(--text-muted)" }}>
-        {formatTokens(group.totalTokens)} · {formatCost(group.totalCost)} · {formatDuration(group.totalDurationMs)}
+        {formatTokens(group.totalTokens)} · {formatCost(group.totalCost, currency, fxRate)} · {formatDuration(group.totalDurationMs)}
       </span>
 
       {group.avgOneShotRate !== undefined && (

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { IntegrationsSection } from "@/components/settings/IntegrationsSection";
 import { TerminalSection } from "@/components/settings/TerminalSection";
 import { AutoTitleSection } from "@/components/settings/AutoTitleSection";
 import { LiveActivitySection } from "@/components/settings/LiveActivitySection";
+import { CostSection } from "@/components/settings/CostSection";
 import { Toggle } from "@/components/settings/Toggle";
 
 // Hoisted so each Settings render doesn't re-filter the static metadata.
@@ -226,7 +227,10 @@ export function SettingsPage() {
         {active === "live-activity" && (
           <LiveActivitySection config={config} onConfigChange={patchConfig} />
         )}
-        {active !== "features" && active !== "notifications" && active !== "integrations" && active !== "terminal" && active !== "auto-title" && active !== "live-activity" && activeSection && (
+        {active === "cost" && (
+          <CostSection config={config} onConfigChange={patchConfig} />
+        )}
+        {active !== "features" && active !== "notifications" && active !== "integrations" && active !== "terminal" && active !== "auto-title" && active !== "live-activity" && active !== "cost" && activeSection && (
           <PlaceholderSection
             label={activeSection.label}
             wave={activeSection.shipsInWave}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -139,8 +139,9 @@ export function SettingsPage() {
     });
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      showToast("Couldn't save setting", body.error || `HTTP ${res.status}`);
-      return;
+      const message = body.error || `HTTP ${res.status}`;
+      showToast("Couldn't save setting", message);
+      throw new Error(message);
     }
     const updated = await res.json().catch(() => null);
     if (updated?.config) setConfig(updated.config as MinderConfig);

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -20,16 +20,13 @@ import { CacheEfficiencyCard } from "./stats/CacheEfficiencyCard";
 import { HookActivityCard } from "./stats/HookActivityCard";
 import { PressurePanel } from "./stats/PressurePanel";
 
+import { formatCost } from "@/lib/format";
+import { useCurrency } from "@/hooks/useCurrency";
+
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
-}
-
-function formatCost(n: number): string {
-  if (n >= 1) return `$${n.toFixed(2)}`;
-  if (n >= 0.01) return `$${n.toFixed(3)}`;
-  return `$${n.toFixed(4)}`;
 }
 
 function SectionHeader({ label }: { label: string }) {
@@ -96,6 +93,7 @@ function StatCell({ label, value, detail, icon, last }: StatCellProps) {
 
 export function StatsDashboard() {
   const { data, loading } = useStats();
+  const { currency, fxRate } = useCurrency();
 
   if (loading || !data) {
     return (
@@ -156,7 +154,7 @@ export function StatsDashboard() {
           {cu ? (
             <StatCell
               label="Est. Cost"
-              value={formatCost(cu.costEstimate)}
+              value={formatCost(cu.costEstimate, currency, fxRate)}
               icon={<DollarSign style={{ width: "13px", height: "13px" }} />}
               detail={`${cu.conversationCount} conversations`}
               last

--- a/src/components/UsageDashboard.tsx
+++ b/src/components/UsageDashboard.tsx
@@ -18,25 +18,15 @@ import { HourlyDistributionChart } from "./HourlyDistributionChart";
 import { Heatmap2D } from "./Heatmap2D";
 import { ContributionCalendar } from "./ContributionCalendar";
 
+import { formatCost, formatCostCompact } from "@/lib/format";
+import { useCurrency } from "@/hooks/useCurrency";
+
 // ── Formatters ─────────────────────────────────────────────────────────────
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
-}
-
-function formatCost(n: number): string {
-  if (n >= 1) return `$${n.toFixed(2)}`;
-  if (n >= 0.01) return `$${n.toFixed(3)}`;
-  if (n > 0) return `$${n.toFixed(4)}`;
-  return "$0";
-}
-
-function formatCostCompact(n: number): string {
-  if (n >= 1) return `$${n.toFixed(2)}`;
-  if (n >= 0.001) return `$${n.toFixed(3)}`;
-  return `$${n.toFixed(4)}`;
 }
 
 // ── Project name decode ────────────────────────────────────────────────────
@@ -141,6 +131,7 @@ function StatCell({ label, value, detail, accent, last }: {
 function CostRow({ label, cost, maxCost, color, detail }: {
   label: string; cost: number; maxCost: number; color: string; detail?: string;
 }) {
+  const { currency, fxRate } = useCurrency();
   return (
     <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
       <span style={{
@@ -166,7 +157,7 @@ function CostRow({ label, cost, maxCost, color, detail }: {
         fontFamily: "var(--font-mono)", fontSize: "0.68rem",
         color: "var(--text-secondary)", width: "54px", textAlign: "right", flexShrink: 0,
       }}>
-        {formatCostCompact(cost)}
+        {formatCostCompact(cost, currency, fxRate)}
       </span>
       {detail && (
         <span style={{
@@ -221,6 +212,7 @@ function CountRow({ label, count, maxCount, color }: {
 function DailyCostChart({ daily }: {
   daily: Array<{ date: string; cost: number; turns: number }>;
 }) {
+  const { currency, fxRate } = useCurrency();
   if (daily.length === 0) return <EmptyNote />;
   const maxCost = Math.max(...daily.map((d) => d.cost), 0.001);
 
@@ -230,7 +222,7 @@ function DailyCostChart({ daily }: {
         {daily.map((d) => (
           <div
             key={d.date}
-            title={`${d.date}: ${formatCost(d.cost)} · ${d.turns} turns`}
+            title={`${d.date}: ${formatCost(d.cost, currency, fxRate)} · ${d.turns} turns`}
             style={{
               flex: 1,
               height: `${d.cost > 0 ? Math.max((d.cost / maxCost) * 100, 2) : 0}%`,
@@ -321,6 +313,7 @@ function ProjectBreakdownView({
 }: {
   projectDetails: ProjectDetail[];
 }) {
+  const { currency, fxRate } = useCurrency();
   const [focusCategory, setFocusCategory] = useState<CategoryType | null>(null);
 
   // Determine which categories are present in the data — depends only on the
@@ -444,7 +437,7 @@ function ProjectBreakdownView({
                   p.categoryBreakdown.map((c) => (
                     <div
                       key={c.category}
-                      title={`${c.category}: ${formatCostCompact(c.cost)}`}
+                      title={`${c.category}: ${formatCostCompact(c.cost, currency, fxRate)}`}
                       style={{
                         width: `${p.cost > 0 ? (c.cost / p.cost) * 100 : 0}%`,
                         height: "100%",
@@ -463,8 +456,8 @@ function ProjectBreakdownView({
                 color: "var(--text-secondary)", width: "54px", textAlign: "right", flexShrink: 0,
               }}>
                 {focusCategory && focusCost !== null
-                  ? formatCostCompact(focusCost)
-                  : formatCostCompact(p.cost)}
+                  ? formatCostCompact(focusCost, currency, fxRate)
+                  : formatCostCompact(p.cost, currency, fxRate)}
               </span>
 
               {/* Top tool + MCP indicator */}
@@ -563,6 +556,7 @@ export function UsageDashboard() {
   const [project, setProject] = useState<string | undefined>(undefined);
   const [breakdownMode, setBreakdownMode] = useState<"aggregate" | "by-project">("aggregate");
   const { data, loading } = useUsage(period, project);
+  const { currency, fxRate } = useCurrency();
   const { data: allData } = useUsage(period);
   const availableProjects = allData?.byProject ?? data?.byProject ?? [];
 
@@ -762,7 +756,7 @@ export function UsageDashboard() {
           }}>
             <StatCell
               label="Total Cost"
-              value={formatCost(data.totalCost)}
+              value={formatCost(data.totalCost, currency, fxRate)}
               detail={data.period}
             />
             <StatCell

--- a/src/components/settings/AutoTitleSection.tsx
+++ b/src/components/settings/AutoTitleSection.tsx
@@ -143,7 +143,7 @@ export function AutoTitleSection({
         {testResult && (
           <div style={{
             marginTop: "12px", padding: "10px 12px", borderRadius: "var(--radius)",
-            background: "var(--surface-2, transparent)",
+            background: "var(--bg-elevated)",
             fontSize: "0.78rem",
             color: testResult.ok ? "var(--text-primary)" : "var(--error, #f87171)",
           }}>

--- a/src/components/settings/CostSection.tsx
+++ b/src/components/settings/CostSection.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { MinderConfig, PricingRule } from "@/lib/types";
+import { S } from "./styles";
+import { SUPPORTED_CURRENCIES, CURRENCY_NAMES } from "@/lib/currencies";
+import { invalidateCurrencyCache } from "@/hooks/useCurrency";
+
+interface FxData {
+  base: string;
+  rates: Record<string, number>;
+  fetchedAt: string | null;
+}
+
+type RuleRow = PricingRule & { _key: number };
+
+let keyCounter = 0;
+function newKey() { return ++keyCounter; }
+
+function toRow(r: PricingRule): RuleRow {
+  return { ...r, _key: newKey() };
+}
+
+function emptyRow(): RuleRow {
+  return { pattern: "", _key: newKey() };
+}
+
+export function CostSection({
+  config,
+  onConfigChange,
+}: {
+  config: MinderConfig | null;
+  onConfigChange: (patch: Partial<MinderConfig>) => Promise<void>;
+}) {
+  const [fx, setFx] = useState<FxData | null>(null);
+  const [currency, setCurrency] = useState(config?.currency ?? "USD");
+  const [currencySaving, setCurrencySaving] = useState(false);
+
+  const [rows, setRows] = useState<RuleRow[]>(() =>
+    (config?.pricingRules ?? []).map(toRow)
+  );
+  const [rulesSaving, setRulesSaving] = useState(false);
+  const [rulesMsg, setRulesMsg] = useState<{ text: string; ok: boolean } | null>(null);
+
+  useEffect(() => {
+    fetch("/api/integrations/fx")
+      .then((r) => r.json())
+      .then((d) => setFx(d as FxData))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    setCurrency(config?.currency ?? "USD");
+  }, [config?.currency]);
+
+  useEffect(() => {
+    setRows((config?.pricingRules ?? []).map(toRow));
+  }, [config?.pricingRules]);
+
+  async function handleCurrencyChange(next: string) {
+    setCurrency(next);
+    setCurrencySaving(true);
+    try {
+      await onConfigChange({ currency: next });
+      invalidateCurrencyCache();
+    } finally {
+      setCurrencySaving(false);
+    }
+  }
+
+  async function handleSaveRules() {
+    setRulesSaving(true);
+    setRulesMsg(null);
+    try {
+      // Validate patterns locally before sending
+      for (const row of rows) {
+        if (!row.pattern.trim()) {
+          setRulesMsg({ text: "All rules must have a non-empty pattern.", ok: false });
+          return;
+        }
+      }
+      const rules: PricingRule[] = rows.map(({ _key: _, ...rest }) => rest);
+      await onConfigChange({ pricingRules: rules });
+      setRulesMsg({ text: "Pricing rules saved.", ok: true });
+    } catch (err) {
+      setRulesMsg({ text: (err as Error).message, ok: false });
+    } finally {
+      setRulesSaving(false);
+    }
+  }
+
+  async function handleResetRules() {
+    setRulesSaving(true);
+    setRulesMsg(null);
+    try {
+      await onConfigChange({ pricingRules: [] });
+      setRows([]);
+      setRulesMsg({ text: "Pricing rules cleared — LiteLLM defaults apply.", ok: true });
+    } catch (err) {
+      setRulesMsg({ text: (err as Error).message, ok: false });
+    } finally {
+      setRulesSaving(false);
+    }
+  }
+
+  function updateRow(key: number, field: keyof PricingRule, value: string) {
+    setRows((prev) =>
+      prev.map((r) => {
+        if (r._key !== key) return r;
+        if (field === "pattern") return { ...r, pattern: value };
+        const num = value === "" ? undefined : parseFloat(value);
+        return { ...r, [field]: num };
+      })
+    );
+    setRulesMsg(null);
+  }
+
+  function deleteRow(key: number) {
+    setRows((prev) => prev.filter((r) => r._key !== key));
+    setRulesMsg(null);
+  }
+
+  const fxRate = currency === "USD" ? 1 : (fx?.rates[currency] ?? null);
+  const fxLabel = fxRate !== null
+    ? `1 USD = ${fxRate.toFixed(4)} ${currency}`
+    : fx === null ? "Loading…" : "Rate unavailable";
+
+  const rateInput: React.CSSProperties = {
+    ...S.input,
+    width: "80px",
+    textAlign: "right",
+    fontFamily: "var(--font-mono)",
+    fontSize: "0.75rem",
+  };
+
+  return (
+    <section>
+      <h2 style={S.sectionTitle}>Cost</h2>
+      <p style={S.desc}>
+        Configure currency display and per-model pricing rule overrides.
+        Currency applies to all cost figures in the dashboard.
+        Pricing rules override LiteLLM defaults immediately for new session ingest.
+      </p>
+
+      {/* ── Currency ─────────────────────────────────────────────────────── */}
+      <div style={S.card}>
+        <div style={{ fontWeight: 600, fontSize: "0.85rem", color: "var(--text-primary)", marginBottom: "12px" }}>
+          Display Currency
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "12px" }}>
+          <select
+            style={{ ...S.select, width: "240px" }}
+            value={currency}
+            onChange={(e) => handleCurrencyChange(e.target.value)}
+            disabled={currencySaving}
+          >
+            {SUPPORTED_CURRENCIES.map((c) => (
+              <option key={c} value={c}>{c} — {CURRENCY_NAMES[c] ?? c}</option>
+            ))}
+          </select>
+
+          {currencySaving && (
+            <span style={S.muted}>Saving…</span>
+          )}
+        </div>
+
+        <div style={{ ...S.muted }}>
+          {currency !== "USD" ? fxLabel : "No conversion — costs shown in USD."}
+          {fx?.fetchedAt && (
+            <span style={{ marginLeft: "8px", opacity: 0.6 }}>
+              (cached {new Date(fx.fetchedAt).toLocaleDateString()})
+            </span>
+          )}
+        </div>
+
+        <div style={{ ...S.muted, marginTop: "6px" }}>
+          Exchange rates fetched from{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>api.frankfurter.dev</code> and cached for 24 hours.
+          Original costs are stored in USD; conversion is display-only.
+        </div>
+      </div>
+
+      {/* ── Pricing Rules ────────────────────────────────────────────────── */}
+      <div style={S.card}>
+        <div style={{ fontWeight: 600, fontSize: "0.85rem", color: "var(--text-primary)", marginBottom: "4px" }}>
+          Pricing Rule Overrides
+        </div>
+
+        <div style={{ ...S.muted, marginBottom: "16px" }}>
+          Override LiteLLM pricing per model. Use <code style={{ fontFamily: "var(--font-mono)" }}>*</code>{" "}
+          as a wildcard (e.g. <code style={{ fontFamily: "var(--font-mono)" }}>claude-opus-4*</code>).
+          Longer patterns take priority. Rates are USD per 1M tokens.
+          Leave a rate blank to keep the LiteLLM default for that field.
+        </div>
+
+        {rows.length > 0 ? (
+          <div style={{ overflowX: "auto", marginBottom: "12px" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.78rem" }}>
+              <thead>
+                <tr style={{ color: "var(--text-muted)", fontFamily: "var(--font-mono)", fontSize: "0.68rem" }}>
+                  <th style={{ textAlign: "left", padding: "4px 8px 8px 0", fontWeight: 500 }}>Pattern</th>
+                  <th style={{ textAlign: "right", padding: "4px 8px 8px", fontWeight: 500, whiteSpace: "nowrap" }}>Input $/M</th>
+                  <th style={{ textAlign: "right", padding: "4px 8px 8px", fontWeight: 500, whiteSpace: "nowrap" }}>Output $/M</th>
+                  <th style={{ textAlign: "right", padding: "4px 8px 8px", fontWeight: 500, whiteSpace: "nowrap" }}>Cache Read $/M</th>
+                  <th style={{ textAlign: "right", padding: "4px 8px 8px", fontWeight: 500, whiteSpace: "nowrap" }}>Cache Write $/M</th>
+                  <th style={{ width: "28px" }} />
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row._key} style={{ borderTop: "1px solid var(--border-subtle)" }}>
+                    <td style={{ padding: "6px 8px 6px 0" }}>
+                      <input
+                        type="text"
+                        style={{ ...S.input, width: "180px", fontFamily: "var(--font-mono)", fontSize: "0.75rem" }}
+                        value={row.pattern}
+                        placeholder="claude-opus-4*"
+                        onChange={(e) => updateRow(row._key, "pattern", e.target.value)}
+                      />
+                    </td>
+                    <td style={{ padding: "6px 8px", textAlign: "right" }}>
+                      <input
+                        type="number"
+                        style={rateInput}
+                        value={row.inputUsdPerMillion ?? ""}
+                        placeholder="—"
+                        min={0}
+                        step="any"
+                        onChange={(e) => updateRow(row._key, "inputUsdPerMillion", e.target.value)}
+                      />
+                    </td>
+                    <td style={{ padding: "6px 8px", textAlign: "right" }}>
+                      <input
+                        type="number"
+                        style={rateInput}
+                        value={row.outputUsdPerMillion ?? ""}
+                        placeholder="—"
+                        min={0}
+                        step="any"
+                        onChange={(e) => updateRow(row._key, "outputUsdPerMillion", e.target.value)}
+                      />
+                    </td>
+                    <td style={{ padding: "6px 8px", textAlign: "right" }}>
+                      <input
+                        type="number"
+                        style={rateInput}
+                        value={row.cacheReadUsdPerMillion ?? ""}
+                        placeholder="—"
+                        min={0}
+                        step="any"
+                        onChange={(e) => updateRow(row._key, "cacheReadUsdPerMillion", e.target.value)}
+                      />
+                    </td>
+                    <td style={{ padding: "6px 8px", textAlign: "right" }}>
+                      <input
+                        type="number"
+                        style={rateInput}
+                        value={row.cacheCreateUsdPerMillion ?? ""}
+                        placeholder="—"
+                        min={0}
+                        step="any"
+                        onChange={(e) => updateRow(row._key, "cacheCreateUsdPerMillion", e.target.value)}
+                      />
+                    </td>
+                    <td style={{ padding: "6px 0 6px 8px" }}>
+                      <button
+                        style={{ ...S.btn, padding: "3px 7px", color: "var(--status-error-text)", borderColor: "var(--status-error-border)" }}
+                        onClick={() => deleteRow(row._key)}
+                        title="Remove rule"
+                      >
+                        ×
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div style={{
+            padding: "12px", borderRadius: "var(--radius)", marginBottom: "12px",
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border-subtle)",
+            fontSize: "0.78rem", color: "var(--text-muted)", textAlign: "center",
+          }}>
+            No overrides — LiteLLM defaults apply.
+          </div>
+        )}
+
+        <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "12px" }}>
+          <button
+            style={S.btn}
+            onClick={() => { setRows((prev) => [...prev, emptyRow()]); setRulesMsg(null); }}
+          >
+            + Add rule
+          </button>
+          <button
+            style={{ ...S.btn, background: "var(--info)", color: "#fff", borderColor: "var(--info)", opacity: rulesSaving ? 0.4 : 1 }}
+            disabled={rulesSaving}
+            onClick={handleSaveRules}
+          >
+            {rulesSaving ? "Saving…" : "Save rules"}
+          </button>
+          {rows.length > 0 && (
+            <button
+              style={{ ...S.btn, color: "var(--status-error-text)", borderColor: "var(--status-error-border)", opacity: rulesSaving ? 0.4 : 1 }}
+              disabled={rulesSaving}
+              onClick={handleResetRules}
+            >
+              Reset to defaults
+            </button>
+          )}
+        </div>
+
+        {rulesMsg && (
+          <div style={{ fontSize: "0.74rem", color: rulesMsg.ok ? "var(--status-active-text)" : "var(--status-error-text)" }}>
+            {rulesMsg.text}
+          </div>
+        )}
+
+        <div style={{
+          padding: "10px 12px", borderRadius: "var(--radius)", marginTop: "8px",
+          background: "var(--bg-elevated)", fontSize: "0.74rem",
+          color: "var(--text-muted)", lineHeight: 1.6,
+        }}>
+          <strong style={{ color: "var(--text-secondary)" }}>Note:</strong>{" "}
+          Pricing rule changes apply to new session ingest immediately.
+          Previously indexed session costs are not retroactively recalculated.
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/IntegrationsSection.tsx
+++ b/src/components/settings/IntegrationsSection.tsx
@@ -137,7 +137,7 @@ export function IntegrationsSection({
 
         <div style={{
           marginTop: "16px", padding: "10px 12px", borderRadius: "var(--radius)",
-          background: "var(--surface-2, transparent)", fontSize: "0.74rem", color: "var(--text-muted)", lineHeight: 1.6,
+          background: "var(--bg-elevated)", fontSize: "0.74rem", color: "var(--text-muted)", lineHeight: 1.6,
         }}>
           <strong style={{ color: "var(--text-secondary)" }}>Setup:</strong>{" "}
           Create a bot with @BotFather and copy the token. Send /start to your bot, then visit{" "}

--- a/src/components/settings/OtelSection.tsx
+++ b/src/components/settings/OtelSection.tsx
@@ -171,7 +171,7 @@ export function OtelSection({
       {/* Setup note */}
       <div style={{
         padding: "10px 12px", borderRadius: "var(--radius)",
-        background: "var(--surface-2, transparent)", fontSize: "0.74rem",
+        background: "var(--bg-elevated)", fontSize: "0.74rem",
         color: "var(--text-muted)", lineHeight: 1.6,
       }}>
         <strong style={{ color: "var(--text-secondary)" }}>Setup:</strong>{" "}

--- a/src/components/settings/styles.ts
+++ b/src/components/settings/styles.ts
@@ -9,19 +9,29 @@ export const S = {
   } as React.CSSProperties,
   card: {
     padding: "16px", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)",
-    background: "var(--surface-1, transparent)", marginBottom: "16px",
+    background: "var(--bg-surface)", marginBottom: "16px",
   } as React.CSSProperties,
   label: { fontSize: "0.82rem", color: "var(--text-primary)", fontWeight: 500 } as React.CSSProperties,
   muted: { fontSize: "0.74rem", color: "var(--text-secondary)", lineHeight: 1.5 } as React.CSSProperties,
   input: {
     width: "100%", boxSizing: "border-box" as const, padding: "6px 10px",
     borderRadius: "var(--radius)", border: "1px solid var(--border-default)",
-    background: "var(--surface-2, transparent)", color: "var(--text-primary)",
+    background: "var(--bg-elevated)", color: "var(--text-primary)",
     fontSize: "0.82rem", fontFamily: "var(--font-body)",
+  } as React.CSSProperties,
+  select: {
+    width: "100%", boxSizing: "border-box" as const, padding: "6px 28px 6px 10px",
+    borderRadius: "var(--radius)", border: "1px solid var(--border-default)",
+    background: "var(--bg-elevated)", color: "var(--text-primary)",
+    fontSize: "0.82rem", fontFamily: "var(--font-body)", cursor: "pointer",
+    appearance: "none" as const, WebkitAppearance: "none" as const,
+    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23888' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`,
+    backgroundRepeat: "no-repeat",
+    backgroundPosition: "right 8px center",
   } as React.CSSProperties,
   btn: {
     fontSize: "0.78rem", padding: "5px 12px", borderRadius: "var(--radius)",
-    border: "1px solid var(--border-default)", background: "var(--surface-2, transparent)",
+    border: "1px solid var(--border-default)", background: "var(--bg-elevated)",
     color: "var(--text-primary)", cursor: "pointer",
   } as React.CSSProperties,
   badge: {
@@ -30,7 +40,7 @@ export const S = {
   } as React.CSSProperties,
   row: {
     display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px",
-    padding: "10px 12px", borderRadius: "var(--radius)", background: "var(--surface-1, transparent)",
+    padding: "10px 12px", borderRadius: "var(--radius)", background: "var(--bg-surface)",
     border: "1px solid var(--border-subtle)", marginBottom: "1px",
   } as React.CSSProperties,
 };

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -23,7 +23,10 @@ async function loadCurrency(): Promise<CurrencyState> {
     currencyLoadPromise = (async () => {
       try {
         const configRes = await fetch("/api/config");
-        if (!configRes.ok) return { currency: "USD", fxRate: 1 };
+        if (!configRes.ok) {
+          currencyLoadPromise = null;
+          return { currency: "USD", fxRate: 1 };
+        }
         const config = (await configRes.json()) as Record<string, unknown>;
         const currency = (typeof config.currency === "string" ? config.currency : null) ?? "USD";
 

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface CurrencyState {
+  currency: string;
+  fxRate: number;
+}
+
+// Module-level cache: all hook instances on the same page share one fetch pair.
+// Cleared when currency changes (CostSection calls invalidateCurrencyCache).
+let currencyCache: CurrencyState | null = null;
+let currencyLoadPromise: Promise<CurrencyState> | null = null;
+
+export function invalidateCurrencyCache() {
+  currencyCache = null;
+  currencyLoadPromise = null;
+}
+
+async function loadCurrency(): Promise<CurrencyState> {
+  if (currencyCache) return currencyCache;
+  if (!currencyLoadPromise) {
+    currencyLoadPromise = (async () => {
+      try {
+        const configRes = await fetch("/api/config");
+        if (!configRes.ok) return { currency: "USD", fxRate: 1 };
+        const config = (await configRes.json()) as Record<string, unknown>;
+        const currency = (typeof config.currency === "string" ? config.currency : null) ?? "USD";
+
+        if (currency === "USD") {
+          currencyCache = { currency: "USD", fxRate: 1 };
+          return currencyCache;
+        }
+
+        const fxRes = await fetch("/api/integrations/fx");
+        if (!fxRes.ok) {
+          currencyCache = { currency, fxRate: 1 };
+          return currencyCache;
+        }
+        const fx = (await fxRes.json()) as { rates: Record<string, number> };
+        currencyCache = { currency, fxRate: fx.rates[currency] ?? 1 };
+        return currencyCache;
+      } catch {
+        currencyCache = { currency: "USD", fxRate: 1 };
+        return currencyCache;
+      }
+    })();
+  }
+  return currencyLoadPromise;
+}
+
+export function useCurrency(): CurrencyState {
+  const [state, setState] = useState<CurrencyState>({ currency: "USD", fxRate: 1 });
+
+  useEffect(() => {
+    let cancelled = false;
+    loadCurrency().then((s) => { if (!cancelled) setState(s); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  return state;
+}

--- a/src/lib/currencies.ts
+++ b/src/lib/currencies.ts
@@ -1,0 +1,35 @@
+// Frankfurter API supported currencies (base=USD). Single source of truth for
+// the allowlist used by the PATCH validator, the settings dropdown, and formatCost.
+
+export const SUPPORTED_CURRENCIES = [
+  "USD", "EUR", "GBP", "JPY", "CHF", "CAD", "AUD", "NZD", "CNY", "HKD",
+  "SGD", "INR", "KRW", "MXN", "BRL", "ZAR", "SEK", "NOK", "DKK", "PLN",
+  "CZK", "HUF", "RON", "BGN", "ILS", "TRY", "THB", "MYR", "PHP", "IDR",
+] as const;
+
+export const VALID_CURRENCIES = new Set(SUPPORTED_CURRENCIES);
+
+// Currencies with no fractional unit — display whole numbers only.
+export const ZERO_DECIMAL_CURRENCIES = new Set(["JPY", "KRW", "IDR"]);
+
+export const CURRENCY_NAMES: Record<string, string> = {
+  USD: "US Dollar",        EUR: "Euro",               GBP: "British Pound",
+  JPY: "Japanese Yen",     CHF: "Swiss Franc",        CAD: "Canadian Dollar",
+  AUD: "Australian Dollar", NZD: "New Zealand Dollar", CNY: "Chinese Yuan",
+  HKD: "Hong Kong Dollar", SGD: "Singapore Dollar",   INR: "Indian Rupee",
+  KRW: "South Korean Won", MXN: "Mexican Peso",       BRL: "Brazilian Real",
+  ZAR: "South African Rand", SEK: "Swedish Krona",    NOK: "Norwegian Krone",
+  DKK: "Danish Krone",     PLN: "Polish Złoty",       CZK: "Czech Koruna",
+  HUF: "Hungarian Forint", RON: "Romanian Leu",       BGN: "Bulgarian Lev",
+  ILS: "Israeli Shekel",   TRY: "Turkish Lira",       THB: "Thai Baht",
+  MYR: "Malaysian Ringgit", PHP: "Philippine Peso",   IDR: "Indonesian Rupiah",
+};
+
+export const CURRENCY_SYMBOL: Record<string, string> = {
+  USD: "$",   EUR: "€",   GBP: "£",   JPY: "¥",   CHF: "Fr",
+  CAD: "CA$", AUD: "A$",  NZD: "NZ$", CNY: "¥",   HKD: "HK$",
+  SGD: "S$",  INR: "₹",   KRW: "₩",   MXN: "MX$", BRL: "R$",
+  ZAR: "R",   SEK: "kr",  NOK: "kr",  DKK: "kr",  PLN: "zł",
+  CZK: "Kč",  HUF: "Ft",  RON: "lei", BGN: "лв",  ILS: "₪",
+  TRY: "₺",   THB: "฿",   MYR: "RM",  PHP: "₱",   IDR: "Rp",
+};

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -38,7 +38,7 @@ export function formatCostCompact(amountUsd: number, currency = "USD", fxRate = 
   const sym = CURRENCY_SYMBOL[currency] ?? currency;
   if (ZERO_DECIMAL_CURRENCIES.has(currency)) {
     const rounded = Math.round(amount);
-    return rounded === 0 ? `<1${sym}` : `${sym}${rounded}`;
+    return amount > 0 && rounded === 0 ? `${sym}<1` : `${sym}${rounded}`;
   }
   if (amount >= 1) return `${sym}${amount.toFixed(2)}`;
   if (amount >= 0.001) return `${sym}${amount.toFixed(3)}`;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -13,3 +13,34 @@ export function msLabel(ms: number): string {
 export function defaultSince(days = 7): string {
   return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 }
+
+// ── Cost formatting ──────────────────────────────────────────────────────────
+
+import { ZERO_DECIMAL_CURRENCIES, CURRENCY_SYMBOL } from "@/lib/currencies";
+
+export function formatCost(amountUsd: number, currency = "USD", fxRate = 1): string {
+  const amount = amountUsd * fxRate;
+  const sym = CURRENCY_SYMBOL[currency] ?? currency;
+  if (ZERO_DECIMAL_CURRENCIES.has(currency)) {
+    return `${sym}${Math.round(amount)}`;
+  }
+  if (amount >= 1) return `${sym}${amount.toFixed(2)}`;
+  if (amount >= 0.01) return `${sym}${amount.toFixed(3)}`;
+  if (amount > 0) return `${sym}${amount.toFixed(4)}`;
+  return `${sym}0`;
+}
+
+/**
+ * Compact variant — narrower precision thresholds for tight UI contexts.
+ */
+export function formatCostCompact(amountUsd: number, currency = "USD", fxRate = 1): string {
+  const amount = amountUsd * fxRate;
+  const sym = CURRENCY_SYMBOL[currency] ?? currency;
+  if (ZERO_DECIMAL_CURRENCIES.has(currency)) {
+    const rounded = Math.round(amount);
+    return rounded === 0 ? `<1${sym}` : `${sym}${rounded}`;
+  }
+  if (amount >= 1) return `${sym}${amount.toFixed(2)}`;
+  if (amount >= 0.001) return `${sym}${amount.toFixed(3)}`;
+  return `${sym}${amount.toFixed(4)}`;
+}

--- a/src/lib/fxRates.ts
+++ b/src/lib/fxRates.ts
@@ -8,6 +8,7 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 let ratesMap: Record<string, number> | null = null;
 let fetchedAt: string | null = null;
+let loadedAt: number | null = null;
 let loadPromise: Promise<void> | null = null;
 
 interface FrankfurterResponse {
@@ -22,7 +23,7 @@ interface CacheEntry {
 }
 
 export async function loadFxRates(): Promise<void> {
-  if (ratesMap) return;
+  if (ratesMap && loadedAt && Date.now() - loadedAt < CACHE_TTL_MS) return;
   if (loadPromise) return loadPromise;
 
   loadPromise = (async () => {
@@ -38,6 +39,7 @@ export async function loadFxRates(): Promise<void> {
         const entry = JSON.parse(raw) as CacheEntry;
         ratesMap = entry.rates;
         fetchedAt = entry.fetchedAt;
+        loadedAt = Date.now();
         return;
       }
 
@@ -49,6 +51,7 @@ export async function loadFxRates(): Promise<void> {
         const body = (await res.json()) as FrankfurterResponse;
         ratesMap = body.rates;
         fetchedAt = new Date().toISOString();
+        loadedAt = Date.now();
 
         try {
           await fs.mkdir(path.dirname(CACHE_FILE), { recursive: true });
@@ -59,7 +62,20 @@ export async function loadFxRates(): Promise<void> {
         clearTimeout(timeout);
       }
     } catch {
-      if (!ratesMap) ratesMap = {};
+      // Network failed: use stale disk cache as last-good fallback.
+      try {
+        const raw = await fs.readFile(CACHE_FILE, "utf-8");
+        const entry = JSON.parse(raw) as CacheEntry;
+        ratesMap = entry.rates;
+        fetchedAt = entry.fetchedAt;
+        loadedAt = Date.now();
+      } catch {
+        ratesMap = {};
+        loadedAt = Date.now();
+      }
+    } finally {
+      // Clear the in-flight guard so TTL expiry can schedule a fresh fetch.
+      loadPromise = null;
     }
   })();
 
@@ -90,5 +106,6 @@ export function getFetchedAt(): string | null {
 export function _resetForTesting(): void {
   ratesMap = null;
   fetchedAt = null;
+  loadedAt = null;
   loadPromise = null;
 }

--- a/src/lib/fxRates.ts
+++ b/src/lib/fxRates.ts
@@ -1,0 +1,94 @@
+import { promises as fs } from "fs";
+import path from "path";
+import os from "os";
+
+const CACHE_FILE = path.join(os.homedir(), ".minder", "exchange-rates.json");
+const FRANKFURTER_URL = "https://api.frankfurter.dev/v1/latest?base=USD";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+let ratesMap: Record<string, number> | null = null;
+let fetchedAt: string | null = null;
+let loadPromise: Promise<void> | null = null;
+
+interface FrankfurterResponse {
+  base: string;
+  date: string;
+  rates: Record<string, number>;
+}
+
+interface CacheEntry {
+  fetchedAt: string;
+  rates: Record<string, number>;
+}
+
+export async function loadFxRates(): Promise<void> {
+  if (ratesMap) return;
+  if (loadPromise) return loadPromise;
+
+  loadPromise = (async () => {
+    try {
+      let useDiskCache = false;
+      try {
+        const stat = await fs.stat(CACHE_FILE);
+        useDiskCache = Date.now() - stat.mtimeMs < CACHE_TTL_MS;
+      } catch { /* no cache */ }
+
+      if (useDiskCache) {
+        const raw = await fs.readFile(CACHE_FILE, "utf-8");
+        const entry = JSON.parse(raw) as CacheEntry;
+        ratesMap = entry.rates;
+        fetchedAt = entry.fetchedAt;
+        return;
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10_000);
+      try {
+        const res = await fetch(FRANKFURTER_URL, { signal: controller.signal });
+        if (!res.ok) throw new Error(`Frankfurter ${res.status}`);
+        const body = (await res.json()) as FrankfurterResponse;
+        ratesMap = body.rates;
+        fetchedAt = new Date().toISOString();
+
+        try {
+          await fs.mkdir(path.dirname(CACHE_FILE), { recursive: true });
+          const entry: CacheEntry = { fetchedAt: fetchedAt!, rates: ratesMap };
+          await fs.writeFile(CACHE_FILE, JSON.stringify(entry), "utf-8");
+        } catch { /* non-critical */ }
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch {
+      if (!ratesMap) ratesMap = {};
+    }
+  })();
+
+  return loadPromise;
+}
+
+/**
+ * FX rate for converting 1 USD to `currency`. Returns 1 for USD.
+ * Triggers a disk/network load on first call.
+ */
+export async function getRate(currency: string): Promise<number> {
+  if (currency === "USD") return 1;
+  if (!ratesMap) await loadFxRates();
+  return (ratesMap ?? {})[currency] ?? 1;
+}
+
+/** Synchronous read of the in-memory rates cache. Returns {} until warmed. */
+export function getRatesSync(): Record<string, number> {
+  return ratesMap ?? {};
+}
+
+/** ISO timestamp of when the cache was last populated. */
+export function getFetchedAt(): string | null {
+  return fetchedAt;
+}
+
+/** For testing only. */
+export function _resetForTesting(): void {
+  ratesMap = null;
+  fetchedAt = null;
+  loadPromise = null;
+}

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -19,6 +19,7 @@ export const helpMapping: Record<string, string> = {
   '/config': 'config',
   '/setup': 'setup',
   '/settings': 'settings',
+  '/settings/cost': 'cost',
   '/settings/notifications': 'notifications',
   '/settings/integrations': 'telegram',
   '/settings/terminal': 'terminal',
@@ -86,6 +87,7 @@ export const helpSlugs = [
   'terminal',
   'auto-title',
   'otel',
+  'cost',
 ] as const
 
 export type HelpSlug = (typeof helpSlugs)[number]

--- a/src/lib/usage/costCalculator.ts
+++ b/src/lib/usage/costCalculator.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from "fs";
 import path from "path";
 import type { ModelPricing, UsageTurn } from "@/lib/usage/types";
+import type { PricingRule } from "@/lib/types";
+import { matchPricingRule, applyPricingOverlay } from "@/lib/usage/pricingRules";
 
 // ── Hardcoded fallback pricing (per token) ──────────────────────────────────
 
@@ -29,6 +31,18 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
 
 let pricingMap: Map<string, ModelPricing> | null = null;
 let pricingLoadPromise: Promise<void> | null = null;
+
+// globalThis so pricing rules survive hot-reload in dev and are shared
+// across concurrent requests in production.
+declare const globalThis: { __minderPricingRules?: PricingRule[] };
+
+export function setPricingRules(rules: PricingRule[]): void {
+  globalThis.__minderPricingRules = rules;
+}
+
+export function getPricingRules(): PricingRule[] {
+  return globalThis.__minderPricingRules ?? [];
+}
 
 // ── Cache paths ──────────────────────────────────────────────────────────────
 
@@ -85,6 +99,13 @@ export async function loadPricing(): Promise<void> {
   if (pricingLoadPromise) return pricingLoadPromise;
 
   pricingLoadPromise = (async () => {
+    // Warm pricing rules from config so they survive server restarts.
+    try {
+      const { readConfig } = await import("@/lib/config");
+      const config = await readConfig();
+      if (config.pricingRules?.length) setPricingRules(config.pricingRules);
+    } catch { /* non-critical */ }
+
     try {
       let useDiskCache = false;
       try {
@@ -121,59 +142,53 @@ export async function loadPricing(): Promise<void> {
 
 /**
  * Look up pricing for a model by name. Falls back gracefully.
+ * Applies any active pricing rule overlay before returning.
  */
 export function getModelPricing(model: string): ModelPricing {
   const map = pricingMap ?? new Map(Object.entries(FALLBACK_PRICING));
 
   // 1. Exact match
-  const exact = map.get(model);
-  if (exact) return exact;
+  let base = map.get(model);
 
-  // 2. Fuzzy match: strip date suffix and progressively shorten
-  //    e.g. "claude-sonnet-4-5-20250514" → "claude-sonnet-4-5" → "claude-sonnet-4" → ...
-  const dateSuffixPattern = /-\d{8}$/;
-  let candidate = model.replace(dateSuffixPattern, "");
+  if (!base) {
+    // 2. Fuzzy match: strip date suffix and progressively shorten
+    const dateSuffixPattern = /-\d{8}$/;
+    let candidate = model.replace(dateSuffixPattern, "");
 
-  while (candidate.length > 0) {
-    const match = map.get(candidate);
-    if (match) return match;
-
-    // Also try fallback map directly for known keys
-    const fallback = FALLBACK_PRICING[candidate];
-    if (fallback) return fallback;
-
-    // Strip last dash-separated segment
-    const lastDash = candidate.lastIndexOf("-");
-    if (lastDash === -1) break;
-    candidate = candidate.substring(0, lastDash);
+    while (candidate.length > 0) {
+      const match = map.get(candidate);
+      if (match) { base = match; break; }
+      const fallback = FALLBACK_PRICING[candidate];
+      if (fallback) { base = fallback; break; }
+      const lastDash = candidate.lastIndexOf("-");
+      if (lastDash === -1) break;
+      candidate = candidate.substring(0, lastDash);
+    }
   }
 
-  // 3. Keyword match: opus, sonnet, haiku
-  const lower = model.toLowerCase();
-  if (lower.includes("opus")) {
-    return (
-      map.get("claude-opus-4") ??
-      FALLBACK_PRICING["claude-opus-4"]
-    );
-  }
-  if (lower.includes("haiku")) {
-    return (
-      map.get("claude-haiku-3.5") ??
-      FALLBACK_PRICING["claude-haiku-3.5"]
-    );
-  }
-  if (lower.includes("sonnet")) {
-    return (
-      map.get("claude-sonnet-4") ??
-      FALLBACK_PRICING["claude-sonnet-4"]
-    );
+  if (!base) {
+    // 3. Keyword match: opus, sonnet, haiku
+    const lower = model.toLowerCase();
+    if (lower.includes("opus")) {
+      base = map.get("claude-opus-4") ?? FALLBACK_PRICING["claude-opus-4"];
+    } else if (lower.includes("haiku")) {
+      base = map.get("claude-haiku-3.5") ?? FALLBACK_PRICING["claude-haiku-3.5"];
+    } else if (lower.includes("sonnet")) {
+      base = map.get("claude-sonnet-4") ?? FALLBACK_PRICING["claude-sonnet-4"];
+    } else {
+      // 4. Default fallback: sonnet pricing
+      base = map.get("claude-sonnet-4") ?? FALLBACK_PRICING["claude-sonnet-4"];
+    }
   }
 
-  // 4. Default fallback: sonnet pricing
-  return (
-    map.get("claude-sonnet-4") ??
-    FALLBACK_PRICING["claude-sonnet-4"]
-  );
+  // Apply pricing rule overlay (user-defined overrides from settings)
+  const rules = getPricingRules();
+  if (rules.length > 0) {
+    const rule = matchPricingRule(rules, model);
+    return applyPricingOverlay(base, rule);
+  }
+
+  return base;
 }
 
 export interface TokenCounts {
@@ -216,4 +231,5 @@ export async function computeTurnCost(turn: UsageTurn): Promise<number> {
 export function _resetForTesting(): void {
   pricingMap = null;
   pricingLoadPromise = null;
+  delete globalThis.__minderPricingRules;
 }

--- a/src/lib/usage/costCalculator.ts
+++ b/src/lib/usage/costCalculator.ts
@@ -34,14 +34,14 @@ let pricingLoadPromise: Promise<void> | null = null;
 
 // globalThis so pricing rules survive hot-reload in dev and are shared
 // across concurrent requests in production.
-declare const globalThis: { __minderPricingRules?: PricingRule[] };
+const g = globalThis as unknown as { __minderPricingRules?: PricingRule[] };
 
 export function setPricingRules(rules: PricingRule[]): void {
-  globalThis.__minderPricingRules = rules;
+  g.__minderPricingRules = rules;
 }
 
 export function getPricingRules(): PricingRule[] {
-  return globalThis.__minderPricingRules ?? [];
+  return g.__minderPricingRules ?? [];
 }
 
 // ── Cache paths ──────────────────────────────────────────────────────────────
@@ -231,5 +231,5 @@ export async function computeTurnCost(turn: UsageTurn): Promise<number> {
 export function _resetForTesting(): void {
   pricingMap = null;
   pricingLoadPromise = null;
-  delete globalThis.__minderPricingRules;
+  delete g.__minderPricingRules;
 }

--- a/src/lib/usage/pricingRules.ts
+++ b/src/lib/usage/pricingRules.ts
@@ -1,0 +1,51 @@
+import type { PricingRule } from "@/lib/types";
+import type { ModelPricing } from "@/lib/usage/types";
+
+const regexCache = new Map<string, RegExp>();
+
+function patternToRegex(pattern: string): RegExp {
+  let re = regexCache.get(pattern);
+  if (!re) {
+    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+    re = new RegExp(`^${escaped}$`, "i");
+    regexCache.set(pattern, re);
+  }
+  return re;
+}
+
+export function matchPricingRule(rules: PricingRule[], model: string): PricingRule | null {
+  let best: PricingRule | null = null;
+  let bestLen = -1;
+
+  for (const rule of rules) {
+    if (patternToRegex(rule.pattern).test(model)) {
+      if (rule.pattern.length > bestLen) {
+        best = rule;
+        bestLen = rule.pattern.length;
+      }
+    }
+  }
+
+  return best;
+}
+
+export function applyPricingOverlay(
+  base: ModelPricing,
+  rule: PricingRule | null
+): ModelPricing {
+  if (!rule) return base;
+  return {
+    inputCostPerToken: rule.inputUsdPerMillion !== undefined
+      ? rule.inputUsdPerMillion / 1_000_000
+      : base.inputCostPerToken,
+    outputCostPerToken: rule.outputUsdPerMillion !== undefined
+      ? rule.outputUsdPerMillion / 1_000_000
+      : base.outputCostPerToken,
+    cacheReadCostPerToken: rule.cacheReadUsdPerMillion !== undefined
+      ? rule.cacheReadUsdPerMillion / 1_000_000
+      : base.cacheReadCostPerToken,
+    cacheWriteCostPerToken: rule.cacheCreateUsdPerMillion !== undefined
+      ? rule.cacheCreateUsdPerMillion / 1_000_000
+      : base.cacheWriteCostPerToken,
+  };
+}

--- a/tests/fxRates.test.ts
+++ b/tests/fxRates.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getRate, getRatesSync, _resetForTesting } from "@/lib/fxRates";
+import * as fs from "fs";
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      stat: vi.fn(),
+      readFile: vi.fn(),
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const mockedFs = vi.mocked(fs.promises);
+
+const FAKE_RATES = { EUR: 0.9, GBP: 0.79, JPY: 150.5 };
+const FAKE_CACHE = JSON.stringify({ fetchedAt: new Date().toISOString(), rates: FAKE_RATES });
+
+describe("fxRates", () => {
+  beforeEach(() => {
+    _resetForTesting();
+    vi.clearAllMocks();
+  });
+
+  it("returns 1 for USD without any fetch", async () => {
+    const rate = await getRate("USD");
+    expect(rate).toBe(1);
+  });
+
+  it("loads from disk cache when fresh", async () => {
+    mockedFs.stat.mockResolvedValueOnce({ mtimeMs: Date.now() - 1000 } as unknown as import("fs").Stats);
+    mockedFs.readFile.mockResolvedValueOnce(FAKE_CACHE);
+
+    const rate = await getRate("EUR");
+    expect(rate).toBeCloseTo(0.9);
+    expect(mockedFs.readFile).toHaveBeenCalledOnce();
+  });
+
+  it("returns 1 as fallback when currency not in rates map", async () => {
+    mockedFs.stat.mockResolvedValueOnce({ mtimeMs: Date.now() - 1000 } as unknown as import("fs").Stats);
+    mockedFs.readFile.mockResolvedValueOnce(FAKE_CACHE);
+
+    const rate = await getRate("ZZZ");
+    expect(rate).toBe(1);
+  });
+
+  it("returns {} from getRatesSync before any load", () => {
+    expect(getRatesSync()).toEqual({});
+  });
+
+  it("returns populated map from getRatesSync after load", async () => {
+    mockedFs.stat.mockResolvedValueOnce({ mtimeMs: Date.now() - 1000 } as unknown as import("fs").Stats);
+    mockedFs.readFile.mockResolvedValueOnce(FAKE_CACHE);
+    await getRate("EUR");
+    expect(getRatesSync()).toEqual(FAKE_RATES);
+  });
+
+  it("falls back to empty map when disk cache is absent and fetch fails", async () => {
+    mockedFs.stat.mockRejectedValueOnce(new Error("ENOENT"));
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error("network error")) as typeof fetch;
+    try {
+      const rate = await getRate("EUR");
+      expect(rate).toBe(1); // fallback
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it("deduplicates concurrent loads", async () => {
+    mockedFs.stat.mockResolvedValue({ mtimeMs: Date.now() - 1000 } as unknown as import("fs").Stats);
+    mockedFs.readFile.mockResolvedValue(FAKE_CACHE);
+
+    const [r1, r2] = await Promise.all([getRate("JPY"), getRate("GBP")]);
+    expect(r1).toBeCloseTo(150.5);
+    expect(r2).toBeCloseTo(0.79);
+    // Only one actual readFile call despite two concurrent getRate calls
+    expect(mockedFs.readFile).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/pricingRules.test.ts
+++ b/tests/pricingRules.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { matchPricingRule, applyPricingOverlay } from "@/lib/usage/pricingRules";
+import type { PricingRule } from "@/lib/types";
+import type { ModelPricing } from "@/lib/usage/types";
+
+const BASE: ModelPricing = {
+  inputCostPerToken: 0.000003,
+  outputCostPerToken: 0.000015,
+  cacheWriteCostPerToken: 0.00000375,
+  cacheReadCostPerToken: 0.0000003,
+};
+
+describe("matchPricingRule", () => {
+  it("returns null for empty rules", () => {
+    expect(matchPricingRule([], "claude-sonnet-4-6")).toBeNull();
+  });
+
+  it("matches exact model name", () => {
+    const rules: PricingRule[] = [{ pattern: "claude-sonnet-4-6", inputUsdPerMillion: 5 }];
+    expect(matchPricingRule(rules, "claude-sonnet-4-6")?.inputUsdPerMillion).toBe(5);
+  });
+
+  it("matches with * wildcard", () => {
+    const rules: PricingRule[] = [{ pattern: "claude-opus-4*", outputUsdPerMillion: 90 }];
+    expect(matchPricingRule(rules, "claude-opus-4-7")?.outputUsdPerMillion).toBe(90);
+    expect(matchPricingRule(rules, "claude-opus-4-20250514")?.outputUsdPerMillion).toBe(90);
+  });
+
+  it("matches leading wildcard *haiku*", () => {
+    const rules: PricingRule[] = [{ pattern: "*haiku*", inputUsdPerMillion: 1 }];
+    expect(matchPricingRule(rules, "claude-haiku-3.5")?.inputUsdPerMillion).toBe(1);
+    expect(matchPricingRule(rules, "claude-haiku-3-5-20251001")?.inputUsdPerMillion).toBe(1);
+  });
+
+  it("returns null when no pattern matches", () => {
+    const rules: PricingRule[] = [{ pattern: "claude-opus-4*" }];
+    expect(matchPricingRule(rules, "claude-sonnet-4-6")).toBeNull();
+  });
+
+  it("picks longest pattern when multiple match", () => {
+    const rules: PricingRule[] = [
+      { pattern: "claude-opus-4*",    inputUsdPerMillion: 10 },
+      { pattern: "claude-opus-4-7",   inputUsdPerMillion: 20 },
+      { pattern: "claude*",            inputUsdPerMillion: 1 },
+    ];
+    expect(matchPricingRule(rules, "claude-opus-4-7")?.inputUsdPerMillion).toBe(20);
+  });
+
+  it("does not match partial prefix without wildcard", () => {
+    const rules: PricingRule[] = [{ pattern: "claude-opus" }];
+    expect(matchPricingRule(rules, "claude-opus-4-7")).toBeNull();
+  });
+
+  it("escapes regex special chars in patterns", () => {
+    const rules: PricingRule[] = [{ pattern: "claude.opus*", inputUsdPerMillion: 5 }];
+    // "claude.opus" with literal dot should NOT match "claude-opus-4"
+    expect(matchPricingRule(rules, "claude-opus-4")).toBeNull();
+    expect(matchPricingRule(rules, "claude.opus.4")).not.toBeNull();
+  });
+});
+
+describe("applyPricingOverlay", () => {
+  it("returns base unchanged when rule is null", () => {
+    expect(applyPricingOverlay(BASE, null)).toEqual(BASE);
+  });
+
+  it("overrides only the fields specified in the rule", () => {
+    const rule: PricingRule = { pattern: "*", inputUsdPerMillion: 10 };
+    const result = applyPricingOverlay(BASE, rule);
+    expect(result.inputCostPerToken).toBeCloseTo(10 / 1_000_000);
+    expect(result.outputCostPerToken).toBe(BASE.outputCostPerToken);
+    expect(result.cacheWriteCostPerToken).toBe(BASE.cacheWriteCostPerToken);
+    expect(result.cacheReadCostPerToken).toBe(BASE.cacheReadCostPerToken);
+  });
+
+  it("converts per-million rates to per-token correctly", () => {
+    const rule: PricingRule = {
+      pattern: "*",
+      inputUsdPerMillion: 15,
+      outputUsdPerMillion: 75,
+      cacheReadUsdPerMillion: 1.5,
+      cacheCreateUsdPerMillion: 18.75,
+    };
+    const result = applyPricingOverlay(BASE, rule);
+    expect(result.inputCostPerToken).toBeCloseTo(0.000015);
+    expect(result.outputCostPerToken).toBeCloseTo(0.000075);
+    expect(result.cacheReadCostPerToken).toBeCloseTo(0.0000015);
+    expect(result.cacheWriteCostPerToken).toBeCloseTo(0.00001875);
+  });
+});


### PR DESCRIPTION
## Summary

- **Display currency preference** (Settings → Cost) — 30 ISO 4217 currencies via Frankfurter API; 24h disk cache at `~/.minder/exchange-rates.json`; last-good fallback on network failure; zero-decimal rendering for JPY/KRW/IDR
- **Per-model pricing rule overrides** (Settings → Cost) — `*` wildcard patterns, longest-match-wins, four rate fields (USD/M tokens), Reset to defaults; rules apply to new session ingest immediately via globalThis warm-up
- **Centralized `formatCost` / `formatCostCompact`** in `src/lib/format.ts` — five components were each inlining identical functions; all now import from the shared module
- **`useCurrency()` hook** with module-level singleton — one fetch pair per page load regardless of how many components call the hook; `invalidateCurrencyCache()` called on currency save
- **`src/lib/currencies.ts`** — single source of truth for the 30-currency allowlist, names, symbols, and zero-decimal set (previously duplicated across `route.ts`, `CostSection.tsx`, and `format.ts`)
- **`PATCH /api/config`** — `currency` allowlist validation + `pricingRules` shape/range checks; `setPricingRules()` called after `mutateConfig` returns (not inside `patches[]`)
- **`GET /api/integrations/fx`** — serves Frankfurter rates from 24h cache
- **CSS token fix** — `--surface-1`/`--surface-2` (undefined in this design system) replaced with `--bg-surface`/`--bg-elevated` across all settings components; `<select>` gets `appearance:none` + SVG chevron for proper dark-mode rendering
- **Help doc** — `cost.md`, `HelpPanel.tsx` slugTitles, `help-mapping.ts` route wired

## New files

| File | Purpose |
|---|---|
| `src/lib/currencies.ts` | Canonical currency data (allowlist, names, symbols) |
| `src/lib/fxRates.ts` | Frankfurter fetch + 24h disk cache + in-flight dedup |
| `src/lib/usage/pricingRules.ts` | Wildcard match (RegExp cache) + overlay merge |
| `src/app/api/integrations/fx/route.ts` | FX rate API endpoint |
| `src/components/settings/CostSection.tsx` | Currency picker + pricing rules table editor |
| `src/hooks/useCurrency.ts` | Shared currency/fxRate hook with module singleton |
| `tests/fxRates.test.ts` | 7 tests: TTL cache, fallback, dedup |
| `tests/pricingRules.test.ts` | 9 tests: wildcard, longest-wins, overlay |
| `docs/help/cost.md` + `public/help/cost.md` | Help doc |

## Test plan

- [ ] Settings → Cost: currency dropdown renders in dark theme (no white box)
- [ ] Switch to EUR → all cost figures in UsageDashboard/Sessions/Stats reformat with € symbol and live FX rate
- [ ] Switch to JPY → no decimal places shown
- [ ] Add pricing rule `claude-opus-4*` with `inputUsdPerMillion: 999` → new session ingest reflects override
- [ ] Reset to defaults → pricing returns to LiteLLM rates
- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 1373 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)