### PR TITLE
feat(wave8.3): Cluster T — session-row UX bundle (#158 #162 #164 #189 #191 #231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 8.3 — Cluster T: Session-row UX bundle.** TODOs #158, #162, #164, #189, #191, #231.
+  - **#164 Worktree consolidation.** `canonicalizeDirName` now applied in both DB (`sessionsListFromDb`) and file-parse (`claudeConversations`) loaders so worktree sessions group under the parent project slug. `SessionsBrowser` groups by `projectSlug` (was `projectPath`). `claudeSessions` scanner unions worktree JSONL counts into parent session count. Worktree branch chip renders on session rows.
+  - **#191 Per-project Git activity panel.** `GET /api/projects/[slug]/git-activity` aggregates `git commit` / `git push` counts and branch activity from tool call arguments (DB-first with file-parse fallback; 5-min cache). `GitActivityPanel` renders commit/push stat boxes and a recency-sorted branch list in Project Overview.
+  - **#158 Work-mode distribution.** `sessions.work_mode_{exploration,building,testing,other}_pct` columns (schema v10). `aggregateWorkMode` maps the 13 classifer categories to 4 buckets. `StackedStrip` (pure SVG, largest-remainder rounding) renders per-session in `SessionsBrowser`. "By Work Mode" subsection in `EfficiencyTab`.
+  - **#162 Invocation source tracking.** `tool_uses.invocation_source` (`slash_command` | `auto`) stamped during ingest. `GET /api/skills` returns `slashCount` / `autoCount`; `SkillsBrowser` renders the breakdown inline.
+  - **#189 Tool error categorization.** `tool_uses.is_error` now written correctly; `tool_uses.error_category` (`permission` | `timeout` | `not-found` | `parse` | `network` | `interrupted` | `other`) populated by `categorizeToolError`. `DiagnosisPanel` renders a "Tool errors by category" chip strip below findings.
+  - **#231 Deep tool args in session timeline.** `TimelineEvent` gains `toolInput` + `toolUseId`. Both timeline builders (DB and file-parse) populate these fields. `SessionTimeline` shows a "show args" expand toggle on `tool_use` events, rendering via `formatToolArgs` (Bash command, file path, edit diff, or JSON).
+
 - **Wave 8.2b — Cluster S: Claude Max quota burndown + schedule mode.** TODO #136, #137.
   - **Claude Max quota probe** (`src/lib/quota.ts`). Reads the OAuth access token from `~/.claude/.credentials.json` and makes a minimal POST to `api.anthropic.com/v1/messages` (Claude Haiku 4.5, 1 token, ~$0.00001/probe) to read `anthropic-ratelimit-unified-*` response headers. Returns 5-hour and 7-day rolling-window utilization (0–1), status, and reset timestamps. Disk-cached 5 min at `~/.minder/quota-cache.json`; stale-cache fallback on network failure. Only works for Claude Max subscribers using OAuth (not API-key auth).
   - **`GET /api/integrations/quota`** — returns `QuotaResult` (either `{ configured: true, windows: { "5h", "7d", overage }, subscriptionType, rateLimitTier, ... }` or `{ configured: false, reason }`).

--- a/docs/help/project-details.md
+++ b/docs/help/project-details.md
@@ -43,6 +43,15 @@ Lists any external APIs or services detected in the project (e.g., AWS, Firebase
 - Last commit message
 - Number of uncommitted changes (if any)
 
+### Git Activity
+
+When the project has Claude sessions, the **Git Activity** panel aggregates `git commit` and `git push` calls made across all recorded sessions. It shows:
+
+- **Commits** and **Pushes** — total counts across all sessions
+- **Branches** — list of branches Claude worked on, sorted by most-recent session
+
+Data is sourced from Bash/PowerShell tool call arguments in the SQLite index (DB mode) or by re-parsing JSONL files (file-parse fallback). The panel is hidden when no git activity was detected.
+
 ## Context Tab
 
 Displays the full contents of the project's `CLAUDE.md` file, if one exists. This is the context file that Claude reads when working on the project.
@@ -84,10 +93,11 @@ Shows your Claude session history for this project:
 
 ## Efficiency Tab
 
-Appears when the project has Claude sessions. Shows two analytics panels:
+Appears when the project has Claude sessions. Shows three analytics panels:
 
 - **Waste Optimizer** — grades the project A–F and lists up to 5 findings: junk-directory reads, duplicate reads, unused MCP servers, ghost agent/skill capabilities, and low read/edit ratio. Each finding includes a severity level and actionable detail.
 - **Session Yield** — classifies sessions as Productive, Reverted, or Abandoned by aligning session intervals with the main-branch commit log. Displays yield rate, total sessions analysed, and cost-per-shipped-commit when session cost data is available.
+- **By Work Mode** — colour-coded strip and percentage breakdown of how the project's assistant turns were classified across the four work modes (Exploration, Building, Testing, Other). Matches the per-session strips shown in the Sessions browser.
 
 ## Patterns Tab
 

--- a/docs/help/sessions.md
+++ b/docs/help/sessions.md
@@ -28,9 +28,22 @@ Each session card shows:
 - **Git branch** — the branch active during the session
 - **Model badges** — which Claude models were used
 
+### Work-mode strip
+
+Each session row shows a narrow colour-coded strip on the right summarising how the session's turns were classified:
+
+| Colour | Mode | Includes |
+|---|---|---|
+| Green | Exploration | Exploration, Brainstorming, Planning |
+| Amber | Building | Coding, Feature Dev, Refactoring |
+| Red | Testing | Testing |
+| Grey | Other | Git Ops, Build/Deploy, Debugging, Delegation, Conversation, General |
+
+The strip is proportional to the percentage of assistant turns in each mode. Hover the strip for a tooltip with exact percentages. Sessions indexed before schema v10 (DERIVED_VERSION 7) will not show the strip.
+
 ### Quality chips
 
-When a session has been re-indexed under DERIVED_VERSION 6 (or scanned by the file-parse path), the row may surface up to five quality chips:
+When a session has been re-indexed under DERIVED_VERSION 7 (or scanned by the file-parse path), the row may surface up to five quality chips:
 
 - **`NN% cache`** — cache hit ratio (`cache_read / (cache_read + cache_create)`). Green at ≥70% (cache paying back the build cost), amber under 50% (rebuilds dominating). Sessions with no cache activity at all simply don't show the chip.
 - **`compaction loop`** (red) — at least one run of consecutive turn pairs where input variance was <10% and context fill was >75%. Signals Claude was burning tokens cycling on the same context without progress.
@@ -65,6 +78,8 @@ Click a session to see the full detail view with tabs:
 Chronological list of all events: user prompts, assistant responses, tool calls, thinking blocks, and errors. Each event shows a time offset from the session start. Assistant and user messages render **markdown formatting** — fenced code blocks appear in a monospace code box, and inline `code` spans are styled distinctly.
 
 **Turn-duration badges** appear on assistant events when the session data includes `turn_duration` system entries — a wall-clock measurement Claude Code records at the end of each assistant turn. Durations format as `2.3s` for sub-minute turns and `4m12s` for longer ones.
+
+**Tool call arguments** — click **show args** on any tool call row to expand the full arguments. Bash and PowerShell events show the command string; Read/Write/Glob events show the file path; Edit/MultiEdit events show an old→new inline diff; all other tools show a JSON pretty-print. Sessions indexed before schema v10 may not show tool arguments (requires `arguments_json` to be populated in the SQLite index).
 
 **Thinking blocks** are collapsible. Click to expand an extended-thinking event and read the full reasoning trace (up to ~3000 characters). When the SQLite index is active (the default), thinking content is not stored in the database — it is fetched on demand from the original JSONL at the recorded byte offset. If the file has been moved or deleted, the block shows "Thinking content unavailable for this turn." rather than silently hiding the section.
 
@@ -106,6 +121,8 @@ The header strip surfaces outcome (completed / partial / abandoned / stuck), cac
 Two additional finding categories appear when relevant:
 - **Buggy CLI version** (P1) — the session ran on CLI 2.1.69–2.1.89, a range with a known prompt-cache bug that causes cache rebuilds after compaction. Upgraded to P0 when a resume anomaly is also present.
 - **Resume anomaly** (P1) — post-compaction output token spike detected (≥10× pre-boundary median). May indicate context confusion following `--resume` or `--continue` under a buggy CLI version.
+
+**Tool errors by category** — below the findings, a strip of coloured chips shows how many tool errors occurred in each error category (permission, timeout, not-found, parse, network, interrupted, other). This section only appears when at least one tool call in the session errored.
 
 This view is computed from JSONL on demand and does not require the SQLite index.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@tanstack/react-virtual": "^3.13.24",
-        "better-sqlite3": "^12.9.0",
         "chokidar": "^4.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/public/help/project-details.md
+++ b/public/help/project-details.md
@@ -43,6 +43,15 @@ Lists any external APIs or services detected in the project (e.g., AWS, Firebase
 - Last commit message
 - Number of uncommitted changes (if any)
 
+### Git Activity
+
+When the project has Claude sessions, the **Git Activity** panel aggregates `git commit` and `git push` calls made across all recorded sessions. It shows:
+
+- **Commits** and **Pushes** — total counts across all sessions
+- **Branches** — list of branches Claude worked on, sorted by most-recent session
+
+Data is sourced from Bash/PowerShell tool call arguments in the SQLite index (DB mode) or by re-parsing JSONL files (file-parse fallback). The panel is hidden when no git activity was detected.
+
 ## Context Tab
 
 Displays the full contents of the project's `CLAUDE.md` file, if one exists. This is the context file that Claude reads when working on the project.
@@ -84,10 +93,11 @@ Shows your Claude session history for this project:
 
 ## Efficiency Tab
 
-Appears when the project has Claude sessions. Shows two analytics panels:
+Appears when the project has Claude sessions. Shows three analytics panels:
 
 - **Waste Optimizer** — grades the project A–F and lists up to 5 findings: junk-directory reads, duplicate reads, unused MCP servers, ghost agent/skill capabilities, and low read/edit ratio. Each finding includes a severity level and actionable detail.
 - **Session Yield** — classifies sessions as Productive, Reverted, or Abandoned by aligning session intervals with the main-branch commit log. Displays yield rate, total sessions analysed, and cost-per-shipped-commit when session cost data is available.
+- **By Work Mode** — colour-coded strip and percentage breakdown of how the project's assistant turns were classified across the four work modes (Exploration, Building, Testing, Other). Matches the per-session strips shown in the Sessions browser.
 
 ## Patterns Tab
 

--- a/public/help/sessions.md
+++ b/public/help/sessions.md
@@ -28,9 +28,22 @@ Each session card shows:
 - **Git branch** — the branch active during the session
 - **Model badges** — which Claude models were used
 
+### Work-mode strip
+
+Each session row shows a narrow colour-coded strip on the right summarising how the session's turns were classified:
+
+| Colour | Mode | Includes |
+|---|---|---|
+| Green | Exploration | Exploration, Brainstorming, Planning |
+| Amber | Building | Coding, Feature Dev, Refactoring |
+| Red | Testing | Testing |
+| Grey | Other | Git Ops, Build/Deploy, Debugging, Delegation, Conversation, General |
+
+The strip is proportional to the percentage of assistant turns in each mode. Hover the strip for a tooltip with exact percentages. Sessions indexed before schema v10 (DERIVED_VERSION 7) will not show the strip.
+
 ### Quality chips
 
-When a session has been re-indexed under DERIVED_VERSION 6 (or scanned by the file-parse path), the row may surface up to five quality chips:
+When a session has been re-indexed under DERIVED_VERSION 7 (or scanned by the file-parse path), the row may surface up to five quality chips:
 
 - **`NN% cache`** — cache hit ratio (`cache_read / (cache_read + cache_create)`). Green at ≥70% (cache paying back the build cost), amber under 50% (rebuilds dominating). Sessions with no cache activity at all simply don't show the chip.
 - **`compaction loop`** (red) — at least one run of consecutive turn pairs where input variance was <10% and context fill was >75%. Signals Claude was burning tokens cycling on the same context without progress.
@@ -65,6 +78,8 @@ Click a session to see the full detail view with tabs:
 Chronological list of all events: user prompts, assistant responses, tool calls, thinking blocks, and errors. Each event shows a time offset from the session start. Assistant and user messages render **markdown formatting** — fenced code blocks appear in a monospace code box, and inline `code` spans are styled distinctly.
 
 **Turn-duration badges** appear on assistant events when the session data includes `turn_duration` system entries — a wall-clock measurement Claude Code records at the end of each assistant turn. Durations format as `2.3s` for sub-minute turns and `4m12s` for longer ones.
+
+**Tool call arguments** — click **show args** on any tool call row to expand the full arguments. Bash and PowerShell events show the command string; Read/Write/Glob events show the file path; Edit/MultiEdit events show an old→new inline diff; all other tools show a JSON pretty-print. Sessions indexed before schema v10 may not show tool arguments (requires `arguments_json` to be populated in the SQLite index).
 
 **Thinking blocks** are collapsible. Click to expand an extended-thinking event and read the full reasoning trace (up to ~3000 characters). When the SQLite index is active (the default), thinking content is not stored in the database — it is fetched on demand from the original JSONL at the recorded byte offset. If the file has been moved or deleted, the block shows "Thinking content unavailable for this turn." rather than silently hiding the section.
 
@@ -106,6 +121,8 @@ The header strip surfaces outcome (completed / partial / abandoned / stuck), cac
 Two additional finding categories appear when relevant:
 - **Buggy CLI version** (P1) — the session ran on CLI 2.1.69–2.1.89, a range with a known prompt-cache bug that causes cache rebuilds after compaction. Upgraded to P0 when a resume anomaly is also present.
 - **Resume anomaly** (P1) — post-compaction output token spike detected (≥10× pre-boundary median). May indicate context confusion following `--resume` or `--continue` under a buggy CLI version.
+
+**Tool errors by category** — below the findings, a strip of coloured chips shows how many tool errors occurred in each error category (permission, timeout, not-found, parse, network, interrupted, other). This section only appears when at least one tool call in the session errored.
 
 This view is computed from JSONL on demand and does not require the SQLite index.
 

--- a/src/app/api/projects/[slug]/efficiency/route.ts
+++ b/src/app/api/projects/[slug]/efficiency/route.ts
@@ -7,15 +7,25 @@ import { scanAllProjects } from "@/lib/scanner";
 import { getCachedScan, setCachedScan } from "@/lib/cache";
 import { loadCatalog } from "@/lib/indexer/catalog";
 import { gatherProjectTurns } from "@/lib/usage/projectMatch";
+import { classifyTurn } from "@/lib/usage/classifier";
+import { aggregateWorkMode } from "@/lib/usage/workMode";
 
 // On-demand per-project efficiency report. Cached on globalThis with a
 // 5-min TTL keyed by slug; cache also bypassed when the JSONL maxMtime
 // advances so newly-ingested sessions surface promptly.
 
+interface WorkModeDistribution {
+  exploration: number;
+  building: number;
+  testing: number;
+  other: number;
+}
+
 interface EfficiencyResponse {
   slug: string;
   waste: WasteOptimizerInfo;
   yieldReport: YieldResult;
+  workMode: WorkModeDistribution;
   generatedAt: string;
 }
 
@@ -92,10 +102,17 @@ export async function GET(
     };
   }
 
+  const workMode = aggregateWorkMode(
+    projectTurns
+      .filter((t) => t.role === "assistant")
+      .map((t) => ({ category: classifyTurn(t) }))
+  );
+
   const data: EfficiencyResponse = {
     slug,
     waste,
     yieldReport,
+    workMode,
     generatedAt: new Date().toISOString(),
   };
   cache.set(slug, { data, cachedAt: Date.now(), jsonlMtime: currentMtime });

--- a/src/app/api/projects/[slug]/git-activity/route.ts
+++ b/src/app/api/projects/[slug]/git-activity/route.ts
@@ -54,32 +54,38 @@ export async function GET(
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
     }
 
-    let activity: GitActivitySummary;
+    let activity: GitActivitySummary | null = null;
 
     const db = await getDb();
     if (db) {
-      // DB path: single join gives commands + branch info
-      type ToolRow = { arguments_json: string | null };
-      type BranchRow = { git_branch: string | null; end_ts: string | null };
-      const toolRows = db.prepare(
-        `SELECT tu.arguments_json FROM tool_uses tu
-         JOIN sessions s ON tu.session_id = s.session_id
-         WHERE s.project_slug = ? AND tu.tool_name IN ('Bash', 'PowerShell')`
-      ).all(slug) as ToolRow[];
-      const branchRows = db.prepare(
-        `SELECT DISTINCT git_branch, end_ts FROM sessions WHERE project_slug = ?`
-      ).all(slug) as BranchRow[];
+      try {
+        // DB path: single join gives commands + branch info
+        type ToolRow = { arguments_json: string | null };
+        type BranchRow = { git_branch: string | null; end_ts: string | null };
+        const toolRows = db.prepare(
+          `SELECT tu.arguments_json FROM tool_uses tu
+           JOIN sessions s ON tu.session_id = s.session_id
+           WHERE s.project_slug = ? AND tu.tool_name IN ('Bash', 'PowerShell')`
+        ).all(slug) as ToolRow[];
+        const branchRows = db.prepare(
+          `SELECT git_branch, end_ts FROM sessions WHERE project_slug = ?`
+        ).all(slug) as BranchRow[];
 
-      const toolCommands = toolRows.map((r) => {
-        try { return { command: (JSON.parse(r.arguments_json ?? "{}") as Record<string, unknown>)?.command as string ?? "" }; }
-        catch { return { command: "" }; }
-      });
-      const sessionBranches = branchRows.map((r) => ({
-        branch: r.git_branch,
-        lastActivity: r.end_ts ?? "",
-      }));
-      activity = aggregateGitActivity(toolCommands, sessionBranches);
-    } else {
+        const toolCommands = toolRows.map((r) => {
+          try { return { command: (JSON.parse(r.arguments_json ?? "{}") as Record<string, unknown>)?.command as string ?? "" }; }
+          catch { return { command: "" }; }
+        });
+        const sessionBranches = branchRows.map((r) => ({
+          branch: r.git_branch,
+          lastActivity: r.end_ts ?? "",
+        }));
+        activity = aggregateGitActivity(toolCommands, sessionBranches);
+      } catch {
+        // DB schema not ready — fall through to file-parse
+      }
+    }
+
+    if (!activity) {
       // File-parse fallback: commands only; branch list omitted (no gitBranch on UsageTurn)
       const sessionMap = await parseAllSessions();
       const projectTurns = gatherProjectTurns(sessionMap, slug, project.path);

--- a/src/app/api/projects/[slug]/git-activity/route.ts
+++ b/src/app/api/projects/[slug]/git-activity/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db/connection";
+import { aggregateGitActivity, type GitActivitySummary } from "@/lib/usage/gitActivity";
+import { parseAllSessions, getJsonlMaxMtime } from "@/lib/usage/parser";
+import { gatherProjectTurns } from "@/lib/usage/projectMatch";
+import { scanAllProjects } from "@/lib/scanner";
+import { getCachedScan, setCachedScan } from "@/lib/cache";
+
+interface GitActivityResponse {
+  slug: string;
+  activity: GitActivitySummary;
+  generatedAt: string;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheSlot {
+  data: GitActivityResponse;
+  cachedAt: number;
+  jsonlMtime: number;
+}
+
+const globalForGitActivity = globalThis as unknown as {
+  __gitActivityCache?: Map<string, CacheSlot>;
+};
+
+function getCache(): Map<string, CacheSlot> {
+  if (!globalForGitActivity.__gitActivityCache) {
+    globalForGitActivity.__gitActivityCache = new Map();
+  }
+  return globalForGitActivity.__gitActivityCache;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  try {
+    const cache = getCache();
+    const cached = cache.get(slug);
+    const currentMtime = getJsonlMaxMtime();
+    if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS && cached.jsonlMtime === currentMtime) {
+      return NextResponse.json(cached.data);
+    }
+
+    let scan = getCachedScan();
+    if (!scan) {
+      scan = await scanAllProjects();
+      setCachedScan(scan);
+    }
+    const project = scan.projects.find((p) => p.slug === slug);
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    let activity: GitActivitySummary;
+
+    const db = await getDb();
+    if (db) {
+      // DB path: single join gives commands + branch info
+      type ToolRow = { arguments_json: string | null };
+      type BranchRow = { git_branch: string | null; end_ts: string | null };
+      const toolRows = db.prepare(
+        `SELECT tu.arguments_json FROM tool_uses tu
+         JOIN sessions s ON tu.session_id = s.session_id
+         WHERE s.project_slug = ? AND tu.tool_name IN ('Bash', 'PowerShell')`
+      ).all(slug) as ToolRow[];
+      const branchRows = db.prepare(
+        `SELECT DISTINCT git_branch, end_ts FROM sessions WHERE project_slug = ?`
+      ).all(slug) as BranchRow[];
+
+      const toolCommands = toolRows.map((r) => {
+        try { return { command: (JSON.parse(r.arguments_json ?? "{}") as Record<string, unknown>)?.command as string ?? "" }; }
+        catch { return { command: "" }; }
+      });
+      const sessionBranches = branchRows.map((r) => ({
+        branch: r.git_branch,
+        lastActivity: r.end_ts ?? "",
+      }));
+      activity = aggregateGitActivity(toolCommands, sessionBranches);
+    } else {
+      // File-parse fallback: commands only; branch list omitted (no gitBranch on UsageTurn)
+      const sessionMap = await parseAllSessions();
+      const projectTurns = gatherProjectTurns(sessionMap, slug, project.path);
+      const toolCommands = projectTurns.flatMap((t) =>
+        t.toolCalls
+          .filter((tc) => tc.name === "Bash" || tc.name === "PowerShell")
+          .map((tc) => ({
+            command: (tc.arguments?.command as string | undefined) ??
+                     (tc.arguments?.script as string | undefined) ?? "",
+          }))
+      );
+      activity = aggregateGitActivity(toolCommands, []);
+    }
+
+    const data: GitActivityResponse = { slug, activity, generatedAt: new Date().toISOString() };
+    cache.set(slug, { data, cachedAt: Date.now(), jsonlMtime: currentMtime });
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error(`[git-activity] Error processing slug="${slug}":`, err);
+    return NextResponse.json({ error: "Failed to compute git activity." }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/[sessionId]/quality/route.ts
+++ b/src/app/api/sessions/[sessionId]/quality/route.ts
@@ -54,5 +54,19 @@ export async function GET(
     compactBoundaries: meta.compactBoundaries,
     cliVersion: meta.cliVersion,
   });
-  return NextResponse.json(report);
+
+  const toolErrorsByCategory: Record<string, number> = {};
+  for (const turn of turns) {
+    for (const tc of turn.toolCalls) {
+      if (tc.isError && tc.errorCategory) {
+        toolErrorsByCategory[tc.errorCategory] = (toolErrorsByCategory[tc.errorCategory] ?? 0) + 1;
+      }
+    }
+  }
+
+  return NextResponse.json(
+    Object.keys(toolErrorsByCategory).length > 0
+      ? { ...report, toolErrorsByCategory }
+      : report
+  );
 }

--- a/src/app/api/sessions/[sessionId]/quality/route.ts
+++ b/src/app/api/sessions/[sessionId]/quality/route.ts
@@ -64,9 +64,8 @@ export async function GET(
     }
   }
 
-  return NextResponse.json(
-    Object.keys(toolErrorsByCategory).length > 0
-      ? { ...report, toolErrorsByCategory }
-      : report
-  );
+  if (Object.keys(toolErrorsByCategory).length > 0) {
+    report.toolErrorsByCategory = toolErrorsByCategory;
+  }
+  return NextResponse.json(report);
 }

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -152,28 +152,33 @@ export async function GET(request: NextRequest) {
   }
 
   // Augment with invocation-source breakdown from DB when available.
-  const db = await getDb();
-  if (db) {
-    type InvRow = { skill_name: string; invocation_source: string; cnt: number };
-    const invRows = db.prepare(
-      `SELECT skill_name, invocation_source, COUNT(*) AS cnt
-       FROM tool_uses WHERE tool_name = 'Skill' AND skill_name IS NOT NULL
-       GROUP BY skill_name, invocation_source`
-    ).all() as InvRow[];
-    const slashMap = new Map<string, number>();
-    const autoMap = new Map<string, number>();
-    for (const r of invRows) {
-      if (r.invocation_source === "slash_command") slashMap.set(r.skill_name, (slashMap.get(r.skill_name) ?? 0) + r.cnt);
-      else autoMap.set(r.skill_name, (autoMap.get(r.skill_name) ?? 0) + r.cnt);
+  try {
+    const db = await getDb();
+    if (db) {
+      type InvRow = { skill_name: string; invocation_source: string; cnt: number };
+      const invRows = db.prepare(
+        `SELECT skill_name, invocation_source, COUNT(*) AS cnt
+         FROM tool_uses WHERE tool_name = 'Skill' AND skill_name IS NOT NULL
+         AND invocation_source IS NOT NULL
+         GROUP BY skill_name, invocation_source`
+      ).all() as InvRow[];
+      const slashMap = new Map<string, number>();
+      const autoMap = new Map<string, number>();
+      for (const r of invRows) {
+        if (r.invocation_source === "slash_command") slashMap.set(r.skill_name, (slashMap.get(r.skill_name) ?? 0) + r.cnt);
+        else autoMap.set(r.skill_name, (autoMap.get(r.skill_name) ?? 0) + r.cnt);
+      }
+      result = result.map((r) => {
+        const name = r.entry?.name ?? r.usage?.name;
+        if (!name) return r;
+        const slash = slashMap.get(name) ?? 0;
+        const auto = autoMap.get(name) ?? 0;
+        if (slash === 0 && auto === 0) return r;
+        return { ...r, slashCount: slash, autoCount: auto };
+      });
     }
-    result = result.map((r) => {
-      const name = r.entry?.name ?? r.usage?.name;
-      if (!name) return r;
-      const slash = slashMap.get(name) ?? 0;
-      const auto = autoMap.get(name) ?? 0;
-      if (slash === 0 && auto === 0) return r;
-      return { ...r, slashCount: slash, autoCount: auto };
-    });
+  } catch {
+    // DB schema not ready (e.g. empty/new DB) — skip invocation-source augmentation
   }
 
   setRouteCache(cacheKey, result, skillUsage.meta.backend);

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -6,6 +6,7 @@ import { getCachedScan } from "@/lib/cache";
 import { pathToUsageSlug } from "@/lib/usage/slug";
 import { skillUpdateCache } from "@/lib/skillUpdateCache";
 import { jsonWithCacheControl } from "@/lib/httpCache";
+import { getDb } from "@/lib/db/connection";
 import type { QueueItem } from "@/lib/skillUpdateCache";
 import type { SkillStats } from "@/lib/usage/types";
 import type { SkillEntry } from "@/lib/indexer/types";
@@ -16,6 +17,8 @@ interface SkillRow {
   entry?: SkillEntry;
   usage?: SkillStats;
   catalogMissing?: boolean;
+  slashCount?: number;
+  autoCount?: number;
 }
 
 interface CacheSlot {
@@ -145,6 +148,31 @@ export async function GET(request: NextRequest) {
         .join(" ")
         .toLowerCase();
       return text.includes(query);
+    });
+  }
+
+  // Augment with invocation-source breakdown from DB when available.
+  const db = await getDb();
+  if (db) {
+    type InvRow = { skill_name: string; invocation_source: string; cnt: number };
+    const invRows = db.prepare(
+      `SELECT skill_name, invocation_source, COUNT(*) AS cnt
+       FROM tool_uses WHERE tool_name = 'Skill' AND skill_name IS NOT NULL
+       GROUP BY skill_name, invocation_source`
+    ).all() as InvRow[];
+    const slashMap = new Map<string, number>();
+    const autoMap = new Map<string, number>();
+    for (const r of invRows) {
+      if (r.invocation_source === "slash_command") slashMap.set(r.skill_name, (slashMap.get(r.skill_name) ?? 0) + r.cnt);
+      else autoMap.set(r.skill_name, (autoMap.get(r.skill_name) ?? 0) + r.cnt);
+    }
+    result = result.map((r) => {
+      const name = r.entry?.name ?? r.usage?.name;
+      if (!name) return r;
+      const slash = slashMap.get(name) ?? 0;
+      const auto = autoMap.get(name) ?? 0;
+      if (slash === 0 && auto === 0) return r;
+      return { ...r, slashCount: slash, autoCount: auto };
     });
   }
 

--- a/src/components/DiagnosisPanel.tsx
+++ b/src/components/DiagnosisPanel.tsx
@@ -219,7 +219,7 @@ function HeaderStat({
 // ── Main panel ────────────────────────────────────────────────────────────────
 
 export function DiagnosisPanel({ sessionId }: { sessionId: string }) {
-  const [report, setReport] = useState<DiagnosisReport | null>(null);
+  const [report, setReport] = useState<(DiagnosisReport & { toolErrorsByCategory?: Record<string, number> }) | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -251,7 +251,7 @@ export function DiagnosisPanel({ sessionId }: { sessionId: string }) {
           setLoading(false);
           return;
         }
-        const data = (await res.json()) as DiagnosisReport;
+        const data = (await res.json()) as DiagnosisReport & { toolErrorsByCategory?: Record<string, number> };
         if (cancelled) return;
         setReport(data);
         setLoading(false);
@@ -437,6 +437,40 @@ export function DiagnosisPanel({ sessionId }: { sessionId: string }) {
           report.findings.map((f) => <FindingCard key={f.category} finding={f} />)
         )}
       </div>
+
+      {/* ── Tool errors by category ──────────────────────────────────────── */}
+      {report.toolErrorsByCategory && Object.keys(report.toolErrorsByCategory).length > 0 && (
+        <div>
+          <div
+            style={{
+              fontSize: "0.68rem", fontWeight: 600, color: "var(--text-muted)",
+              textTransform: "uppercase", letterSpacing: "0.06em",
+              fontFamily: "var(--font-body)", marginBottom: "8px",
+            }}
+          >
+            Tool errors by category
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+            {Object.entries(report.toolErrorsByCategory)
+              .sort((a, b) => b[1] - a[1])
+              .map(([cat, count]) => (
+                <div
+                  key={cat}
+                  style={{
+                    display: "inline-flex", alignItems: "center", gap: "6px",
+                    padding: "4px 10px",
+                    background: "var(--status-error-bg)",
+                    border: "1px solid var(--status-error-border)",
+                    borderRadius: "var(--radius)",
+                  }}
+                >
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--status-error-text)", fontWeight: 600 }}>{count}×</span>
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--text-secondary)" }}>{cat}</span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/DiagnosisPanel.tsx
+++ b/src/components/DiagnosisPanel.tsx
@@ -219,7 +219,7 @@ function HeaderStat({
 // ── Main panel ────────────────────────────────────────────────────────────────
 
 export function DiagnosisPanel({ sessionId }: { sessionId: string }) {
-  const [report, setReport] = useState<(DiagnosisReport & { toolErrorsByCategory?: Record<string, number> }) | null>(null);
+  const [report, setReport] = useState<DiagnosisReport | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -251,7 +251,7 @@ export function DiagnosisPanel({ sessionId }: { sessionId: string }) {
           setLoading(false);
           return;
         }
-        const data = (await res.json()) as DiagnosisReport & { toolErrorsByCategory?: Record<string, number> };
+        const data = (await res.json()) as DiagnosisReport;
         if (cancelled) return;
         setReport(data);
         setLoading(false);

--- a/src/components/EfficiencyTab.tsx
+++ b/src/components/EfficiencyTab.tsx
@@ -10,20 +10,13 @@ import type {
   WasteGrade,
 } from "@/lib/scanner/wasteOptimizer";
 import type { YieldResult, YieldOutcome } from "@/lib/usage/yieldAnalysis";
-
-
-interface WorkModeDistribution {
-  exploration: number;
-  building: number;
-  testing: number;
-  other: number;
-}
+import { WORK_MODE_DISPLAY, workModeToSegments, type WorkMode, type WorkModeBreakdown } from "@/lib/usage/workMode";
 
 interface EfficiencyResponse {
   slug: string;
   waste: WasteOptimizerInfo;
   yieldReport: YieldResult;
-  workMode?: WorkModeDistribution;
+  workMode?: WorkModeBreakdown;
   generatedAt: string;
 }
 
@@ -350,35 +343,24 @@ export function EfficiencyTab({ slug }: EfficiencyTabProps) {
           </div>
 
           <div style={{ marginBottom: "10px" }}>
-            <StackedStrip
-              height={8}
-              title="Work-mode distribution across project sessions"
-              segments={[
-                { key: "exploration", pct: workMode.exploration, color: "var(--status-active-text)", label: `Exploration ${workMode.exploration}%` },
-                { key: "building",    pct: workMode.building,    color: "var(--accent)",             label: `Building ${workMode.building}%` },
-                { key: "testing",     pct: workMode.testing,     color: "var(--status-error-text)",  label: `Testing ${workMode.testing}%` },
-                { key: "other",       pct: workMode.other,       color: "var(--border-default)",     label: `Other ${workMode.other}%` },
-              ]}
-            />
+            <StackedStrip height={8} title="Work-mode distribution across project sessions" segments={workModeToSegments(workMode)} />
           </div>
 
           <div style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
-            {[
-              { key: "exploration", label: "Exploration", pct: workMode.exploration, color: "var(--status-active-text)" },
-              { key: "building",    label: "Building",    pct: workMode.building,    color: "var(--accent)" },
-              { key: "testing",     label: "Testing",     pct: workMode.testing,     color: "var(--status-error-text)" },
-              { key: "other",       label: "Other",       pct: workMode.other,       color: "var(--border-default)" },
-            ].filter((m) => m.pct > 0).map((m) => (
-              <div key={m.key} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-                <div style={{ width: "8px", height: "8px", borderRadius: "2px", background: m.color, flexShrink: 0 }} />
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-secondary)" }}>
-                  {m.label}
-                </span>
-                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", fontWeight: 600, color: "var(--text-primary)" }}>
-                  {m.pct}%
-                </span>
-              </div>
-            ))}
+            {workModeToSegments(workMode).filter((m) => m.pct > 0).map((m) => {
+              const display = WORK_MODE_DISPLAY[m.key as WorkMode];
+              return (
+                <div key={m.key} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                  <div style={{ width: "8px", height: "8px", borderRadius: "2px", background: m.color, flexShrink: 0 }} />
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-secondary)" }}>
+                    {display.label}
+                  </span>
+                  <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", fontWeight: 600, color: "var(--text-primary)" }}>
+                    {m.pct}%
+                  </span>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/components/EfficiencyTab.tsx
+++ b/src/components/EfficiencyTab.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { AlertOctagon, AlertTriangle, Info, Activity } from "lucide-react";
+import { StackedStrip } from "@/components/stats/StackedStrip";
 import type {
   WasteOptimizerInfo,
   WasteFinding,
@@ -11,10 +12,18 @@ import type {
 import type { YieldResult, YieldOutcome } from "@/lib/usage/yieldAnalysis";
 
 
+interface WorkModeDistribution {
+  exploration: number;
+  building: number;
+  testing: number;
+  other: number;
+}
+
 interface EfficiencyResponse {
   slug: string;
   waste: WasteOptimizerInfo;
   yieldReport: YieldResult;
+  workMode?: WorkModeDistribution;
   generatedAt: string;
 }
 
@@ -222,7 +231,7 @@ export function EfficiencyTab({ slug }: EfficiencyTabProps) {
   }
   if (!data) return null;
 
-  const { waste, yieldReport } = data;
+  const { waste, yieldReport, workMode } = data;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
@@ -325,6 +334,54 @@ export function EfficiencyTab({ slug }: EfficiencyTabProps) {
           </>
         )}
       </div>
+
+      {/* ── By Work Mode ───────────────────────────────────────────── */}
+      {workMode && (workMode.exploration + workMode.building + workMode.testing + workMode.other) > 0 && (
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "12px" }}>
+            <span style={{
+              fontSize: "0.6rem", fontWeight: 700, letterSpacing: "0.1em",
+              textTransform: "uppercase", color: "var(--text-muted)",
+              fontFamily: "var(--font-body)",
+            }}>
+              By Work Mode
+            </span>
+            <div style={{ flex: 1, height: "1px", background: "var(--border-subtle)" }} />
+          </div>
+
+          <div style={{ marginBottom: "10px" }}>
+            <StackedStrip
+              height={8}
+              title="Work-mode distribution across project sessions"
+              segments={[
+                { key: "exploration", pct: workMode.exploration, color: "var(--status-active-text)", label: `Exploration ${workMode.exploration}%` },
+                { key: "building",    pct: workMode.building,    color: "var(--accent)",             label: `Building ${workMode.building}%` },
+                { key: "testing",     pct: workMode.testing,     color: "var(--status-error-text)",  label: `Testing ${workMode.testing}%` },
+                { key: "other",       pct: workMode.other,       color: "var(--border-default)",     label: `Other ${workMode.other}%` },
+              ]}
+            />
+          </div>
+
+          <div style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
+            {[
+              { key: "exploration", label: "Exploration", pct: workMode.exploration, color: "var(--status-active-text)" },
+              { key: "building",    label: "Building",    pct: workMode.building,    color: "var(--accent)" },
+              { key: "testing",     label: "Testing",     pct: workMode.testing,     color: "var(--status-error-text)" },
+              { key: "other",       label: "Other",       pct: workMode.other,       color: "var(--border-default)" },
+            ].filter((m) => m.pct > 0).map((m) => (
+              <div key={m.key} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                <div style={{ width: "8px", height: "8px", borderRadius: "2px", background: m.color, flexShrink: 0 }} />
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--text-secondary)" }}>
+                  {m.label}
+                </span>
+                <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", fontWeight: 600, color: "var(--text-primary)" }}>
+                  {m.pct}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -21,6 +21,7 @@ import { ClaudeMdAuditPanel } from "./ClaudeMdAuditPanel";
 import { ContextBudgetPanel } from "./ContextBudgetPanel";
 import { EfficiencyTab } from "./EfficiencyTab";
 import { HotFilesPanel } from "./HotFilesPanel";
+import { GitActivityPanel } from "./projects/GitActivityPanel";
 import dynamic from "next/dynamic";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -386,6 +387,9 @@ export function ProjectDetail({ project, onStatusChange }: ProjectDetailProps) {
                   </div>
                 </div>
               )}
+
+              {/* Git Activity (Claude-driven commits/pushes per branch) */}
+              <GitActivityPanel slug={project.slug} />
 
               {/* Infrastructure: ports + database + services */}
               {(devPort || project.dbPort || project.dockerPorts.length > 0 || project.database || project.externalServices.length > 0) && (

--- a/src/components/SessionTimeline.tsx
+++ b/src/components/SessionTimeline.tsx
@@ -4,6 +4,7 @@ import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { TimelineEvent } from "@/lib/types";
 import { User, Bot, Wrench, Brain, AlertCircle, ChevronDown, ChevronRight } from "lucide-react";
 import { parseMarkdown, hasCodeFence } from "@/lib/markdown";
+import { formatToolArgs } from "@/lib/usage/toolArgFormatter";
 
 type EventType = TimelineEvent["type"];
 
@@ -195,6 +196,7 @@ function TimelineItem({ event, sessionStart, sessionId }: {
   sessionId?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const [toolExpanded, setToolExpanded] = useState(false);
   const cfg = EVENT_CONFIG[event.type];
   const Icon = cfg.icon;
   // Expand threshold: code-heavy content warrants more space before truncation.
@@ -267,6 +269,26 @@ function TimelineItem({ event, sessionStart, sessionId }: {
                   ? <><ChevronDown style={{ width: "10px", height: "10px" }} /> less</>
                   : <><ChevronRight style={{ width: "10px", height: "10px" }} /> more</>}
               </button>
+            )}
+            {event.type === "tool_use" && event.toolInput && (
+              <>
+                <button
+                  onClick={() => setToolExpanded(!toolExpanded)}
+                  style={{ display: "inline-flex", alignItems: "center", gap: "3px", background: "none", border: "none", padding: 0, fontSize: "0.68rem", color: "var(--text-muted)", cursor: "pointer", width: "fit-content" }}
+                >
+                  {toolExpanded
+                    ? <><ChevronDown style={{ width: "10px", height: "10px" }} /> hide args</>
+                    : <><ChevronRight style={{ width: "10px", height: "10px" }} /> show args</>}
+                </button>
+                {toolExpanded && (() => {
+                  const formatted = formatToolArgs(event.toolName ?? "", event.toolInput!);
+                  return (
+                    <pre style={{ margin: "4px 0 0", fontSize: "0.72rem", fontFamily: "var(--font-mono)", whiteSpace: "pre-wrap", wordBreak: "break-all", color: "var(--text-secondary)", background: "var(--bg-surface)", borderRadius: "3px", padding: "6px 8px", lineHeight: 1.5 }}>
+                      {formatted.content || formatted.preview}
+                    </pre>
+                  );
+                })()}
+              </>
             )}
           </>
         )}

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -26,6 +26,7 @@ import { StatusDot } from "./ui/StatusDot";
 import { FILE_OP_BY_TOOL, isFileWriteOp } from "@/lib/usage/toolNames";
 import { formatCost } from "@/lib/format";
 import { useCurrency } from "@/hooks/useCurrency";
+import { StackedStrip } from "@/components/stats/StackedStrip";
 
 type SortOption = "recent" | "longest" | "tokens" | "oneshot";
 
@@ -476,6 +477,21 @@ function SessionRow({
               {m}
             </span>
           ))}
+          {session.workMode && (
+            <div style={{ marginLeft: "auto", flexShrink: 0 }}>
+              <StackedStrip
+                width={64}
+                height={5}
+                title="Work-mode breakdown"
+                segments={[
+                  { key: "exploration", pct: session.workMode.exploration, color: "var(--status-active-text)", label: `Exploration ${session.workMode.exploration}%` },
+                  { key: "building",    pct: session.workMode.building,    color: "var(--accent)",             label: `Building ${session.workMode.building}%` },
+                  { key: "testing",     pct: session.workMode.testing,     color: "var(--status-error-text)",  label: `Testing ${session.workMode.testing}%` },
+                  { key: "other",       pct: session.workMode.other,       color: "var(--border-default)",     label: `Other ${session.workMode.other}%` },
+                ]}
+              />
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -27,7 +27,6 @@ import { FILE_OP_BY_TOOL, isFileWriteOp } from "@/lib/usage/toolNames";
 import { formatCost, formatTokens } from "@/lib/format";
 import { useCurrency } from "@/hooks/useCurrency";
 import { StackedStrip } from "@/components/stats/StackedStrip";
-import { isWorktreeEncodedDir } from "@/lib/scanner/worktreeCheck";
 import { WORK_MODE_SEGMENTS } from "@/lib/usage/workMode";
 
 type SortOption = "recent" | "longest" | "tokens" | "oneshot";
@@ -340,7 +339,7 @@ function SessionRow({
               recap
             </span>
           )}
-          {isWorktreeEncodedDir(session.projectName) && session.gitBranch && (
+          {session.isWorktree && session.gitBranch && (
             <QualityChip tone="neutral" title={`Worktree session — branch: ${session.gitBranch}`}>
               {session.gitBranch}
             </QualityChip>

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -343,6 +343,11 @@ function SessionRow({
               recap
             </span>
           )}
+          {isWorktreeEncodedDir(session.projectName) && session.gitBranch && (
+            <QualityChip tone="neutral" title={`Worktree session — branch: ${session.gitBranch}`}>
+              {session.gitBranch}
+            </QualityChip>
+          )}
           <span
             style={{
               flex: 1,
@@ -491,16 +496,28 @@ interface ProjectGroup {
   avgOneShotRate?: number;
 }
 
+function isWorktreeEncodedDir(dirName: string): boolean {
+  const searchFrom = /^[A-Za-z]--/.test(dirName) ? 2 : 0;
+  let pos = searchFrom;
+  while (pos < dirName.length) {
+    const idx = dirName.indexOf("--", pos);
+    if (idx === -1) break;
+    if (/^(?:[a-z]+-)?worktrees-/.test(dirName.slice(idx + 2))) return true;
+    pos = idx + 2;
+  }
+  return false;
+}
+
 function buildProjectGroups(sessions: SessionSummary[]): ProjectGroup[] {
   const map = new Map<string, SessionSummary[]>();
   for (const s of sessions) {
-    const list = map.get(s.projectPath) ?? [];
+    const list = map.get(s.projectSlug) ?? [];
     list.push(s);
-    map.set(s.projectPath, list);
+    map.set(s.projectSlug, list);
   }
 
   const groups: ProjectGroup[] = [];
-  for (const [projectPath, projectSessions] of map) {
+  for (const [projectSlug, projectSessions] of map) {
     let totalTokens = 0, totalCost = 0, totalDurationMs = 0, activeSessions = 0;
     let lastActivity: string | undefined;
     const oneShotRates: number[] = [];
@@ -515,9 +532,9 @@ function buildProjectGroups(sessions: SessionSummary[]): ProjectGroup[] {
     }
 
     groups.push({
-      projectPath,
+      projectPath: projectSessions[0].projectPath,
       projectName: projectSessions[0].projectName,
-      projectSlug: projectSessions[0].projectSlug,
+      projectSlug,
       sessions: projectSessions,
       totalTokens,
       totalCost,
@@ -732,7 +749,7 @@ export function SessionsBrowser() {
     });
   };
 
-  const allCollapsed = projectGroups.length > 0 && projectGroups.every((g) => collapsedSlugs.has(g.projectPath));
+  const allCollapsed = projectGroups.length > 0 && projectGroups.every((g) => collapsedSlugs.has(g.projectSlug));
 
   // Flatten the (possibly grouped) tree into a single positional array so one
   // virtualizer can drive both render modes. Recomputes only when the inputs
@@ -743,7 +760,7 @@ export function SessionsBrowser() {
     }
     const items: FlatItem[] = [];
     for (const group of projectGroups) {
-      const collapsed = collapsedSlugs.has(group.projectPath);
+      const collapsed = collapsedSlugs.has(group.projectSlug);
       items.push({ kind: "header", group, collapsed });
       if (!collapsed) {
         for (const session of group.sessions) {
@@ -861,7 +878,7 @@ export function SessionsBrowser() {
         {/* Collapse all */}
         {groupByProject && projectGroups.length > 1 && (
           <button
-            onClick={() => allCollapsed ? setCollapsedSlugs(new Set()) : setCollapsedSlugs(new Set(projectGroups.map((g) => g.projectPath)))}
+            onClick={() => allCollapsed ? setCollapsedSlugs(new Set()) : setCollapsedSlugs(new Set(projectGroups.map((g) => g.projectSlug)))}
             style={{ padding: "5px 11px", fontSize: "0.72rem", fontFamily: "var(--font-body)", letterSpacing: "0.03em", color: "var(--text-secondary)", background: "var(--bg-surface)", border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)", cursor: "pointer", lineHeight: 1, flexShrink: 0 }}
           >
             {allCollapsed ? "Expand all" : "Collapse all"}
@@ -932,7 +949,7 @@ export function SessionsBrowser() {
                     <SectionHeader
                       group={item.group}
                       collapsed={item.collapsed}
-                      onToggle={() => toggleCollapse(item.group.projectPath)}
+                      onToggle={() => toggleCollapse(item.group.projectSlug)}
                     />
                   ) : (
                     <SessionRow session={item.session} showProject={item.showProject} search={search} />

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -24,9 +24,11 @@ import {
 import Link from "next/link";
 import { StatusDot } from "./ui/StatusDot";
 import { FILE_OP_BY_TOOL, isFileWriteOp } from "@/lib/usage/toolNames";
-import { formatCost } from "@/lib/format";
+import { formatCost, formatTokens } from "@/lib/format";
 import { useCurrency } from "@/hooks/useCurrency";
 import { StackedStrip } from "@/components/stats/StackedStrip";
+import { isWorktreeEncodedDir } from "@/lib/scanner/worktreeCheck";
+import { WORK_MODE_SEGMENTS } from "@/lib/usage/workMode";
 
 type SortOption = "recent" | "longest" | "tokens" | "oneshot";
 
@@ -37,12 +39,6 @@ function formatDuration(ms?: number): string {
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m`;
   return `${Math.floor(m / 60)}h ${m % 60}m`;
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
 }
 
 function formatDate(iso?: string): string {
@@ -479,17 +475,7 @@ function SessionRow({
           ))}
           {session.workMode && (
             <div style={{ marginLeft: "auto", flexShrink: 0 }}>
-              <StackedStrip
-                width={64}
-                height={5}
-                title="Work-mode breakdown"
-                segments={[
-                  { key: "exploration", pct: session.workMode.exploration, color: "var(--status-active-text)", label: `Exploration ${session.workMode.exploration}%` },
-                  { key: "building",    pct: session.workMode.building,    color: "var(--accent)",             label: `Building ${session.workMode.building}%` },
-                  { key: "testing",     pct: session.workMode.testing,     color: "var(--status-error-text)",  label: `Testing ${session.workMode.testing}%` },
-                  { key: "other",       pct: session.workMode.other,       color: "var(--border-default)",     label: `Other ${session.workMode.other}%` },
-                ]}
-              />
+              <StackedStrip width={64} height={5} title="Work-mode breakdown" segments={WORK_MODE_SEGMENTS(session.workMode)} />
             </div>
           )}
         </div>
@@ -510,18 +496,6 @@ interface ProjectGroup {
   activeSessions: number;
   lastActivity?: string;
   avgOneShotRate?: number;
-}
-
-function isWorktreeEncodedDir(dirName: string): boolean {
-  const searchFrom = /^[A-Za-z]--/.test(dirName) ? 2 : 0;
-  let pos = searchFrom;
-  while (pos < dirName.length) {
-    const idx = dirName.indexOf("--", pos);
-    if (idx === -1) break;
-    if (/^(?:[a-z]+-)?worktrees-/.test(dirName.slice(idx + 2))) return true;
-    pos = idx + 2;
-  }
-  return false;
 }
 
 function buildProjectGroups(sessions: SessionSummary[]): ProjectGroup[] {

--- a/src/components/SkillsBrowser.tsx
+++ b/src/components/SkillsBrowser.tsx
@@ -206,6 +206,17 @@ function SkillRowItem({
               {row.usage.invocations}×
             </span>
           )}
+          {(row.slashCount ?? 0) + (row.autoCount ?? 0) > 0 && (
+            <span
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.6rem",
+                color: "var(--text-muted)",
+              }}
+            >
+              {row.slashCount ?? 0} slash · {row.autoCount ?? 0} auto
+            </span>
+          )}
           {row.usage?.lastUsed && (
             <span
               style={{

--- a/src/components/projects/GitActivityPanel.tsx
+++ b/src/components/projects/GitActivityPanel.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GitCommit, GitBranch, UploadCloud } from "lucide-react";
+import type { GitActivitySummary } from "@/lib/usage/gitActivity";
+
+interface GitActivityResponse {
+  slug: string;
+  activity: GitActivitySummary;
+}
+
+function StatBox({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: number;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        padding: "10px 14px",
+        background: "var(--bg-surface)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "var(--radius)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "5px", marginBottom: "5px" }}>
+        {icon}
+        <span
+          style={{
+            fontSize: "0.62rem",
+            fontWeight: 600,
+            color: "var(--text-muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            fontFamily: "var(--font-body)",
+          }}
+        >
+          {label}
+        </span>
+      </div>
+      <span
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "1.3rem",
+          fontWeight: 600,
+          color: "var(--text-primary)",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function GitActivityPanel({ slug }: { slug: string }) {
+  const [data, setData] = useState<GitActivityResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/projects/${slug}/git-activity`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: GitActivityResponse | null) => { setData(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [slug]);
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          height: "80px",
+          background: "var(--bg-surface)",
+          borderRadius: "var(--radius)",
+          animation: "pulse 1.5s ease-in-out infinite",
+        }}
+      />
+    );
+  }
+  if (!data) return null;
+  const { commits, pushes, branches } = data.activity;
+  if (commits === 0 && pushes === 0 && branches.length === 0) return null;
+
+  return (
+    <div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "6px",
+          marginBottom: "10px",
+        }}
+      >
+        <GitBranch style={{ width: "12px", height: "12px", color: "var(--text-muted)" }} />
+        <span
+          style={{
+            fontSize: "0.68rem",
+            fontWeight: 600,
+            color: "var(--text-muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            fontFamily: "var(--font-body)",
+          }}
+        >
+          Git Activity
+        </span>
+      </div>
+
+      <div style={{ display: "flex", gap: "10px", marginBottom: branches.length > 0 ? "12px" : "0" }}>
+        <StatBox
+          label="Commits"
+          value={commits}
+          icon={<GitCommit style={{ width: "11px", height: "11px", color: "var(--text-muted)" }} />}
+        />
+        <StatBox
+          label="Pushes"
+          value={pushes}
+          icon={<UploadCloud style={{ width: "11px", height: "11px", color: "var(--text-muted)" }} />}
+        />
+      </div>
+
+      {branches.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {branches.map((b) => (
+            <div
+              key={b.branch}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                padding: "5px 0",
+                borderBottom: "1px solid var(--border-subtle)",
+              }}
+            >
+              <GitBranch
+                style={{ width: "10px", height: "10px", color: "var(--text-muted)", flexShrink: 0 }}
+              />
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.75rem",
+                  color: "var(--text-primary)",
+                  flex: 1,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {b.branch}
+              </span>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.62rem",
+                  color: "var(--text-muted)",
+                  flexShrink: 0,
+                }}
+              >
+                {b.sessionCount} session{b.sessionCount !== 1 ? "s" : ""}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/stats/StackedStrip.tsx
+++ b/src/components/stats/StackedStrip.tsx
@@ -1,0 +1,70 @@
+export interface StripSegment {
+  key: string;
+  pct: number;
+  color: string;
+  label?: string;
+}
+
+interface StackedStripProps {
+  segments: StripSegment[];
+  height?: number;
+  /** Total SVG width in px. Fills container when omitted (100%). */
+  width?: number;
+  title?: string;
+}
+
+/**
+ * Horizontal stacked bar rendered as SVG. Each segment occupies `pct`% of the
+ * total width. Rounding is applied so segment widths are integer px and the
+ * total always fills the bar. A 0.5 px gap between segments provides visual
+ * separation without affecting the reported percentages.
+ */
+export function StackedStrip({ segments, height = 6, width, title }: StackedStripProps) {
+  const svgWidth = width ?? 80;
+  const gap = 0.5;
+
+  // Compute integer pixel widths that sum exactly to svgWidth.
+  // Largest-remainder algorithm avoids drift without a reduce-then-clamp hack.
+  const pctSum = segments.reduce((s, g) => s + g.pct, 0);
+  if (pctSum === 0) return null;
+
+  const exact = segments.map((g) => (g.pct / pctSum) * svgWidth);
+  const floored = exact.map(Math.floor);
+  const remainder = svgWidth - floored.reduce((s, w) => s + w, 0);
+  const fracs = exact.map((v, i) => ({ i, frac: v - Math.floor(v) }));
+  fracs.sort((a, b) => b.frac - a.frac);
+  for (let k = 0; k < remainder; k++) floored[fracs[k].i]++;
+
+  let x = 0;
+  const rects: React.ReactNode[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    const w = floored[i];
+    if (w <= 0) { x += w; continue; }
+    const g = i < segments.length - 1 ? gap : 0;
+    rects.push(
+      <rect
+        key={segments[i].key}
+        x={x}
+        y={0}
+        width={Math.max(0, w - g)}
+        height={height}
+        fill={segments[i].color}
+        rx={1}
+        ry={1}
+      >
+        {segments[i].label && <title>{segments[i].label}: {segments[i].pct.toFixed(0)}%</title>}
+      </rect>
+    );
+    x += w;
+  }
+
+  const svgProps = width
+    ? { width, height }
+    : { width: "100%", height, viewBox: `0 0 80 ${height}`, preserveAspectRatio: "none" as const };
+
+  return (
+    <svg {...svgProps} aria-label={title} style={{ display: "block", flexShrink: 0, borderRadius: "1px" }}>
+      {rects}
+    </svg>
+  );
+}

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -37,6 +37,8 @@ export interface SkillRow {
     sessions: string[];
   };
   catalogMissing?: boolean;
+  slashCount?: number;
+  autoCount?: number;
 }
 
 export function useSkills(source?: string, project?: string, query?: string) {

--- a/src/lib/data/sessionDetailFromDb.ts
+++ b/src/lib/data/sessionDetailFromDb.ts
@@ -332,11 +332,14 @@ function buildTimeline(turns: TurnRow[], toolsByTurn: Map<number, ToolRow[]>): T
     const toolList = toolsByTurn.get(turn.turn_index);
     if (!toolList) continue;
     for (const tu of toolList) {
+      const parsedArgs = parseStoredArgs(tu.arguments_json) ?? undefined;
       events.push({
         type: "tool_use",
         timestamp: tu.ts ?? turn.ts,
         content: summarizeTool(tu),
         toolName: tu.tool_name,
+        toolUseId: tu.tool_use_id ?? undefined,
+        toolInput: parsedArgs && Object.keys(parsedArgs).length > 0 ? parsedArgs : undefined,
       });
     }
   }

--- a/src/lib/data/sessionsListFromDb.ts
+++ b/src/lib/data/sessionsListFromDb.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type DatabaseT from "better-sqlite3";
 import { decodeDirName } from "@/lib/platform";
+import { canonicalizeDirName } from "@/lib/usage/parser";
 import { prepCached } from "@/lib/db/connection";
 import type { SessionSummary, SessionStatus } from "@/lib/types";
 
@@ -283,7 +284,7 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
 
     result.push({
       sessionId: h.session_id,
-      projectPath: decodeDirName(h.project_dir_name),
+      projectPath: decodeDirName(canonicalizeDirName(h.project_dir_name)),
       // `project_slug` is set at ingest via `toSlug(canonicalDir)` so
       // it should never be NULL on a healthy index. Schema permits NULL
       // though, so fall back to deriving the same slug on the fly

--- a/src/lib/data/sessionsListFromDb.ts
+++ b/src/lib/data/sessionsListFromDb.ts
@@ -131,6 +131,10 @@ interface SessionRow {
   starred_at: string | null;
   distilled_at: string | null;
   distilled_text: string | null;
+  work_mode_exploration_pct: number | null;
+  work_mode_building_pct: number | null;
+  work_mode_testing_pct: number | null;
+  work_mode_other_pct: number | null;
 }
 
 interface ToolCountRow {
@@ -184,7 +188,9 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
             git_branch, initial_prompt, last_prompt,
             slug, continued_from_session_id,
             has_thinking, cli_version, has_resume_anomaly, compact_boundary_count,
-            generated_title, starred_at, distilled_at, distilled_text
+            generated_title, starred_at, distilled_at, distilled_text,
+            work_mode_exploration_pct, work_mode_building_pct,
+            work_mode_testing_pct, work_mode_other_pct
      FROM sessions
      ORDER BY end_ts DESC`
   ).all() as SessionRow[];
@@ -327,6 +333,14 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
       starredAt: h.starred_at ?? undefined,
       distilledAt: h.distilled_at ?? undefined,
       distilledText: h.distilled_text ?? undefined,
+      workMode: (h.work_mode_exploration_pct !== null)
+        ? {
+            exploration: h.work_mode_exploration_pct!,
+            building: h.work_mode_building_pct!,
+            testing: h.work_mode_testing_pct!,
+            other: h.work_mode_other_pct!,
+          }
+        : undefined,
     });
   }
 

--- a/src/lib/data/sessionsListFromDb.ts
+++ b/src/lib/data/sessionsListFromDb.ts
@@ -4,6 +4,7 @@ import { decodeDirName } from "@/lib/platform";
 import { canonicalizeDirName } from "@/lib/usage/parser";
 import { prepCached } from "@/lib/db/connection";
 import type { SessionSummary, SessionStatus } from "@/lib/types";
+import { isWorktreeEncodedDir } from "@/lib/scanner/worktreeCheck";
 
 // SQL-backed list loader for `/api/sessions` and `/api/sessions/activity`.
 // Mirrors `scanAllSessions` (in `src/lib/scanner/claudeConversations.ts`)
@@ -334,14 +335,18 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
       starredAt: h.starred_at ?? undefined,
       distilledAt: h.distilled_at ?? undefined,
       distilledText: h.distilled_text ?? undefined,
-      workMode: (h.work_mode_exploration_pct !== null)
+      workMode: (h.work_mode_exploration_pct !== null &&
+                 h.work_mode_building_pct !== null &&
+                 h.work_mode_testing_pct !== null &&
+                 h.work_mode_other_pct !== null)
         ? {
-            exploration: h.work_mode_exploration_pct!,
-            building: h.work_mode_building_pct!,
-            testing: h.work_mode_testing_pct!,
-            other: h.work_mode_other_pct!,
+            exploration: h.work_mode_exploration_pct,
+            building: h.work_mode_building_pct,
+            testing: h.work_mode_testing_pct,
+            other: h.work_mode_other_pct,
           }
         : undefined,
+      isWorktree: isWorktreeEncodedDir(h.project_dir_name),
     });
   }
 

--- a/src/lib/db/derivationVersion.ts
+++ b/src/lib/db/derivationVersion.ts
@@ -14,7 +14,7 @@
 //   files skip re-parse and the new columns stay NULL on the existing
 //   corpus indefinitely (only newly-modified files would populate them).
 // - Don't bump for FTS5 trigger changes (those rebuild on insert/update).
-export const DERIVED_VERSION = 6;
+export const DERIVED_VERSION = 7;
 // History:
 // 1 — initial.
 // 2 — added `tool_result_preview` storage so `detectOneShot` rehydrates
@@ -54,3 +54,11 @@ export const DERIVED_VERSION = 6;
 //     get the new fields. No read-side gate needed — missing values
 //     degrade to "thinking content unavailable" / no duration badge,
 //     both of which are explicit non-silent UX states.
+// 7 — Wave 8.3 added `tool_uses.{is_error (was always 0), error_category,
+//     invocation_source}` and `sessions.{work_mode_*_pct}`. All four
+//     work-mode columns are derived from turns.category at session
+//     finalization; error fields require re-reading tool_result blocks
+//     in user turns. Bumping forces a full re-parse so these are
+//     populated across the existing corpus. No read-side gate — NULL
+//     work_mode columns degrade to "no work-mode strip", NULL error
+//     columns to "no error category breakdown", both non-silent.

--- a/src/lib/db/ingest.ts
+++ b/src/lib/db/ingest.ts
@@ -442,18 +442,22 @@ async function readJsonlSession(
   let assistantTurnCount = 0;
   let slug: string | null = null;
 
-  // Pre-pass: index tool_result error flags and slash-command markers from
-  // user turns so the main loop can enrich tool_use rows without a second
-  // file read. Tool results appear in user turns AFTER the assistant turn
-  // that called the tool, so a single-pass approach would miss them.
+  // Parse JSONL lines once into an array so the pre-pass and main pass
+  // both walk parsed objects — avoids a second JSON.parse per line.
+  // Tool results appear in user turns AFTER the assistant turn that called
+  // the tool, so two logical passes over the array are still required.
+  const rawLines = raw.split("\n");
+  const parsedLines: Array<{ line: string; entry: ConversationEntry | null }> = rawLines.map((line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return { line, entry: null };
+    try { return { line, entry: JSON.parse(trimmed) as ConversationEntry }; }
+    catch { return { line, entry: null }; }
+  });
+
   const errorByToolUseId = new Map<string, { isError: boolean; content: string }>();
   const slashCommandsByTimestamp = new Map<string, Set<string>>();
-  for (const line of raw.split("\n")) {
-    const trimmedPre = line.trim();
-    if (!trimmedPre) continue;
-    let preEntry: ConversationEntry;
-    try { preEntry = JSON.parse(trimmedPre); } catch { continue; }
-    if (preEntry.type !== "user" || preEntry.isSidechain || preEntry.isMeta || !preEntry.timestamp) continue;
+  for (const { entry: preEntry } of parsedLines) {
+    if (!preEntry || preEntry.type !== "user" || preEntry.isSidechain || preEntry.isMeta || !preEntry.timestamp) continue;
     const msgContent = preEntry.message?.content ?? [];
     const topContent = (preEntry.content ?? []) as unknown[];
     const src = (msgContent as unknown[]).length > 0 ? msgContent : topContent;
@@ -469,21 +473,13 @@ async function readJsonlSession(
   let prevUserTimestamp: string | null = null;
 
   const tParse = PROFILE ? performance.now() : 0;
-  for (const line of raw.split("\n")) {
+  for (const { line, entry } of parsedLines) {
     // Advance byte cursor BEFORE any continues so the offset is correct
     // for every line, including blank and sidechain lines.
     const thisLineOffset = relativeBytePos;
     relativeBytePos += Buffer.byteLength(line + "\n", "utf8");
 
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-
-    let entry: ConversationEntry;
-    try {
-      entry = JSON.parse(trimmed);
-    } catch {
-      continue;
-    }
+    if (!entry) continue;
 
     // Collect CLI version from every entry that carries it.
     if (typeof entry.version === "string" && entry.version) {

--- a/src/lib/db/ingest.ts
+++ b/src/lib/db/ingest.ts
@@ -14,8 +14,12 @@ import { parseMcpTool } from "@/lib/usage/mcpParser";
 import {
   extractText,
   extractToolResults,
+  extractToolResultEntries,
+  extractCommandNames,
   isHumanText,
 } from "@/lib/usage/contentBlocks";
+import { categorizeToolError } from "@/lib/usage/toolErrorCategorizer";
+import { aggregateWorkMode } from "@/lib/usage/workMode";
 import {
   FILE_OP_BY_TOOL,
   AGENT_DISPATCH_TOOL,
@@ -107,6 +111,8 @@ interface ParsedToolUse {
   filePath: string | null;
   fileOp: FileOp | null;
   isError: 0 | 1;
+  errorCategory: string | null;
+  invocationSource: string | null;
 }
 
 interface ParsedTurn {
@@ -257,6 +263,10 @@ interface ParsedSession {
   compactBoundaryCount: number;
   /** Whether the resume-anomaly detector fired. Populated by Phase 3 detector; 0 here. */
   hasResumeAnomaly: 0 | 1;
+  workModeExplorationPct: number | null;
+  workModeBuildingPct: number | null;
+  workModeTestingPct: number | null;
+  workModeOtherPct: number | null;
   turns: ParsedTurn[];
   // (day, project, model) tuples to recompute in daily_costs after this
   // session is replaced.
@@ -432,6 +442,32 @@ async function readJsonlSession(
   let assistantTurnCount = 0;
   let slug: string | null = null;
 
+  // Pre-pass: index tool_result error flags and slash-command markers from
+  // user turns so the main loop can enrich tool_use rows without a second
+  // file read. Tool results appear in user turns AFTER the assistant turn
+  // that called the tool, so a single-pass approach would miss them.
+  const errorByToolUseId = new Map<string, { isError: boolean; content: string }>();
+  const slashCommandsByTimestamp = new Map<string, Set<string>>();
+  for (const line of raw.split("\n")) {
+    const trimmedPre = line.trim();
+    if (!trimmedPre) continue;
+    let preEntry: ConversationEntry;
+    try { preEntry = JSON.parse(trimmedPre); } catch { continue; }
+    if (preEntry.type !== "user" || preEntry.isSidechain || preEntry.isMeta || !preEntry.timestamp) continue;
+    const msgContent = preEntry.message?.content ?? [];
+    const topContent = (preEntry.content ?? []) as unknown[];
+    const src = (msgContent as unknown[]).length > 0 ? msgContent : topContent;
+    for (const tr of extractToolResultEntries(src)) {
+      if (tr.tool_use_id) errorByToolUseId.set(tr.tool_use_id, { isError: tr.isError, content: tr.content });
+    }
+    const names = extractCommandNames(src);
+    if (names.length > 0) slashCommandsByTimestamp.set(preEntry.timestamp, new Set(names));
+  }
+
+  // Tracks the timestamp of the most-recent user turn so the following
+  // assistant turn can look up that turn's slash-command set.
+  let prevUserTimestamp: string | null = null;
+
   const tParse = PROFILE ? performance.now() : 0;
   for (const line of raw.split("\n")) {
     // Advance byte cursor BEFORE any continues so the offset is correct
@@ -525,6 +561,8 @@ async function readJsonlSession(
       }
       const textPreview = truncateText(text, TEXT_PREVIEW_LIMIT);
 
+      const slashCmds = prevUserTimestamp ? slashCommandsByTimestamp.get(prevUserTimestamp) : undefined;
+      let slashWindowConsumed = false;
       const toolUses: ParsedToolUse[] = toolBlocks.map((b, idx): ParsedToolUse => {
         const args = (b.input ?? {}) as Record<string, unknown>;
         const toolName = typeof b.name === "string" ? b.name : "unknown";
@@ -536,18 +574,30 @@ async function readJsonlSession(
         } catch {
           argsJson = null;
         }
+        const toolUseId = typeof b.id === "string" ? b.id : null;
+        const errEntry = toolUseId ? errorByToolUseId.get(toolUseId) : undefined;
+        const isError: 0 | 1 = errEntry?.isError ? 1 : 0;
+        const errorCategory: string | null =
+          isError && errEntry?.content ? categorizeToolError(errEntry.content) : null;
+        const skillName = extractSkillName(toolName, args);
+        const isSlashMatch =
+          !slashWindowConsumed && !!slashCmds && !!skillName && slashCmds.has(skillName);
+        if (isSlashMatch) slashWindowConsumed = true;
+        const invocationSource: string = isSlashMatch ? "slash_command" : "auto";
         return {
           sequenceInTurn: idx,
-          toolUseId: typeof b.id === "string" ? b.id : null,
+          toolUseId,
           toolName,
           mcpServer: mcp?.server ?? null,
           mcpTool: mcp?.tool ?? null,
           agentName: extractAgentName(toolName, args),
-          skillName: extractSkillName(toolName, args),
+          skillName,
           argumentsJson: argsJson,
           filePath: fp,
           fileOp,
-          isError: 0,
+          isError,
+          errorCategory,
+          invocationSource,
         };
       });
       toolCallCount += toolUses.length;
@@ -685,6 +735,7 @@ async function readJsonlSession(
           }
         }
       }
+      prevUserTimestamp = timestamp;
     }
   }
 
@@ -709,6 +760,9 @@ async function readJsonlSession(
     }
   }
   if (PROFILE) tick("classify+price", performance.now() - tClassify);
+
+  // Derive: work-mode distribution across categorized assistant turns.
+  const workMode = aggregateWorkMode(turns.map((t) => ({ category: t.category })));
 
   // Derive: one-shot detection across the whole session.
   const allUsageTurns = turns.map((t) => t.usageTurn);
@@ -829,6 +883,10 @@ async function readJsonlSession(
       cliVersion,
       compactBoundaryCount: compactBoundaries.length,
       hasResumeAnomaly,
+      workModeExplorationPct: workMode.exploration,
+      workModeBuildingPct: workMode.building,
+      workModeTestingPct: workMode.testing,
+      workModeOtherPct: workMode.other,
       turns,
       affectedDays,
       affectedCategoryTuples,
@@ -927,7 +985,9 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
        has_one_shot, verified_task_count, one_shot_task_count,
        git_branch, initial_prompt, last_prompt, slug,
        has_thinking, cli_version, has_resume_anomaly, compact_boundary_count,
-       derived_version, indexed_at_ms
+       derived_version, indexed_at_ms,
+       work_mode_exploration_pct, work_mode_building_pct,
+       work_mode_testing_pct, work_mode_other_pct
      ) VALUES (
        @session_id, @project_slug, @project_dir_name, @file_path,
        @file_mtime_ms, @file_size, @byte_offset,
@@ -940,7 +1000,9 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
        @has_one_shot, @verified_task_count, @one_shot_task_count,
        @git_branch, @initial_prompt, @last_prompt, @slug,
        @has_thinking, @cli_version, @has_resume_anomaly, @compact_boundary_count,
-       @derived_version, @indexed_at_ms
+       @derived_version, @indexed_at_ms,
+       @work_mode_exploration_pct, @work_mode_building_pct,
+       @work_mode_testing_pct, @work_mode_other_pct
      )`
   ).run({
     session_id: s.sessionId,
@@ -985,6 +1047,10 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
     compact_boundary_count: s.compactBoundaryCount,
     derived_version: DERIVED_VERSION,
     indexed_at_ms: Date.now(),
+    work_mode_exploration_pct: s.workModeExplorationPct,
+    work_mode_building_pct: s.workModeBuildingPct,
+    work_mode_testing_pct: s.workModeTestingPct,
+    work_mode_other_pct: s.workModeOtherPct,
   });
   rows++;
   if (PROFILE) tick("write.insertSession", performance.now() - tInsertSession);
@@ -1010,11 +1076,13 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
     `INSERT INTO tool_uses (
        session_id, turn_index, sequence_in_turn, tool_use_id, ts, tool_name,
        mcp_server, mcp_tool, agent_name, skill_name,
-       arguments_json, file_path, file_op, is_error
+       arguments_json, file_path, file_op, is_error,
+       error_category, invocation_source
      ) VALUES (
        @session_id, @turn_index, @sequence_in_turn, @tool_use_id, @ts, @tool_name,
        @mcp_server, @mcp_tool, @agent_name, @skill_name,
-       @arguments_json, @file_path, @file_op, @is_error
+       @arguments_json, @file_path, @file_op, @is_error,
+       @error_category, @invocation_source
      )`
   );
   const insertFileEdit = db.prepare(
@@ -1064,6 +1132,8 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
         file_path: tu.filePath,
         file_op: tu.fileOp,
         is_error: tu.isError,
+        error_category: tu.errorCategory,
+        invocation_source: tu.invocationSource,
       });
       rows++;
 
@@ -1352,11 +1422,13 @@ function appendSessionTail(
     `INSERT INTO tool_uses (
        session_id, turn_index, sequence_in_turn, tool_use_id, ts, tool_name,
        mcp_server, mcp_tool, agent_name, skill_name,
-       arguments_json, file_path, file_op, is_error
+       arguments_json, file_path, file_op, is_error,
+       error_category, invocation_source
      ) VALUES (
        @session_id, @turn_index, @sequence_in_turn, @tool_use_id, @ts, @tool_name,
        @mcp_server, @mcp_tool, @agent_name, @skill_name,
-       @arguments_json, @file_path, @file_op, @is_error
+       @arguments_json, @file_path, @file_op, @is_error,
+       @error_category, @invocation_source
      )`
   );
   const insertFileEdit = db.prepare(
@@ -1405,6 +1477,8 @@ function appendSessionTail(
         file_path: tu.filePath,
         file_op: tu.fileOp,
         is_error: tu.isError,
+        error_category: tu.errorCategory,
+        invocation_source: tu.invocationSource,
       });
       rows++;
 
@@ -1520,6 +1594,12 @@ function appendSessionTail(
   // `'waiting'` (and time-gate to `working / needs_attention / idle`
   // depending on file mtime) until the next process restart triggers a
   // full reconcile. Acceptable trade-off for the ~150-session corpus.
+  // Recompute work-mode over all turns (old + new) now that new turns are inserted.
+  const allCategoryRows = db
+    .prepare("SELECT category FROM turns WHERE session_id = ? AND role = 'assistant'")
+    .all(sessionId) as Array<{ category: string | null }>;
+  const tailWorkMode = aggregateWorkMode(allCategoryRows);
+
   const refreshStatus = parsed.assistantTurnCount > 0;
   const statusUpdateClause = refreshStatus ? "status = @status, " : "";
   const statusUpdateParam = refreshStatus ? { status: parsed.storedStatus } : {};
@@ -1552,7 +1632,11 @@ function appendSessionTail(
        verified_task_count = @verified_task_count,
        one_shot_task_count = @one_shot_task_count,
        last_prompt         = @last_prompt,
-       indexed_at_ms       = @indexed_at_ms
+       indexed_at_ms       = @indexed_at_ms,
+       work_mode_exploration_pct = @work_mode_exploration_pct,
+       work_mode_building_pct = @work_mode_building_pct,
+       work_mode_testing_pct  = @work_mode_testing_pct,
+       work_mode_other_pct    = @work_mode_other_pct
      WHERE session_id = @session_id`
   ).run({
     ...statusUpdateParam,
@@ -1586,6 +1670,10 @@ function appendSessionTail(
     one_shot_task_count: oneShot.oneShotTasks,
     last_prompt: lastPrompt,
     indexed_at_ms: Date.now(),
+    work_mode_exploration_pct: tailWorkMode.exploration,
+    work_mode_building_pct: tailWorkMode.building,
+    work_mode_testing_pct: tailWorkMode.testing,
+    work_mode_other_pct: tailWorkMode.other,
   });
   rows++;
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -285,6 +285,36 @@ const MIGRATIONS: Migration[] = [
       ).run();
     },
   },
+  {
+    version: 10,
+    name: "wave8.3: work_mode on sessions; error_category + invocation_source on tool_uses",
+    up: (db) => {
+      const sessionCols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>;
+      const sessionColNames = sessionCols.map((c) => c.name);
+      for (const col of [
+        "work_mode_exploration_pct REAL",
+        "work_mode_building_pct REAL",
+        "work_mode_testing_pct REAL",
+        "work_mode_other_pct REAL",
+      ]) {
+        const name = col.split(" ")[0];
+        if (!sessionColNames.includes(name)) {
+          db.prepare(`ALTER TABLE sessions ADD COLUMN ${col}`).run();
+        }
+      }
+
+      const tuCols = db.prepare("PRAGMA table_info(tool_uses)").all() as Array<{ name: string }>;
+      const tuColNames = tuCols.map((c) => c.name);
+      if (!tuColNames.includes("error_category")) {
+        db.prepare("ALTER TABLE tool_uses ADD COLUMN error_category TEXT").run();
+      }
+      if (!tuColNames.includes("invocation_source")) {
+        db.prepare(
+          "ALTER TABLE tool_uses ADD COLUMN invocation_source TEXT CHECK (invocation_source IN ('slash_command','auto'))"
+        ).run();
+      }
+    },
+  },
 ];
 
 function resolveSchemaPath(): string {

--- a/src/lib/db/schema.sql
+++ b/src/lib/db/schema.sql
@@ -111,7 +111,14 @@ CREATE TABLE sessions (
   -- Wave 7.1b columns (schema v8):
   starred_at            TEXT,
   distilled_at          TEXT,
-  distilled_text        TEXT
+  distilled_text        TEXT,
+  -- Wave 8.3 columns (schema v10 / DERIVED_VERSION 7):
+  -- Percentage split of session turns across 3 work modes + other bucket.
+  -- Derived from turns.category at ingest finalization; NULL until computed.
+  work_mode_exploration_pct REAL,
+  work_mode_building_pct    REAL,
+  work_mode_testing_pct     REAL,
+  work_mode_other_pct       REAL
 );
 
 CREATE INDEX sessions_by_project_end      ON sessions(project_slug, end_ts DESC);
@@ -221,6 +228,9 @@ CREATE TABLE tool_uses (
   file_op           TEXT CHECK (file_op IN ('read','write','edit','delete')),
   duration_ms       INTEGER,
   is_error          INTEGER NOT NULL DEFAULT 0 CHECK (is_error IN (0,1)),
+  -- Wave 8.3 columns (schema v10 / DERIVED_VERSION 7):
+  error_category    TEXT,
+  invocation_source TEXT CHECK (invocation_source IN ('slash_command','auto')),
   PRIMARY KEY (session_id, turn_index, sequence_in_turn),
   FOREIGN KEY (session_id, turn_index) REFERENCES turns(session_id, turn_index) ON DELETE CASCADE
 ) WITHOUT ROWID;

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -643,6 +643,8 @@ export async function scanSessionDetail(
                   timestamp: entry.timestamp,
                   content: summary,
                   toolName,
+                  toolUseId: block.id as string | undefined,
+                  toolInput: Object.keys(input).length > 0 ? (input as Record<string, unknown>) : undefined,
                 });
 
                 // File operations

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -13,6 +13,8 @@ import {
 } from "../types";
 import { detectOneShot } from "../usage/oneShotDetector";
 import { computeSessionQuality } from "../usage/sessionQuality";
+import { classifyTurn } from "../usage/classifier";
+import { aggregateWorkMode } from "../usage/workMode";
 import { readSubagentMeta } from "./subagentMeta";
 import type { SubagentMeta } from "./subagentMeta";
 import type { UsageTurn, ToolCall as UsageToolCall } from "../usage/types";
@@ -321,6 +323,15 @@ async function scanSessionFile(
       qualityHasToolFailureStreak = quality.toolFailureStreaks.length > 0;
     } catch { /* non-critical */ }
 
+    // Work-mode distribution: classify each assistant turn and aggregate.
+    let sessionWorkMode: SessionSummary["workMode"] | undefined;
+    try {
+      const categories = lightTurns
+        .filter((t) => t.role === "assistant")
+        .map((t) => ({ category: classifyTurn(t) }));
+      sessionWorkMode = aggregateWorkMode(categories);
+    } catch { /* non-critical */ }
+
     // Per-model cost calculation using LiteLLM pricing (unified with /usage)
     await loadPricing();
     let costEstimate = 0;
@@ -385,6 +396,7 @@ async function scanSessionFile(
       maxContextFill: qualityMaxContextFill,
       hasCompactionLoop: qualityHasCompactionLoop,
       hasToolFailureStreak: qualityHasToolFailureStreak,
+      workMode: sessionWorkMode,
     };
   } catch {
     return null;

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -27,6 +27,7 @@ import {
 } from "../claudeStatsCache";
 import { inferSessionStatus } from "./sessionStatus";
 import { mostFrequent, canonicalizeDirName } from "../usage/parser";
+import { isWorktreeEncodedDir } from "./worktreeCheck";
 
 export interface ConversationEntry {
   type?: string;
@@ -398,6 +399,7 @@ async function scanSessionFile(
       hasCompactionLoop: qualityHasCompactionLoop,
       hasToolFailureStreak: qualityHasToolFailureStreak,
       workMode: sessionWorkMode,
+      isWorktree: isWorktreeEncodedDir(projectDirName),
     };
   } catch {
     return null;

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -26,7 +26,7 @@ import {
   type CachedFileStats,
 } from "../claudeStatsCache";
 import { inferSessionStatus } from "./sessionStatus";
-import { mostFrequent } from "../usage/parser";
+import { mostFrequent, canonicalizeDirName } from "../usage/parser";
 
 export interface ConversationEntry {
   type?: string;
@@ -123,6 +123,7 @@ async function scanSessionFile(
   mtime: Date
 ): Promise<SessionSummary | null> {
   try {
+    const canonicalDirName = canonicalizeDirName(projectDirName);
     const stat = await fs.stat(filePath);
     if (stat.size > MAX_SESSION_FILE_SIZE) return null;
     const content = await fs.readFile(filePath, "utf-8");
@@ -279,8 +280,8 @@ async function scanSessionFile(
           lightTurns.push({
             timestamp: entry.timestamp,
             sessionId,
-            projectSlug: toSlug(projectDirName),
-            projectDirName,
+            projectSlug: toSlug(canonicalDirName),
+            projectDirName: canonicalDirName,
             model: entry.message?.model || "",
             role: entry.type === "assistant" ? "assistant" : "user",
             inputTokens: turnUsage?.input_tokens ?? 0,
@@ -353,8 +354,8 @@ async function scanSessionFile(
         ? new Date(endTime).getTime() - new Date(startTime).getTime()
         : undefined;
 
-    const projectPath = decodeDirName(projectDirName);
-    const projectSlug = toSlug(projectDirName);
+    const projectPath = decodeDirName(canonicalDirName);
+    const projectSlug = toSlug(canonicalDirName);
 
     return {
       sessionId,

--- a/src/lib/scanner/claudeSessions.ts
+++ b/src/lib/scanner/claudeSessions.ts
@@ -89,7 +89,26 @@ export async function scanClaudeSessions(
   const historyMap = await getHistoryByProject();
   const projectEntries = historyMap.get(normalizedPath) || [];
 
-  result.sessionCount = projectEntries.length;
+  // Count worktree sessions: sibling dirs named <parent-encoded>--<type>-worktrees-*
+  // in ~/.claude/projects/ whose sessions are not in history.jsonl under the parent path.
+  const parentEncoded = encodePath(projectPath);
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  let worktreeSessionCount = 0;
+  try {
+    const allDirs = await fs.readdir(projectsDir);
+    for (const d of allDirs) {
+      const suffix = d.slice(parentEncoded.length);
+      if (
+        d.startsWith(parentEncoded + "--") &&
+        /^--(?:[a-z]+-)?worktrees-/.test(suffix)
+      ) {
+        const entries = await fs.readdir(path.join(projectsDir, d));
+        worktreeSessionCount += entries.filter((e) => e.endsWith(".jsonl")).length;
+      }
+    }
+  } catch { /* projectsDir may not exist */ }
+
+  result.sessionCount = projectEntries.length + worktreeSessionCount;
 
   if (projectEntries.length > 0) {
     projectEntries.sort((a, b) => {

--- a/src/lib/scanner/claudeSessions.ts
+++ b/src/lib/scanner/claudeSessions.ts
@@ -23,6 +23,8 @@ interface HistoryEntry {
 
 // Cache parsed history to avoid reading the file 61 times
 let cachedHistory: Map<string, HistoryEntry[]> | null = null;
+// Cache worktree dir listing to avoid 61× readdir on every scan batch
+let cachedWorktreeDirs: string[] | null = null;
 let cacheTime = 0;
 const HISTORY_CACHE_TTL = 60_000; // 1 minute
 
@@ -56,6 +58,12 @@ async function getHistoryByProject(): Promise<Map<string, HistoryEntry[]>> {
   }
 
   cachedHistory = map;
+  const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  try {
+    cachedWorktreeDirs = await fs.readdir(projectsDir);
+  } catch {
+    cachedWorktreeDirs = [];
+  }
   cacheTime = Date.now();
   return map;
 }
@@ -90,23 +98,21 @@ export async function scanClaudeSessions(
   const projectEntries = historyMap.get(normalizedPath) || [];
 
   // Count worktree sessions: sibling dirs named <parent-encoded>--<type>-worktrees-*
-  // in ~/.claude/projects/ whose sessions are not in history.jsonl under the parent path.
+  // in ~/.claude/projects/. The dir listing is cached alongside historyMap (same TTL)
+  // to avoid 61× readdir per scan batch.
   const parentEncoded = encodePath(projectPath);
   const projectsDir = path.join(os.homedir(), ".claude", "projects");
+  const allDirs = cachedWorktreeDirs ?? [];
   let worktreeSessionCount = 0;
-  try {
-    const allDirs = await fs.readdir(projectsDir);
-    for (const d of allDirs) {
-      const suffix = d.slice(parentEncoded.length);
-      if (
-        d.startsWith(parentEncoded + "--") &&
-        /^--(?:[a-z]+-)?worktrees-/.test(suffix)
-      ) {
+  for (const d of allDirs) {
+    const suffix = d.slice(parentEncoded.length);
+    if (d.startsWith(parentEncoded + "--") && /^--(?:[a-z]+-)?worktrees-/.test(suffix)) {
+      try {
         const entries = await fs.readdir(path.join(projectsDir, d));
         worktreeSessionCount += entries.filter((e) => e.endsWith(".jsonl")).length;
-      }
+      } catch { /* dir removed between cache and now */ }
     }
-  } catch { /* projectsDir may not exist */ }
+  }
 
   result.sessionCount = projectEntries.length + worktreeSessionCount;
 

--- a/src/lib/scanner/worktreeCheck.ts
+++ b/src/lib/scanner/worktreeCheck.ts
@@ -1,0 +1,7 @@
+/** Pure worktree-dir detection — no Node.js imports; safe for client components. */
+
+export const WORKTREE_SEP = "--claude-worktrees-";
+
+export function isWorktreeEncodedDir(encodedDirName: string): boolean {
+  return encodedDirName.includes(WORKTREE_SEP);
+}

--- a/src/lib/scanner/worktrees.ts
+++ b/src/lib/scanner/worktrees.ts
@@ -7,6 +7,11 @@ import { scanInsightsMd } from "./insightsMd";
 
 export const WORKTREE_SEP = "--claude-worktrees-";
 
+/** Returns true when an encoded project directory name belongs to a Claude Code worktree. */
+export function isWorktreeEncodedDir(encodedDirName: string): boolean {
+  return encodedDirName.includes(WORKTREE_SEP);
+}
+
 /**
  * Parse the branch name from a worktree's `.git` file.
  *

--- a/src/lib/scanner/worktrees.ts
+++ b/src/lib/scanner/worktrees.ts
@@ -5,12 +5,8 @@ import { scanTodoMd } from "./todoMd";
 import { scanManualStepsMd } from "./manualStepsMd";
 import { scanInsightsMd } from "./insightsMd";
 
-export const WORKTREE_SEP = "--claude-worktrees-";
-
-/** Returns true when an encoded project directory name belongs to a Claude Code worktree. */
-export function isWorktreeEncodedDir(encodedDirName: string): boolean {
-  return encodedDirName.includes(WORKTREE_SEP);
-}
+export { WORKTREE_SEP, isWorktreeEncodedDir } from "./worktreeCheck";
+import { WORKTREE_SEP } from "./worktreeCheck";
 
 /**
  * Parse the branch name from a worktree's `.git` file.

--- a/src/lib/sqlSchemaSnapshot.ts
+++ b/src/lib/sqlSchemaSnapshot.ts
@@ -1,4 +1,4 @@
-// Last verified: schema version 8 (src/lib/db/schema.sql + migrations v1-v8)
+// Last verified: schema version 10 (src/lib/db/schema.sql + migrations v1-v10)
 // Re-verify with `tests/sqlSchemaSnapshot.test.ts` after any migration.
 
 export interface TableSchema {
@@ -28,6 +28,8 @@ export const SQL_SCHEMA: TableSchema[] = [
       "has_resume_anomaly", "compact_boundary_count", "derived_version",
       "indexed_at_ms", "generated_title", "starred_at", "distilled_at",
       "distilled_text",
+      "work_mode_exploration_pct", "work_mode_building_pct",
+      "work_mode_testing_pct", "work_mode_other_pct",
     ],
   },
   {
@@ -46,6 +48,7 @@ export const SQL_SCHEMA: TableSchema[] = [
       "session_id", "turn_index", "sequence_in_turn", "tool_use_id", "ts",
       "tool_name", "mcp_server", "mcp_tool", "agent_name", "skill_name",
       "arguments_json", "file_path", "file_op", "duration_ms", "is_error",
+      "error_category", "invocation_source",
     ],
   },
   {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -468,6 +468,10 @@ export interface TimelineEvent {
   durationMs?: number;
   /** DB-path turn index; used to lazy-fetch thinking content on expand. */
   turnIndex?: number;
+  /** Raw tool arguments for expand-in-place inspection (#231). */
+  toolInput?: Record<string, unknown>;
+  /** Stable ID linking this event to its tool_result counterpart. */
+  toolUseId?: string;
 }
 
 export interface FileOperation {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -457,6 +457,8 @@ export interface SessionSummary {
   distilledText?: string;
   /** Work-mode distribution across categorized turns (integer percentages summing to 100). */
   workMode?: { exploration: number; building: number; testing: number; other: number };
+  /** True when this session came from a Claude Code worktree directory. */
+  isWorktree?: boolean;
 }
 
 export interface TimelineEvent {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -455,6 +455,8 @@ export interface SessionSummary {
   distilledAt?: string;
   /** LLM-generated distillation of the session (Wave 7.1b). */
   distilledText?: string;
+  /** Work-mode distribution across categorized turns (integer percentages summing to 100). */
+  workMode?: { exploration: number; building: number; testing: number; other: number };
 }
 
 export interface TimelineEvent {

--- a/src/lib/usage/contentBlocks.ts
+++ b/src/lib/usage/contentBlocks.ts
@@ -73,3 +73,67 @@ export function toolUseBlocks(content: unknown): Array<{
       b?.type === "tool_use"
   );
 }
+
+/**
+ * Richer tool_result extraction that preserves the `is_error` flag and the
+ * `tool_use_id` linking it back to the originating tool call.
+ *
+ * IMPORTANT: Call this BEFORE applying `isHumanText()` filtering — the
+ * `<command-name>` extractor below has the same constraint. System-injected
+ * user-turn content is structured, not human text, and must be processed
+ * in a pre-pass before the human-text filter discards it.
+ */
+export interface ToolResultEntry {
+  tool_use_id: string;
+  isError: boolean;
+  content: string;
+}
+
+export function extractToolResultEntries(content: unknown): ToolResultEntry[] {
+  if (!Array.isArray(content)) return [];
+  const results: ToolResultEntry[] = [];
+  for (const b of content as ContentBlock[]) {
+    if (b?.type !== "tool_result") continue;
+    const id = (b as { tool_use_id?: string }).tool_use_id ?? "";
+    const isError = Boolean((b as { is_error?: boolean }).is_error);
+    let text = "";
+    if (typeof b.content === "string") {
+      text = b.content;
+    } else if (Array.isArray(b.content)) {
+      for (const c of b.content as ContentBlock[]) {
+        if (c?.type === "text" && typeof c.text === "string") {
+          if (text) text += "\n";
+          text += c.text;
+        }
+      }
+    }
+    results.push({ tool_use_id: id, isError, content: text });
+  }
+  return results;
+}
+
+/**
+ * Extract `<command-name>X</command-name>` tags from user-turn content.
+ * These are Claude Code's internal markers injected before a slash-command
+ * run. Must run BEFORE `isHumanText()` filtering since the tag starts with
+ * `<`, which that filter treats as non-human.
+ */
+export function extractCommandNames(content: unknown): string[] {
+  const text = typeof content === "string"
+    ? content
+    : Array.isArray(content)
+      ? (content as ContentBlock[])
+          .filter((b) => b?.type === "text" && typeof b.text === "string")
+          .map((b) => b.text ?? "")
+          .join("\n")
+      : "";
+  const names: string[] = [];
+  const pattern = /<command-name>([\s\S]*?)<\/command-name>/g;
+  let match = pattern.exec(text);
+  while (match !== null) {
+    const name = match[1].trim();
+    if (name) names.push(name);
+    match = pattern.exec(text);
+  }
+  return names;
+}

--- a/src/lib/usage/diff.ts
+++ b/src/lib/usage/diff.ts
@@ -1,0 +1,67 @@
+export interface DiffLine {
+  kind: "removed" | "added" | "context";
+  text: string;
+}
+
+/**
+ * Produce a line-level unified diff between two strings.
+ * Returns at most `maxLines` lines total; appends a truncation note if cut.
+ * No external dependency — only used for Edit tool old→new display.
+ */
+export function lineDiff(
+  oldStr: string,
+  newStr: string,
+  maxLines = 200
+): DiffLine[] {
+  const oldLines = oldStr.split("\n");
+  const newLines = newStr.split("\n");
+  const result: DiffLine[] = [];
+
+  // Simple LCS-based diff: use the longest-common-subsequence Myers diff.
+  // For small inputs (tool args are capped at 32 KB), the naive O(m*n)
+  // approach is fast enough and avoids a dependency on a diff library.
+  const lcs = computeLCS(oldLines, newLines);
+  let oi = 0;
+  let ni = 0;
+  let li = 0;
+
+  while (oi < oldLines.length || ni < newLines.length) {
+    if (result.length >= maxLines) {
+      result.push({ kind: "context", text: `… (${oldLines.length - oi + newLines.length - ni} more lines)` });
+      break;
+    }
+    if (li < lcs.length && oi < oldLines.length && ni < newLines.length &&
+        oldLines[oi] === lcs[li] && newLines[ni] === lcs[li]) {
+      result.push({ kind: "context", text: oldLines[oi] });
+      oi++; ni++; li++;
+    } else if (ni < newLines.length &&
+               (li >= lcs.length || newLines[ni] !== lcs[li])) {
+      result.push({ kind: "added", text: newLines[ni++] });
+    } else {
+      result.push({ kind: "removed", text: oldLines[oi++] });
+    }
+  }
+
+  return result;
+}
+
+function computeLCS(a: string[], b: string[]): string[] {
+  const m = a.length;
+  const n = b.length;
+  // Limit to avoid O(m*n) blowup on huge strings.
+  if (m * n > 40_000) return [];
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+  const lcs: string[] = [];
+  let i = m, j = n;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) { lcs.unshift(a[i - 1]); i--; j--; }
+    else if (dp[i - 1][j] >= dp[i][j - 1]) i--;
+    else j--;
+  }
+  return lcs;
+}

--- a/src/lib/usage/gitActivity.ts
+++ b/src/lib/usage/gitActivity.ts
@@ -1,0 +1,54 @@
+export interface BranchStat {
+  branch: string;
+  sessionCount: number;
+  lastActivity: string;
+}
+
+export interface GitActivitySummary {
+  commits: number;
+  pushes: number;
+  branches: BranchStat[];
+}
+
+// Matches `git commit` but not `git commit-tree` or `git commit --amend-only` etc.
+const COMMIT_RE = /^\s*git\s+commit(\s|$)/m;
+// Matches `git push` but not `git push-pack` etc.
+const PUSH_RE = /^\s*git\s+push(\s|$)/m;
+
+export function aggregateGitActivity(
+  toolCommands: Array<{ command: string }>,
+  sessionBranches: Array<{ branch: string | null; lastActivity: string }>
+): GitActivitySummary {
+  let commits = 0;
+  let pushes = 0;
+
+  for (const { command } of toolCommands) {
+    if (COMMIT_RE.test(command)) commits++;
+    if (PUSH_RE.test(command)) pushes++;
+  }
+
+  const branchMap = new Map<string, { count: number; lastActivity: string }>();
+  for (const { branch, lastActivity } of sessionBranches) {
+    if (!branch) continue;
+    const existing = branchMap.get(branch);
+    if (!existing || lastActivity > existing.lastActivity) {
+      branchMap.set(branch, {
+        count: (existing?.count ?? 0) + 1,
+        lastActivity,
+      });
+    } else {
+      existing.count++;
+    }
+  }
+
+  const branches: BranchStat[] = Array.from(branchMap.entries())
+    .map(([branch, { count, lastActivity }]) => ({
+      branch,
+      sessionCount: count,
+      lastActivity,
+    }))
+    .sort((a, b) => b.lastActivity.localeCompare(a.lastActivity))
+    .slice(0, 15);
+
+  return { commits, pushes, branches };
+}

--- a/src/lib/usage/gitActivity.ts
+++ b/src/lib/usage/gitActivity.ts
@@ -10,7 +10,7 @@ export interface GitActivitySummary {
   branches: BranchStat[];
 }
 
-// Matches `git commit` but not `git commit-tree` or `git commit --amend-only` etc.
+// Matches `git commit` but not `git commit-tree` etc. (--amend commits are intentionally counted)
 const COMMIT_RE = /^\s*git\s+commit(\s|$)/m;
 // Matches `git push` but not `git push-pack` etc.
 const PUSH_RE = /^\s*git\s+push(\s|$)/m;

--- a/src/lib/usage/parser.ts
+++ b/src/lib/usage/parser.ts
@@ -144,7 +144,7 @@ export async function parseSessionTurns(
     if (!trimmedPre) continue;
     let preEntry: ConversationEntry;
     try { preEntry = JSON.parse(trimmedPre); } catch { continue; }
-    if (preEntry.type !== "user" || preEntry.isMeta || !preEntry.timestamp) continue;
+    if (preEntry.type !== "user" || preEntry.isSidechain || preEntry.isMeta || !preEntry.timestamp) continue;
     const msgC = preEntry.message?.content ?? [];
     const topC = (preEntry.content ?? []) as unknown[];
     const src = (msgC as unknown[]).length > 0 ? msgC : topC;
@@ -194,8 +194,7 @@ export async function parseSessionTurns(
           const id: string | undefined = b.id;
           const errEntry = id ? errorByToolUseId.get(id) : undefined;
           const tcIsError = errEntry?.isError ?? false;
-          const tcErrorCategory = tcIsError && errEntry?.content
-            ? categorizeToolError(errEntry.content) : undefined;
+          const tcErrorCategory = tcIsError ? categorizeToolError(errEntry?.content ?? "") : undefined;
           const skillName = b.name === "Skill" && typeof b.input?.skill === "string"
             ? b.input.skill : undefined;
           const isSlashMatch = !slashWindowConsumed && !!slashCmds && !!skillName && slashCmds.has(skillName);
@@ -308,7 +307,7 @@ export async function parseSessionTurnsWithMeta(
     if (!trimmedPre) continue;
     let preEntry: ConversationEntry;
     try { preEntry = JSON.parse(trimmedPre); } catch { continue; }
-    if (preEntry.type !== "user" || preEntry.isMeta || !preEntry.timestamp) continue;
+    if (preEntry.type !== "user" || preEntry.isSidechain || preEntry.isMeta || !preEntry.timestamp) continue;
     const msgC = preEntry.message?.content ?? [];
     const topC = (preEntry.content ?? []) as unknown[];
     const src = (msgC as unknown[]).length > 0 ? msgC : topC;
@@ -377,8 +376,7 @@ export async function parseSessionTurnsWithMeta(
           const id: string | undefined = b.id;
           const errEntry = id ? errorByToolUseIdMeta.get(id) : undefined;
           const tcIsError = errEntry?.isError ?? false;
-          const tcErrorCategory = tcIsError && errEntry?.content
-            ? categorizeToolError(errEntry.content) : undefined;
+          const tcErrorCategory = tcIsError ? categorizeToolError(errEntry?.content ?? "") : undefined;
           const skillName = b.name === "Skill" && typeof b.input?.skill === "string"
             ? b.input.skill : undefined;
           const isSlashMatch =

--- a/src/lib/usage/parser.ts
+++ b/src/lib/usage/parser.ts
@@ -10,7 +10,10 @@ import { FileCache } from "./cache";
 import {
   extractText as extractTextRaw,
   extractToolResults as extractToolResultsRaw,
+  extractToolResultEntries,
+  extractCommandNames,
 } from "./contentBlocks";
+import { categorizeToolError } from "./toolErrorCategorizer";
 
 const MAX_SESSION_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
@@ -130,6 +133,30 @@ export async function parseSessionTurns(
 
   const turns: UsageTurn[] = [];
 
+  // Pre-pass: index tool_result error flags and slash-command markers from
+  // user turns. Tool results come AFTER the assistant turn that called the
+  // tool, so this pre-pass is required to populate isError/errorCategory on
+  // ToolCall objects in the assistant turn during the main loop.
+  const errorByToolUseId = new Map<string, { isError: boolean; content: string }>();
+  const slashCommandsByTimestamp = new Map<string, Set<string>>();
+  for (const line of raw.split("\n")) {
+    const trimmedPre = line.trim();
+    if (!trimmedPre) continue;
+    let preEntry: ConversationEntry;
+    try { preEntry = JSON.parse(trimmedPre); } catch { continue; }
+    if (preEntry.type !== "user" || preEntry.isMeta || !preEntry.timestamp) continue;
+    const msgC = preEntry.message?.content ?? [];
+    const topC = (preEntry.content ?? []) as unknown[];
+    const src = (msgC as unknown[]).length > 0 ? msgC : topC;
+    for (const tr of extractToolResultEntries(src)) {
+      if (tr.tool_use_id) errorByToolUseId.set(tr.tool_use_id, { isError: tr.isError, content: tr.content });
+    }
+    const names = extractCommandNames(src);
+    if (names.length > 0) slashCommandsByTimestamp.set(preEntry.timestamp, new Set(names));
+  }
+
+  let prevUserTimestamp: string | null = null;
+
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -159,9 +186,29 @@ export async function parseSessionTurns(
       const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
 
       const content = entry.message?.content ?? [];
-      const toolCalls = content
+      const slashCmds = prevUserTimestamp ? slashCommandsByTimestamp.get(prevUserTimestamp) : undefined;
+      let slashWindowConsumed = false;
+      const toolCalls = (content as any[])
         .filter((b: any) => b.type === "tool_use")
-        .map((b: any) => ({ name: b.name, id: b.id as string | undefined, arguments: b.input }));
+        .map((b: any) => {
+          const id: string | undefined = b.id;
+          const errEntry = id ? errorByToolUseId.get(id) : undefined;
+          const tcIsError = errEntry?.isError ?? false;
+          const tcErrorCategory = tcIsError && errEntry?.content
+            ? categorizeToolError(errEntry.content) : undefined;
+          const skillName = b.name === "Skill" && typeof b.input?.skill === "string"
+            ? b.input.skill : undefined;
+          const isSlashMatch = !slashWindowConsumed && !!slashCmds && !!skillName && slashCmds.has(skillName);
+          if (isSlashMatch) slashWindowConsumed = true;
+          return {
+            name: b.name,
+            id,
+            arguments: b.input,
+            isError: tcIsError || undefined,
+            errorCategory: tcErrorCategory,
+            invocationSource: isSlashMatch ? "slash_command" : "auto",
+          };
+        });
 
       const assistantText = extractText(content) || undefined;
 
@@ -209,6 +256,7 @@ export async function parseSessionTurns(
         userMessageText,
         toolResultText,
       });
+      prevUserTimestamp = timestamp;
     }
   }
 
@@ -251,6 +299,26 @@ export async function parseSessionTurnsWithMeta(
   let hasThinking = false;
   // Index into turns[] of the last pushed assistant turn (for turn_duration attachment).
   let lastAssistantTurnIdx = -1;
+
+  // Pre-pass: index tool_result error flags and slash-command markers.
+  const errorByToolUseIdMeta = new Map<string, { isError: boolean; content: string }>();
+  const slashCommandsByTimestampMeta = new Map<string, Set<string>>();
+  for (const line of raw.split("\n")) {
+    const trimmedPre = line.trim();
+    if (!trimmedPre) continue;
+    let preEntry: ConversationEntry;
+    try { preEntry = JSON.parse(trimmedPre); } catch { continue; }
+    if (preEntry.type !== "user" || preEntry.isMeta || !preEntry.timestamp) continue;
+    const msgC = preEntry.message?.content ?? [];
+    const topC = (preEntry.content ?? []) as unknown[];
+    const src = (msgC as unknown[]).length > 0 ? msgC : topC;
+    for (const tr of extractToolResultEntries(src)) {
+      if (tr.tool_use_id) errorByToolUseIdMeta.set(tr.tool_use_id, { isError: tr.isError, content: tr.content });
+    }
+    const names = extractCommandNames(src);
+    if (names.length > 0) slashCommandsByTimestampMeta.set(preEntry.timestamp, new Set(names));
+  }
+  let prevUserTimestampMeta: string | null = null;
 
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
@@ -299,9 +367,32 @@ export async function parseSessionTurnsWithMeta(
       const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
 
       const content = entry.message?.content ?? [];
+      const slashCmdsMeta = prevUserTimestampMeta
+        ? slashCommandsByTimestampMeta.get(prevUserTimestampMeta)
+        : undefined;
+      let slashWindowConsumedMeta = false;
       const toolCalls = (content as any[])
         .filter((b: any) => b.type === "tool_use")
-        .map((b: any) => ({ name: b.name, id: b.id as string | undefined, arguments: b.input }));
+        .map((b: any) => {
+          const id: string | undefined = b.id;
+          const errEntry = id ? errorByToolUseIdMeta.get(id) : undefined;
+          const tcIsError = errEntry?.isError ?? false;
+          const tcErrorCategory = tcIsError && errEntry?.content
+            ? categorizeToolError(errEntry.content) : undefined;
+          const skillName = b.name === "Skill" && typeof b.input?.skill === "string"
+            ? b.input.skill : undefined;
+          const isSlashMatch =
+            !slashWindowConsumedMeta && !!slashCmdsMeta && !!skillName && slashCmdsMeta.has(skillName);
+          if (isSlashMatch) slashWindowConsumedMeta = true;
+          return {
+            name: b.name,
+            id,
+            arguments: b.input,
+            isError: tcIsError || undefined,
+            errorCategory: tcErrorCategory,
+            invocationSource: isSlashMatch ? "slash_command" : "auto",
+          };
+        });
 
       const assistantText = extractText(content) || undefined;
       const isError = entry.isApiErrorMessage === true;
@@ -354,6 +445,7 @@ export async function parseSessionTurnsWithMeta(
         userMessageText,
         toolResultText,
       });
+      prevUserTimestampMeta = timestamp;
     }
   }
 

--- a/src/lib/usage/sessionDiagnosis.ts
+++ b/src/lib/usage/sessionDiagnosis.ts
@@ -60,6 +60,8 @@ export interface DiagnosisReport {
   /** Up to 3 advice strings, ordered by estimated impact desc. */
   topAdvice: string[];
   generatedAt: string;
+  /** Tool error counts by category, populated by the quality route from UsageTurn.toolCalls. */
+  toolErrorsByCategory?: Record<string, number>;
 }
 
 // ── Thresholds ────────────────────────────────────────────────────────────────

--- a/src/lib/usage/toolArgFormatter.ts
+++ b/src/lib/usage/toolArgFormatter.ts
@@ -1,0 +1,75 @@
+export type ToolArgKind = "command" | "file-path" | "edit-diff" | "json";
+
+export interface FormattedToolArg {
+  kind: ToolArgKind;
+  /** Short label for collapsed view (≤80 chars). */
+  preview: string;
+  /** Full content for expanded view. */
+  content: string;
+}
+
+const COMMAND_TOOLS = new Set(["Bash", "PowerShell"]);
+const FILE_READ_TOOLS = new Set(["Read"]);
+const FILE_WRITE_TOOLS = new Set(["Write"]);
+const EDIT_TOOLS = new Set(["Edit", "MultiEdit"]);
+
+export function formatToolArgs(
+  toolName: string,
+  args: Record<string, unknown> | undefined | null
+): FormattedToolArg {
+  if (!args) {
+    return { kind: "json", preview: "(no args)", content: "" };
+  }
+
+  if (COMMAND_TOOLS.has(toolName)) {
+    const cmd = typeof args.command === "string" ? args.command : JSON.stringify(args);
+    return {
+      kind: "command",
+      preview: cmd.length > 80 ? cmd.slice(0, 79) + "…" : cmd,
+      content: cmd,
+    };
+  }
+
+  if (FILE_READ_TOOLS.has(toolName) || FILE_WRITE_TOOLS.has(toolName)) {
+    const filePath = typeof args.file_path === "string" ? args.file_path : "";
+    const preview = filePath || "(no path)";
+    return {
+      kind: "file-path",
+      preview: preview.length > 80 ? "…" + preview.slice(-79) : preview,
+      content: preview,
+    };
+  }
+
+  if (EDIT_TOOLS.has(toolName)) {
+    const oldStr = typeof args.old_string === "string" ? args.old_string : "";
+    const newStr = typeof args.new_string === "string" ? args.new_string : "";
+    const filePath = typeof args.file_path === "string" ? args.file_path : "";
+    const isTruncated = typeof args.old_string === "string" && args.old_string.endsWith("…");
+
+    const lines: string[] = [];
+    if (filePath) lines.push(`--- ${filePath}`, `+++ ${filePath}`);
+    for (const line of oldStr.split("\n")) {
+      lines.push(`- ${line}`);
+    }
+    for (const line of newStr.split("\n")) {
+      lines.push(`+ ${line}`);
+    }
+    if (isTruncated) lines.push("(truncated — arguments_json 32 KB cap)");
+
+    const preview = filePath
+      ? filePath.length > 70
+        ? "…" + filePath.slice(-69)
+        : filePath
+      : oldStr.slice(0, 40).replace(/\n/g, "↵") + (oldStr.length > 40 ? "…" : "");
+
+    return { kind: "edit-diff", preview, content: lines.join("\n") };
+  }
+
+  const json = JSON.stringify(args, null, 2);
+  const firstLine = JSON.stringify(args).slice(0, 80);
+  return {
+    kind: "json",
+    preview: firstLine.length === 80 ? firstLine.slice(0, 77) + "…" : firstLine,
+    content: json,
+  };
+}

--- a/src/lib/usage/toolArgFormatter.ts
+++ b/src/lib/usage/toolArgFormatter.ts
@@ -9,8 +9,7 @@ export interface FormattedToolArg {
 }
 
 const COMMAND_TOOLS = new Set(["Bash", "PowerShell"]);
-const FILE_READ_TOOLS = new Set(["Read"]);
-const FILE_WRITE_TOOLS = new Set(["Write"]);
+const FILE_PATH_TOOLS = new Set(["Read", "Write", "Glob"]);
 const EDIT_TOOLS = new Set(["Edit", "MultiEdit"]);
 
 export function formatToolArgs(
@@ -30,13 +29,14 @@ export function formatToolArgs(
     };
   }
 
-  if (FILE_READ_TOOLS.has(toolName) || FILE_WRITE_TOOLS.has(toolName)) {
-    const filePath = typeof args.file_path === "string" ? args.file_path : "";
-    const preview = filePath || "(no path)";
+  if (FILE_PATH_TOOLS.has(toolName)) {
+    const filePath = typeof args.file_path === "string" ? args.file_path
+      : typeof args.pattern === "string" ? args.pattern
+      : "";
     return {
       kind: "file-path",
-      preview: preview.length > 80 ? "…" + preview.slice(-79) : preview,
-      content: preview,
+      preview: filePath.length > 80 ? "…" + filePath.slice(-79) : filePath || "(no path)",
+      content: filePath || "(no path)",
     };
   }
 

--- a/src/lib/usage/toolErrorCategorizer.ts
+++ b/src/lib/usage/toolErrorCategorizer.ts
@@ -1,0 +1,94 @@
+export type ErrorCategory =
+  | "permission"
+  | "timeout"
+  | "not-found"
+  | "parse"
+  | "network"
+  | "interrupted"
+  | "other";
+
+interface CategoryRule {
+  category: ErrorCategory;
+  patterns: RegExp[];
+}
+
+const RULES: CategoryRule[] = [
+  {
+    category: "permission",
+    patterns: [
+      /permission denied/i,
+      /access denied/i,
+      /EACCES/,
+      /not allowed/i,
+      /forbidden/i,
+      /unauthorized/i,
+      /read-?only/i,
+    ],
+  },
+  {
+    category: "timeout",
+    patterns: [
+      /timed? ?out/i,
+      /ETIMEDOUT/,
+      /deadline exceeded/i,
+      /took too long/i,
+      /exceeded.*time limit/i,
+    ],
+  },
+  {
+    category: "not-found",
+    patterns: [
+      /no such file/i,
+      /file not found/i,
+      /ENOENT/,
+      /not found/i,
+      /does not exist/i,
+      /cannot find/i,
+      /could not find/i,
+    ],
+  },
+  {
+    category: "parse",
+    patterns: [
+      /syntax error/i,
+      /parse error/i,
+      /invalid json/i,
+      /unexpected token/i,
+      /failed to parse/i,
+      /malformed/i,
+    ],
+  },
+  {
+    category: "network",
+    patterns: [
+      /ECONNREFUSED/,
+      /ENOTFOUND/,
+      /ECONNRESET/,
+      /network error/i,
+      /connection refused/i,
+      /failed to fetch/i,
+      /socket hang up/i,
+      /getaddrinfo/i,
+    ],
+  },
+  {
+    category: "interrupted",
+    patterns: [
+      /interrupted/i,
+      /aborted/i,
+      /cancelled/i,
+      /SIGINT/,
+      /SIGTERM/,
+      /process exited/i,
+    ],
+  },
+];
+
+export function categorizeToolError(content: string): ErrorCategory {
+  for (const rule of RULES) {
+    for (const pattern of rule.patterns) {
+      if (pattern.test(content)) return rule.category;
+    }
+  }
+  return "other";
+}

--- a/src/lib/usage/types.ts
+++ b/src/lib/usage/types.ts
@@ -2,6 +2,9 @@ export interface ToolCall {
   name: string;
   id?: string;
   arguments?: Record<string, any>;
+  isError?: boolean;
+  errorCategory?: string;
+  invocationSource?: string;
 }
 
 export interface UsageTurn {

--- a/src/lib/usage/workMode.ts
+++ b/src/lib/usage/workMode.ts
@@ -1,6 +1,27 @@
 import type { CategoryType } from "./types";
 
 export type WorkMode = "exploration" | "building" | "testing" | "other";
+export type InvocationSource = "slash_command" | "auto";
+
+export const WORK_MODE_DISPLAY: Record<WorkMode, { color: string; label: string }> = {
+  exploration: { color: "var(--status-active-text)", label: "Exploration" },
+  building:    { color: "var(--accent)",             label: "Building"    },
+  testing:     { color: "var(--status-error-text)",  label: "Testing"     },
+  other:       { color: "var(--border-default)",     label: "Other"       },
+};
+
+export function workModeToSegments(
+  breakdown: WorkModeBreakdown
+): Array<{ key: string; pct: number; color: string; label: string }> {
+  return (["exploration", "building", "testing", "other"] as WorkMode[]).map((key) => ({
+    key,
+    pct: breakdown[key],
+    color: WORK_MODE_DISPLAY[key].color,
+    label: `${WORK_MODE_DISPLAY[key].label} ${breakdown[key]}%`,
+  }));
+}
+
+export const WORK_MODE_SEGMENTS = workModeToSegments;
 
 export interface WorkModeBreakdown {
   exploration: number;
@@ -25,8 +46,8 @@ const MODE_MAP: Record<CategoryType, WorkMode> = {
   General: "other",
 };
 
-export function categoryToWorkMode(cat: CategoryType): WorkMode {
-  return MODE_MAP[cat] ?? "other";
+export function categoryToWorkMode(cat: string | null | undefined): WorkMode {
+  return (cat ? MODE_MAP[cat as CategoryType] : undefined) ?? "other";
 }
 
 export function aggregateWorkMode(
@@ -41,7 +62,7 @@ export function aggregateWorkMode(
   for (const t of turns) {
     if (!t.category) continue;
     total++;
-    const mode = categoryToWorkMode(t.category as CategoryType);
+    const mode = categoryToWorkMode(t.category);
     if (mode === "exploration") exploration++;
     else if (mode === "building") building++;
     else if (mode === "testing") testing++;

--- a/src/lib/usage/workMode.ts
+++ b/src/lib/usage/workMode.ts
@@ -17,7 +17,7 @@ export function workModeToSegments(
     key,
     pct: breakdown[key],
     color: WORK_MODE_DISPLAY[key].color,
-    label: `${WORK_MODE_DISPLAY[key].label} ${breakdown[key]}%`,
+    label: WORK_MODE_DISPLAY[key].label,
   }));
 }
 
@@ -73,10 +73,17 @@ export function aggregateWorkMode(
     return { exploration: 0, building: 0, testing: 0, other: 0 };
   }
 
-  return {
-    exploration: Math.round((exploration / total) * 100),
-    building: Math.round((building / total) * 100),
-    testing: Math.round((testing / total) * 100),
-    other: Math.round((other / total) * 100),
-  };
+  const rawPcts = [
+    { key: "exploration" as const, raw: (exploration / total) * 100 },
+    { key: "building" as const, raw: (building / total) * 100 },
+    { key: "testing" as const, raw: (testing / total) * 100 },
+    { key: "other" as const, raw: (other / total) * 100 },
+  ];
+  const floored = rawPcts.map((p) => ({ ...p, v: Math.floor(p.raw) }));
+  const remainder = 100 - floored.reduce((s, p) => s + p.v, 0);
+  const sorted = [...floored].sort((a, b) => (b.raw - b.v) - (a.raw - a.v));
+  for (let i = 0; i < remainder; i++) sorted[i].v++;
+  const result: Record<string, number> = {};
+  for (const p of floored) result[p.key] = p.v;
+  return { exploration: result.exploration, building: result.building, testing: result.testing, other: result.other };
 }

--- a/src/lib/usage/workMode.ts
+++ b/src/lib/usage/workMode.ts
@@ -1,0 +1,61 @@
+import type { CategoryType } from "./types";
+
+export type WorkMode = "exploration" | "building" | "testing" | "other";
+
+export interface WorkModeBreakdown {
+  exploration: number;
+  building: number;
+  testing: number;
+  other: number;
+}
+
+const MODE_MAP: Record<CategoryType, WorkMode> = {
+  Exploration: "exploration",
+  Brainstorming: "exploration",
+  Planning: "exploration",
+  Coding: "building",
+  "Feature Dev": "building",
+  Refactoring: "building",
+  Testing: "testing",
+  "Git Ops": "other",
+  "Build/Deploy": "other",
+  Debugging: "other",
+  Delegation: "other",
+  Conversation: "other",
+  General: "other",
+};
+
+export function categoryToWorkMode(cat: CategoryType): WorkMode {
+  return MODE_MAP[cat] ?? "other";
+}
+
+export function aggregateWorkMode(
+  turns: Array<{ category?: string | null }>
+): WorkModeBreakdown {
+  let exploration = 0;
+  let building = 0;
+  let testing = 0;
+  let other = 0;
+  let total = 0;
+
+  for (const t of turns) {
+    if (!t.category) continue;
+    total++;
+    const mode = categoryToWorkMode(t.category as CategoryType);
+    if (mode === "exploration") exploration++;
+    else if (mode === "building") building++;
+    else if (mode === "testing") testing++;
+    else other++;
+  }
+
+  if (total === 0) {
+    return { exploration: 0, building: 0, testing: 0, other: 0 };
+  }
+
+  return {
+    exploration: Math.round((exploration / total) * 100),
+    building: Math.round((building / total) * 100),
+    testing: Math.round((testing / total) * 100),
+    other: Math.round((other / total) * 100),
+  };
+}

--- a/tests/contentBlocks.test.ts
+++ b/tests/contentBlocks.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractToolResults,
+  extractToolResultEntries,
+  extractCommandNames,
+  isHumanText,
+} from "@/lib/usage/contentBlocks";
+
+describe("extractToolResults (legacy)", () => {
+  it("joins multiple tool_result text blocks", () => {
+    const content = [
+      { type: "tool_result", content: "result one" },
+      { type: "tool_result", content: "result two" },
+    ];
+    expect(extractToolResults(content)).toBe("result one\nresult two");
+  });
+
+  it("handles nested content array", () => {
+    const content = [
+      { type: "tool_result", content: [{ type: "text", text: "nested" }] },
+    ];
+    expect(extractToolResults(content)).toBe("nested");
+  });
+
+  it("returns empty string for non-array", () => {
+    expect(extractToolResults(null)).toBe("");
+    expect(extractToolResults("string")).toBe("");
+  });
+});
+
+describe("extractToolResultEntries", () => {
+  it("preserves is_error=true from tool_result block", () => {
+    const content = [
+      {
+        type: "tool_result",
+        tool_use_id: "tu_abc",
+        is_error: true,
+        content: "permission denied",
+      },
+    ];
+    const entries = extractToolResultEntries(content);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].isError).toBe(true);
+    expect(entries[0].tool_use_id).toBe("tu_abc");
+    expect(entries[0].content).toBe("permission denied");
+  });
+
+  it("preserves is_error=false (default)", () => {
+    const content = [
+      {
+        type: "tool_result",
+        tool_use_id: "tu_ok",
+        content: "file contents",
+      },
+    ];
+    const entries = extractToolResultEntries(content);
+    expect(entries[0].isError).toBe(false);
+  });
+
+  it("handles nested content array in tool_result", () => {
+    const content = [
+      {
+        type: "tool_result",
+        tool_use_id: "tu_x",
+        is_error: true,
+        content: [{ type: "text", text: "ENOENT: no such file" }],
+      },
+    ];
+    const entries = extractToolResultEntries(content);
+    expect(entries[0].content).toBe("ENOENT: no such file");
+    expect(entries[0].isError).toBe(true);
+  });
+
+  it("skips non-tool_result blocks", () => {
+    const content = [
+      { type: "text", text: "hello" },
+      { type: "tool_use", id: "x", name: "Bash", input: {} },
+    ];
+    expect(extractToolResultEntries(content)).toHaveLength(0);
+  });
+
+  it("returns empty array for non-array content", () => {
+    expect(extractToolResultEntries(null)).toHaveLength(0);
+  });
+});
+
+describe("extractCommandNames", () => {
+  it("extracts a single slash command name", () => {
+    const text = "<command-name>gsd-execute-phase</command-name> do the thing";
+    expect(extractCommandNames(text)).toEqual(["gsd-execute-phase"]);
+  });
+
+  it("extracts multiple command names from the same string", () => {
+    const text = "<command-name>foo</command-name>\n<command-name>bar</command-name>";
+    expect(extractCommandNames(text)).toEqual(["foo", "bar"]);
+  });
+
+  it("handles content array by joining text blocks", () => {
+    const content = [
+      { type: "text", text: "<command-name>plan</command-name>" },
+      { type: "tool_use", name: "Skill" },
+    ];
+    expect(extractCommandNames(content)).toEqual(["plan"]);
+  });
+
+  it("returns empty array when no command-name tags present", () => {
+    expect(extractCommandNames("just normal text")).toEqual([]);
+    expect(extractCommandNames(null)).toEqual([]);
+  });
+
+  it("trims whitespace from extracted names", () => {
+    expect(extractCommandNames("<command-name>  foo  </command-name>")).toEqual(["foo"]);
+  });
+
+  it("skips empty command-name tags", () => {
+    expect(extractCommandNames("<command-name></command-name>")).toEqual([]);
+  });
+});
+
+describe("isHumanText interaction", () => {
+  it("returns false for command-name bearing text (starts with <)", () => {
+    expect(isHumanText("<command-name>plan</command-name>")).toBe(false);
+  });
+
+  it("returns true for real human text", () => {
+    expect(isHumanText("implement the feature")).toBe(true);
+  });
+});

--- a/tests/dbIngest.test.ts
+++ b/tests/dbIngest.test.ts
@@ -199,7 +199,7 @@ describe.skipIf(!driverAvailable)("reconcileAllSessions", () => {
     expect(session.cost_usd).toBeGreaterThan(0);
     expect(session.initial_prompt).toBe("fix the migration bug");
     expect(session.last_prompt).toBe("fix the migration bug");
-    expect(session.derived_version).toBe(6);
+    expect(session.derived_version).toBe(7);
 
     const turnRows = db
       .prepare("SELECT role, category FROM turns WHERE session_id = 'abc-session' ORDER BY turn_index")
@@ -1160,7 +1160,7 @@ describe.skipIf(!driverAvailable)("reconcileAllSessions", () => {
       .prepare("SELECT slug, derived_version FROM sessions WHERE session_id = 'abc'")
       .get() as { slug: string | null; derived_version: number };
     expect(row.slug).toBe("graceful-pivoting-ferret");
-    expect(row.derived_version).toBe(6);
+    expect(row.derived_version).toBe(7);
     reloaded.conn.closeDb();
   });
 });

--- a/tests/dbMigrations.test.ts
+++ b/tests/dbMigrations.test.ts
@@ -81,8 +81,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     // but each still bumps the schema_version stamp. Note that v3
     // ALSO sets `meta.needs_reconcile_after_v3 = 1` even on fresh DBs;
     // that's harmless because the indexer's first reconcile clears it.
-    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.schemaVersion).toBe(10);
 
     const db = await conn.getDb();
     expect(db).not.toBeNull();
@@ -104,7 +104,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
     expect(result.appliedMigrations).toEqual([]);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     second.conn.closeDb();
   });
 
@@ -164,7 +164,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     expect(result.error).toBeNull();
     expect(result.available).toBe(true);
     expect(result.quarantined).not.toBeNull();
-    expect(result.schemaVersion).toBe(9);
+    expect(result.schemaVersion).toBe(10);
     second.conn.closeDb();
   });
 
@@ -218,8 +218,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6, 7, 8, 9]);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.schemaVersion).toBe(10);
 
     const db2 = await second.conn.getDb();
     const colsRecovered = db2!
@@ -254,8 +254,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([3, 4, 5, 6, 7, 8, 9]);
-    expect(result.schemaVersion).toBe(9);
+    expect(result.appliedMigrations).toEqual([3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.schemaVersion).toBe(10);
 
     const db2 = await second.conn.getDb();
     expect(db2).not.toBeNull();
@@ -278,6 +278,30 @@ describe.skipIf(!driverAvailable)("initDb", () => {
       .get() as { value?: string } | undefined;
     expect(flag?.value).toBe("1");
     second.conn.closeDb();
+  });
+
+  it("v10 migration adds work_mode columns to sessions and error/source columns to tool_uses", async () => {
+    const reloaded = await reloadModulesPointingAt(tmpHome);
+    const result = await reloaded.mig.initDb();
+    expect(result.error).toBeNull();
+    expect(result.schemaVersion).toBe(10);
+
+    const db = await reloaded.conn.getDb();
+    expect(db).not.toBeNull();
+
+    const sessionCols = db!.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>;
+    const sessionNames = sessionCols.map((c) => c.name);
+    expect(sessionNames).toContain("work_mode_exploration_pct");
+    expect(sessionNames).toContain("work_mode_building_pct");
+    expect(sessionNames).toContain("work_mode_testing_pct");
+    expect(sessionNames).toContain("work_mode_other_pct");
+
+    const tuCols = db!.prepare("PRAGMA table_info(tool_uses)").all() as Array<{ name: string }>;
+    const tuNames = tuCols.map((c) => c.name);
+    expect(tuNames).toContain("error_category");
+    expect(tuNames).toContain("invocation_source");
+
+    reloaded.conn.closeDb();
   });
 });
 

--- a/tests/gitActivity.test.ts
+++ b/tests/gitActivity.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { aggregateGitActivity } from "@/lib/usage/gitActivity";
+
+describe("aggregateGitActivity", () => {
+  it("counts git commits", () => {
+    const result = aggregateGitActivity(
+      [{ command: "git commit -m 'feat: add thing'" }],
+      []
+    );
+    expect(result.commits).toBe(1);
+    expect(result.pushes).toBe(0);
+  });
+
+  it("counts git pushes", () => {
+    const result = aggregateGitActivity(
+      [{ command: "git push origin main" }],
+      []
+    );
+    expect(result.pushes).toBe(1);
+    expect(result.commits).toBe(0);
+  });
+
+  it("does NOT count git commit-tree as a commit", () => {
+    const result = aggregateGitActivity(
+      [{ command: "git commit-tree HEAD^{tree}" }],
+      []
+    );
+    expect(result.commits).toBe(0);
+  });
+
+  it("handles both commit and push in one command set", () => {
+    const cmds = [
+      { command: "git add ." },
+      { command: "git commit -m 'update'" },
+      { command: "git push" },
+      { command: "git push origin feature" },
+    ];
+    const result = aggregateGitActivity(cmds, []);
+    expect(result.commits).toBe(1);
+    expect(result.pushes).toBe(2);
+  });
+
+  it("builds branch list sorted by recency", () => {
+    const branches = [
+      { branch: "main", lastActivity: "2026-05-07T10:00:00Z" },
+      { branch: "feature", lastActivity: "2026-05-08T12:00:00Z" },
+      { branch: "main", lastActivity: "2026-05-06T08:00:00Z" },
+    ];
+    const result = aggregateGitActivity([], branches);
+    expect(result.branches).toHaveLength(2);
+    expect(result.branches[0].branch).toBe("feature");
+    expect(result.branches[1].branch).toBe("main");
+    expect(result.branches[1].sessionCount).toBe(2);
+  });
+
+  it("limits branch list to 15 entries", () => {
+    const branches = Array.from({ length: 20 }, (_, i) => ({
+      branch: `branch-${i}`,
+      lastActivity: `2026-05-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
+    }));
+    const result = aggregateGitActivity([], branches);
+    expect(result.branches.length).toBe(15);
+  });
+
+  it("ignores null branches", () => {
+    const branches = [
+      { branch: null, lastActivity: "2026-05-08T10:00:00Z" },
+      { branch: "main", lastActivity: "2026-05-08T10:00:00Z" },
+    ];
+    const result = aggregateGitActivity([], branches);
+    expect(result.branches).toHaveLength(1);
+  });
+
+  it("returns zeros and empty for empty inputs", () => {
+    expect(aggregateGitActivity([], [])).toEqual({ commits: 0, pushes: 0, branches: [] });
+  });
+});

--- a/tests/parity.test.ts
+++ b/tests/parity.test.ts
@@ -238,9 +238,11 @@ describe.skipIf(!driverAvailable)("Commit 3 parity: DB path vs file-parse path",
       fpTurns.filter((t) => t.role === "assistant").map((t) => ({ category: classifyTurn(t) }))
     );
 
-    // Both paths should agree on which buckets are non-zero
-    const dbIsExplorationNonZero = (dbSession.work_mode_exploration_pct ?? 0) > 0;
-    const fpIsExplorationNonZero = fpWorkMode.exploration > 0;
-    expect(dbIsExplorationNonZero).toBe(fpIsExplorationNonZero);
+    // Exact match across all 4 buckets — both paths use the same aggregateWorkMode
+    // and classifyTurn, so values must be identical, not just sign-equal.
+    expect(fpWorkMode.exploration).toBe(dbSession.work_mode_exploration_pct);
+    expect(fpWorkMode.building).toBe(dbSession.work_mode_building_pct);
+    expect(fpWorkMode.testing).toBe(dbSession.work_mode_testing_pct);
+    expect(fpWorkMode.other).toBe(dbSession.work_mode_other_pct);
   });
 });

--- a/tests/parity.test.ts
+++ b/tests/parity.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Parity gate for Commit 3 (Wave 8.3).
+ *
+ * Same JSONL fixture is parsed by:
+ *   (A) DB path — reconcileSessionFile → SELECT from tool_uses / sessions
+ *   (B) File-parse path — parseSessionTurns → ToolCall[].isError / errorCategory / invocationSource
+ *
+ * Both paths must produce equivalent results for the three new fields.
+ * workMode parity is verified by comparing the DB sessions columns against
+ * the output of aggregateWorkMode(classifyTurn(...)) on the parsed turns.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
+
+let driverAvailable: boolean;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require("better-sqlite3");
+  driverAvailable = true;
+} catch {
+  driverAvailable = false;
+}
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+
+beforeEach(async () => {
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "pm-parity-test-"));
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  try {
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+async function writeFixture(filePath: string, entries: object[]): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, entries.map((e) => JSON.stringify(e)).join("\n") + "\n");
+}
+
+/** Build the JSONL fixture that exercises all three new fields. */
+function buildFixture() {
+  return [
+    // User turn 1: slash-command invocation + tool_result for Bash (not error)
+    {
+      type: "user",
+      timestamp: "2026-05-01T10:00:00Z",
+      message: {
+        content: [{ type: "text", text: "<command-name>gsd-debug</command-name>\nDebug the session" }],
+      },
+    },
+    // Assistant turn 1: Skill (slash_command) + Bash (auto) + Read (auto)
+    {
+      type: "assistant",
+      timestamp: "2026-05-01T10:00:01Z",
+      message: {
+        model: "claude-sonnet-4-5",
+        content: [
+          { type: "tool_use", id: "tu_skill", name: "Skill", input: { skill: "gsd-debug" } },
+          { type: "tool_use", id: "tu_bash", name: "Bash", input: { command: "npm test" } },
+          { type: "tool_use", id: "tu_read", name: "Read", input: { file_path: "/src/foo.ts" } },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 200, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      },
+    },
+    // User turn 2: tool_results — bash succeeds, read fails with ENOENT
+    {
+      type: "user",
+      timestamp: "2026-05-01T10:00:02Z",
+      message: {
+        content: [
+          { type: "tool_result", tool_use_id: "tu_skill", content: "skill launched" },
+          { type: "tool_result", tool_use_id: "tu_bash", content: "All tests pass" },
+          { type: "tool_result", tool_use_id: "tu_read", is_error: true, content: "ENOENT: no such file or directory, open '/src/foo.ts'" },
+        ],
+      },
+    },
+    // Assistant turn 2: plain coding turn (no slash command from prior user turn)
+    {
+      type: "assistant",
+      timestamp: "2026-05-01T10:00:03Z",
+      message: {
+        model: "claude-sonnet-4-5",
+        content: [
+          { type: "tool_use", id: "tu_edit", name: "Edit", input: { file_path: "/src/bar.ts", old_string: "a", new_string: "b" } },
+        ],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 150, output_tokens: 40, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+      },
+    },
+    // User turn 3: tool_result for edit (succeeds)
+    {
+      type: "user",
+      timestamp: "2026-05-01T10:00:04Z",
+      message: {
+        content: [
+          { type: "tool_result", tool_use_id: "tu_edit", content: "File updated" },
+        ],
+      },
+    },
+  ];
+}
+
+describe.skipIf(!driverAvailable)("Commit 3 parity: DB path vs file-parse path", () => {
+  it("tool_uses.is_error, error_category, invocation_source match ToolCall fields", async () => {
+    // ── Setup ──────────────────────────────────────────────────────────
+    vi.resetModules();
+    delete (globalThis as { __minderDb?: unknown }).__minderDb;
+    vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+
+    const conn = await import("@/lib/db/connection");
+    const mig = await import("@/lib/db/migrations");
+    const ingest = await import("@/lib/db/ingest");
+    const { parseSessionTurns } = await import("@/lib/usage/parser");
+
+    const init = await mig.initDb();
+    expect(init.available).toBe(true);
+    const db = (await conn.getDb())!;
+
+    const projectsDir = path.join(tmpHome, ".claude", "projects");
+    const sessionFile = path.join(projectsDir, "C--dev-myapp", "parity-session.jsonl");
+    await writeFixture(sessionFile, buildFixture());
+
+    // ── DB path ────────────────────────────────────────────────────────
+    const result = await ingest.reconcileSessionFile(db, sessionFile, "C--dev-myapp");
+    expect(result.rowsWritten).toBeGreaterThan(0);
+
+    const dbToolUses = db
+      .prepare("SELECT tool_use_id, is_error, error_category, invocation_source FROM tool_uses WHERE session_id = 'parity-session' ORDER BY sequence_in_turn")
+      .all() as Array<{ tool_use_id: string; is_error: number; error_category: string | null; invocation_source: string | null }>;
+
+    // 4 tool uses total: tu_skill, tu_bash, tu_read (turn1) + tu_edit (turn2)
+    expect(dbToolUses).toHaveLength(4);
+
+    const dbByTuId = Object.fromEntries(dbToolUses.map((r) => [r.tool_use_id, r]));
+
+    // tu_skill: slash_command (matches <command-name>gsd-debug</command-name>), no error
+    expect(dbByTuId["tu_skill"].is_error).toBe(0);
+    expect(dbByTuId["tu_skill"].error_category).toBeNull();
+    expect(dbByTuId["tu_skill"].invocation_source).toBe("slash_command");
+
+    // tu_bash: auto (window consumed by Skill), no error
+    expect(dbByTuId["tu_bash"].is_error).toBe(0);
+    expect(dbByTuId["tu_bash"].error_category).toBeNull();
+    expect(dbByTuId["tu_bash"].invocation_source).toBe("auto");
+
+    // tu_read: auto, error (ENOENT → not-found)
+    expect(dbByTuId["tu_read"].is_error).toBe(1);
+    expect(dbByTuId["tu_read"].error_category).toBe("not-found");
+    expect(dbByTuId["tu_read"].invocation_source).toBe("auto");
+
+    // tu_edit: auto (no slash commands in prior user turn 3), no error
+    expect(dbByTuId["tu_edit"].is_error).toBe(0);
+    expect(dbByTuId["tu_edit"].error_category).toBeNull();
+    expect(dbByTuId["tu_edit"].invocation_source).toBe("auto");
+
+    // ── File-parse path ────────────────────────────────────────────────
+    const fpTurns = await parseSessionTurns(sessionFile, "C--dev-myapp");
+    const fpAssistantTurns = fpTurns.filter((t) => t.role === "assistant");
+    expect(fpAssistantTurns).toHaveLength(2);
+
+    // Turn 1 tool calls
+    const [fpSkill, fpBash, fpRead] = fpAssistantTurns[0].toolCalls;
+    expect(fpSkill.invocationSource).toBe("slash_command");
+    expect(fpSkill.isError).toBeFalsy();
+
+    expect(fpBash.invocationSource).toBe("auto");
+    expect(fpBash.isError).toBeFalsy();
+
+    expect(fpRead.invocationSource).toBe("auto");
+    expect(fpRead.isError).toBe(true);
+    expect(fpRead.errorCategory).toBe("not-found");
+
+    // Turn 2 tool calls
+    const [fpEdit] = fpAssistantTurns[1].toolCalls;
+    expect(fpEdit.invocationSource).toBe("auto");
+    expect(fpEdit.isError).toBeFalsy();
+  });
+
+  it("sessions.work_mode_*_pct populated and non-negative", async () => {
+    vi.resetModules();
+    delete (globalThis as { __minderDb?: unknown }).__minderDb;
+    vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+
+    const conn = await import("@/lib/db/connection");
+    const mig = await import("@/lib/db/migrations");
+    const ingest = await import("@/lib/db/ingest");
+    const { aggregateWorkMode } = await import("@/lib/usage/workMode");
+    const { classifyTurn } = await import("@/lib/usage/classifier");
+    const { parseSessionTurns } = await import("@/lib/usage/parser");
+
+    const init = await mig.initDb();
+    expect(init.available).toBe(true);
+    const db = (await conn.getDb())!;
+
+    const projectsDir = path.join(tmpHome, ".claude", "projects");
+    const sessionFile = path.join(projectsDir, "C--dev-myapp", "wm-session.jsonl");
+    await writeFixture(sessionFile, buildFixture());
+
+    await ingest.reconcileSessionFile(db, sessionFile, "C--dev-myapp");
+
+    const dbSession = db
+      .prepare("SELECT work_mode_exploration_pct, work_mode_building_pct, work_mode_testing_pct, work_mode_other_pct FROM sessions WHERE session_id = 'wm-session'")
+      .get() as { work_mode_exploration_pct: number | null; work_mode_building_pct: number | null; work_mode_testing_pct: number | null; work_mode_other_pct: number | null };
+
+    expect(dbSession.work_mode_exploration_pct).not.toBeNull();
+    expect(dbSession.work_mode_building_pct).not.toBeNull();
+    expect(dbSession.work_mode_testing_pct).not.toBeNull();
+    expect(dbSession.work_mode_other_pct).not.toBeNull();
+
+    const sum =
+      dbSession.work_mode_exploration_pct! +
+      dbSession.work_mode_building_pct! +
+      dbSession.work_mode_testing_pct! +
+      dbSession.work_mode_other_pct!;
+    // Percentages should sum to ~100 (allow rounding ±2)
+    expect(sum).toBeGreaterThanOrEqual(98);
+    expect(sum).toBeLessThanOrEqual(102);
+
+    // File-parse path: compute workMode from parseSessionTurns + classifyTurn + aggregateWorkMode
+    const fpTurns = await parseSessionTurns(sessionFile, "C--dev-myapp");
+    const fpWorkMode = aggregateWorkMode(
+      fpTurns.filter((t) => t.role === "assistant").map((t) => ({ category: classifyTurn(t) }))
+    );
+
+    // Both paths should agree on which buckets are non-zero
+    const dbIsExplorationNonZero = (dbSession.work_mode_exploration_pct ?? 0) > 0;
+    const fpIsExplorationNonZero = fpWorkMode.exploration > 0;
+    expect(dbIsExplorationNonZero).toBe(fpIsExplorationNonZero);
+  });
+});

--- a/tests/toolArgFormatter.test.ts
+++ b/tests/toolArgFormatter.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { formatToolArgs } from "@/lib/usage/toolArgFormatter";
+
+describe("formatToolArgs", () => {
+  it("formats Bash command", () => {
+    const result = formatToolArgs("Bash", { command: "npm run test" });
+    expect(result.kind).toBe("command");
+    expect(result.content).toBe("npm run test");
+    expect(result.preview).toBe("npm run test");
+  });
+
+  it("truncates long Bash command in preview", () => {
+    const longCmd = "a".repeat(100);
+    const result = formatToolArgs("Bash", { command: longCmd });
+    expect(result.preview.length).toBe(80);
+    expect(result.preview.endsWith("…")).toBe(true);
+    expect(result.content).toBe(longCmd);
+  });
+
+  it("formats PowerShell as command", () => {
+    const result = formatToolArgs("PowerShell", { command: "Get-Process" });
+    expect(result.kind).toBe("command");
+  });
+
+  it("formats Read as file-path", () => {
+    const result = formatToolArgs("Read", { file_path: "/src/lib/foo.ts" });
+    expect(result.kind).toBe("file-path");
+    expect(result.content).toBe("/src/lib/foo.ts");
+  });
+
+  it("formats Write as file-path", () => {
+    const result = formatToolArgs("Write", { file_path: "/tmp/out.txt" });
+    expect(result.kind).toBe("file-path");
+  });
+
+  it("formats Edit as edit-diff with +/- lines", () => {
+    const result = formatToolArgs("Edit", {
+      file_path: "src/foo.ts",
+      old_string: "const x = 1;",
+      new_string: "const x = 2;",
+    });
+    expect(result.kind).toBe("edit-diff");
+    expect(result.content).toContain("- const x = 1;");
+    expect(result.content).toContain("+ const x = 2;");
+    expect(result.content).toContain("--- src/foo.ts");
+  });
+
+  it("formats MultiEdit as edit-diff", () => {
+    const result = formatToolArgs("MultiEdit", {
+      file_path: "x.ts",
+      old_string: "a",
+      new_string: "b",
+    });
+    expect(result.kind).toBe("edit-diff");
+  });
+
+  it("returns json kind for unknown tools", () => {
+    const result = formatToolArgs("WebFetch", { url: "https://example.com" });
+    expect(result.kind).toBe("json");
+    expect(result.content).toContain("example.com");
+  });
+
+  it("handles null args gracefully", () => {
+    const result = formatToolArgs("Bash", null);
+    expect(result.kind).toBe("json");
+    expect(result.preview).toBe("(no args)");
+  });
+});

--- a/tests/toolErrorCategorizer.test.ts
+++ b/tests/toolErrorCategorizer.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { categorizeToolError } from "@/lib/usage/toolErrorCategorizer";
+
+describe("categorizeToolError", () => {
+  it("classifies EACCES as permission", () => {
+    expect(categorizeToolError("Error: EACCES: permission denied, open '/etc/hosts'")).toBe("permission");
+  });
+
+  it("classifies 'access denied' as permission", () => {
+    expect(categorizeToolError("Access denied: cannot write to protected path")).toBe("permission");
+  });
+
+  it("classifies ETIMEDOUT as timeout", () => {
+    expect(categorizeToolError("ETIMEDOUT: connection timed out after 5000ms")).toBe("timeout");
+  });
+
+  it("classifies 'took too long' as timeout", () => {
+    expect(categorizeToolError("Command took too long to complete")).toBe("timeout");
+  });
+
+  it("classifies ENOENT as not-found", () => {
+    expect(categorizeToolError("Error: ENOENT: no such file or directory, open 'missing.ts'")).toBe("not-found");
+  });
+
+  it("classifies 'file not found' as not-found", () => {
+    expect(categorizeToolError("file not found: config.json")).toBe("not-found");
+  });
+
+  it("classifies 'syntax error' as parse", () => {
+    expect(categorizeToolError("SyntaxError: Unexpected token '}' at line 42")).toBe("parse");
+  });
+
+  it("classifies ECONNREFUSED as network", () => {
+    expect(categorizeToolError("Error: ECONNREFUSED 127.0.0.1:3000")).toBe("network");
+  });
+
+  it("classifies 'socket hang up' as network", () => {
+    expect(categorizeToolError("socket hang up")).toBe("network");
+  });
+
+  it("classifies 'interrupted' as interrupted", () => {
+    expect(categorizeToolError("Process interrupted by user")).toBe("interrupted");
+  });
+
+  it("classifies 'aborted' as interrupted", () => {
+    expect(categorizeToolError("Operation aborted")).toBe("interrupted");
+  });
+
+  it("classifies unknown errors as other", () => {
+    expect(categorizeToolError("Something went wrong")).toBe("other");
+    expect(categorizeToolError("")).toBe("other");
+  });
+
+  it("first matching rule wins (permission before not-found when both match)", () => {
+    // This string matches permission first in rule order.
+    expect(categorizeToolError("permission denied: file not found")).toBe("permission");
+  });
+});

--- a/tests/workMode.test.ts
+++ b/tests/workMode.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { categoryToWorkMode, aggregateWorkMode } from "@/lib/usage/workMode";
+
+describe("categoryToWorkMode", () => {
+  it("maps Exploration categories to exploration", () => {
+    expect(categoryToWorkMode("Exploration")).toBe("exploration");
+    expect(categoryToWorkMode("Brainstorming")).toBe("exploration");
+    expect(categoryToWorkMode("Planning")).toBe("exploration");
+  });
+
+  it("maps Building categories to building", () => {
+    expect(categoryToWorkMode("Coding")).toBe("building");
+    expect(categoryToWorkMode("Feature Dev")).toBe("building");
+    expect(categoryToWorkMode("Refactoring")).toBe("building");
+  });
+
+  it("maps Testing to testing", () => {
+    expect(categoryToWorkMode("Testing")).toBe("testing");
+  });
+
+  it("maps everything else to other", () => {
+    expect(categoryToWorkMode("Git Ops")).toBe("other");
+    expect(categoryToWorkMode("Build/Deploy")).toBe("other");
+    expect(categoryToWorkMode("Debugging")).toBe("other");
+    expect(categoryToWorkMode("Delegation")).toBe("other");
+    expect(categoryToWorkMode("Conversation")).toBe("other");
+    expect(categoryToWorkMode("General")).toBe("other");
+  });
+});
+
+describe("aggregateWorkMode", () => {
+  it("returns all zeros for empty turns", () => {
+    expect(aggregateWorkMode([])).toEqual({ exploration: 0, building: 0, testing: 0, other: 0 });
+  });
+
+  it("returns all zeros when no turns have categories", () => {
+    expect(aggregateWorkMode([{ category: null }, { category: undefined }]))
+      .toEqual({ exploration: 0, building: 0, testing: 0, other: 0 });
+  });
+
+  it("computes correct percentages", () => {
+    const turns = [
+      { category: "Exploration" },
+      { category: "Exploration" },
+      { category: "Coding" },
+      { category: "Testing" },
+    ];
+    const result = aggregateWorkMode(turns);
+    expect(result.exploration).toBe(50);
+    expect(result.building).toBe(25);
+    expect(result.testing).toBe(25);
+    expect(result.other).toBe(0);
+  });
+
+  it("handles mixed with nulls (nulls skipped from denominator)", () => {
+    const turns = [
+      { category: "Coding" },
+      { category: null },
+      { category: "Coding" },
+    ];
+    const result = aggregateWorkMode(turns);
+    // 2 categorized turns, both Building
+    expect(result.building).toBe(100);
+    expect(result.exploration).toBe(0);
+  });
+
+  it("percentages round to integers", () => {
+    // 1/3 ≈ 33%
+    const turns = [
+      { category: "Exploration" },
+      { category: "Coding" },
+      { category: "Testing" },
+    ];
+    const result = aggregateWorkMode(turns);
+    expect(result.exploration).toBe(33);
+    expect(result.building).toBe(33);
+    expect(result.testing).toBe(33);
+    expect(result.other).toBe(0);
+  });
+
+  it("all 13 categories map without throwing", () => {
+    const allCats = [
+      "Exploration", "Brainstorming", "Planning",
+      "Coding", "Feature Dev", "Refactoring",
+      "Testing",
+      "Git Ops", "Build/Deploy", "Debugging", "Delegation", "Conversation", "General",
+    ];
+    const turns = allCats.map((category) => ({ category }));
+    expect(() => aggregateWorkMode(turns)).not.toThrow();
+  });
+});

--- a/tests/workMode.test.ts
+++ b/tests/workMode.test.ts
@@ -64,18 +64,21 @@ describe("aggregateWorkMode", () => {
     expect(result.exploration).toBe(0);
   });
 
-  it("percentages round to integers", () => {
-    // 1/3 ≈ 33%
+  it("percentages round to integers summing to 100", () => {
+    // 1/3 each — largest-remainder gives one bucket the extra 1%
     const turns = [
       { category: "Exploration" },
       { category: "Coding" },
       { category: "Testing" },
     ];
     const result = aggregateWorkMode(turns);
-    expect(result.exploration).toBe(33);
-    expect(result.building).toBe(33);
-    expect(result.testing).toBe(33);
+    const sum = result.exploration + result.building + result.testing + result.other;
+    expect(sum).toBe(100);
     expect(result.other).toBe(0);
+    // Each of the three active buckets is either 33 or 34
+    expect([33, 34]).toContain(result.exploration);
+    expect([33, 34]).toContain(result.building);
+    expect([33, 34]).toContain(result.testing);
   });
 
   it("all 13 categories map without throwing", () => {


### PR DESCRIPTION
## Summary

Wave 8.3 closes Cluster T from the roadmap. Six TODO items, six commits, one PR.

- **#164 Worktree consolidation** — `canonicalizeDirName` applied in both DB and file-parse loaders so worktree sessions group under their parent project slug. `SessionsBrowser` groups by `projectSlug`. `claudeSessions` scanner unions worktree JSONL counts into parent session count. Branch chip on worktree session rows.
- **#191 Per-project Git activity panel** — `GET /api/projects/[slug]/git-activity` aggregates `git commit`/`git push` counts and branch recency from Bash/PowerShell tool args (DB-first, file-parse fallback, 5-min cache). `GitActivityPanel` added to Project Overview.
- **#158 Work-mode distribution** — Schema v10 / DERIVED_VERSION 7 adds `sessions.work_mode_*_pct` columns. `aggregateWorkMode` shared across DB ingest, file-parse, and efficiency route. `StackedStrip` pure-SVG component (largest-remainder rounding). Per-session strip in `SessionsBrowser`, "By Work Mode" subsection in `EfficiencyTab`.
- **#162 Invocation source tracking** — `tool_uses.invocation_source` (`slash_command` | `auto`) stamped during ingest via `<command-name>` pre-pass. `/api/skills` returns `slashCount`/`autoCount`; `SkillsBrowser` renders the breakdown.
- **#189 Tool error categorization** — `tool_uses.is_error` now written correctly; `error_category` populated by `categorizeToolError`. `DiagnosisPanel` renders a chip strip for error counts per category.
- **#231 Deep tool args in timeline** — `TimelineEvent` gains `toolInput` + `toolUseId`. Both timeline builders populate these. `SessionTimeline` shows "show args" expand toggle on tool_use events, rendered via `formatToolArgs`.

## Test plan

- [ ] `npm run typecheck` — clean ✅
- [ ] `npm test` — 1440 passed (136 files), 1 skipped ✅
- [ ] Sessions browser: worktree sessions group under parent project, not as phantom groups
- [ ] Sessions browser: worktree row shows branch chip; work-mode strip visible on right
- [ ] Project Overview: Git Activity panel shows commit/push counts on dogfood data
- [ ] Project Efficiency tab: "By Work Mode" strip + percentages render
- [ ] Session diagnosis: "Tool errors by category" chip strip appears on sessions with tool errors
- [ ] Session timeline: "show args" toggle on Bash events shows command; Edit events show old→new diff
- [ ] Skills browser: "N slash · M auto" breakdown line appears under invocation count
- [ ] DB fresh init: delete `~/.minder/index.db`, restart — schema v10 lands (4 work_mode columns + error_category + invocation_source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)