### PR TITLE
feat(wave9.1b): dispatcher loop + classic spawning + approve/rerun + Task Composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 9.1b — Cluster U (continued): Dispatcher loop + classic spawning + Task Composer.** TODO #244.
+  - Dispatcher loop singleton (`globalThis.__minderDispatcher`) starts automatically on the first `/api/tasks` request. 30-second tick: writes heartbeat to `~/.minder/dispatcher-heartbeat.json`, materializes due cron schedules into `ops_tasks` rows (wrapped in `BEGIN IMMEDIATE` to prevent double-materialization), promotes `requires_approval` tasks to `awaiting_approval`, claims up to 3 pending tasks and spawns `claude -p` (classic mode).
+  - PID marker files at `~/.minder/pids/<pid>` — written on spawn, deleted on exit. `sweepStalePids()` on each tick cleans dead files via `process.kill(pid, 0)` (cross-platform, throws ESRCH if dead).
+  - `POST /api/tasks/[id]/approve` — transitions `awaiting_approval → pending`, sets `approved_at`; dispatcher picks up on next tick.
+  - `POST /api/tasks/[id]/rerun` — resets `failed` task to `pending`, clears all output fields (`error_message`, `started_at`, `completed_at`, `duration_ms`, `cost_usd`, `output_summary`, `session_id`).
+  - Task Composer modal (`TaskComposer.tsx`) — "New task" button in TasksBrowser toolbar opens a full-form overlay. Fields: title, description, quadrant, priority, skill, model, risk level, scheduled_for, requires_approval, dry_run. POSTs to `/api/tasks` and refreshes the list on success.
+  - New store helpers: `approveTask()`, `rerunTask()`, `completeTask()`, `failTask()`, `promoteApprovalTasks()`, `materializeSchedules()`.
+  - `taskDispatcher` feature flag flipped to `wired: true`. Settings UI now shows it as active.
+  - Help doc at `/help/tasks` updated with dispatcher architecture, approve/rerun usage, and upcoming Wave 9.1c (stream mode) and Wave 9.2 (HITL) roadmap.
+  - Stream mode (line-buffered JSON, `session_id` extraction), `DECISION:` / `INBOX:` parsing, and emergency-stop button deferred to Wave 9.1c / 9.2.
+
 - **Wave 9.1a — Cluster U (partial): Tasks queue foundation.** TODO #244.
   - New `~/.minder/tasks.db` SQLite database (`src/lib/tasksDb/`) with `ops_tasks` and `ops_schedules` tables (schema v1). Status enum locked to `pending/awaiting_approval/running/done/failed/cancelled`. Full CHECK constraints, FK on `schedule_id`, and 5 covering indexes.
   - CRUD store (`src/lib/tasks/store.ts`) with `listTasks`, `createTask`, `patchTask`, `deleteTask`, `claimPendingTask` (atomic, for 9.1b dispatcher), and matching schedule functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - **Wave 9.1b — Cluster U (continued): Dispatcher loop + classic spawning + Task Composer.** TODO #244.
-  - Dispatcher loop singleton (`globalThis.__minderDispatcher`) starts automatically on the first `/api/tasks` request. 30-second tick: writes heartbeat to `~/.minder/dispatcher-heartbeat.json`, materializes due cron schedules into `ops_tasks` rows (wrapped in `BEGIN IMMEDIATE` to prevent double-materialization), promotes `requires_approval` tasks to `awaiting_approval`, claims up to 3 pending tasks and spawns `claude -p` (classic mode).
+  - Dispatcher loop singleton (`globalThis.__minderDispatcher`) starts automatically on the first `/api/tasks` request. 30-second tick: writes heartbeat to `~/.minder/dispatcher-heartbeat.json`, materializes due cron schedules into `ops_tasks` rows (serialized transaction), promotes `requires_approval` tasks to `awaiting_approval`, claims up to 3 pending tasks and spawns `claude -p` (classic mode).
   - PID marker files at `~/.minder/pids/<pid>` — written on spawn, deleted on exit. `sweepStalePids()` on each tick cleans dead files via `process.kill(pid, 0)` (cross-platform, throws ESRCH if dead).
   - `POST /api/tasks/[id]/approve` — transitions `awaiting_approval → pending`, sets `approved_at`; dispatcher picks up on next tick.
   - `POST /api/tasks/[id]/rerun` — resets `failed` task to `pending`, clears all output fields (`error_message`, `started_at`, `completed_at`, `duration_ms`, `cost_usd`, `output_summary`, `session_id`).

--- a/docs/help/tasks.md
+++ b/docs/help/tasks.md
@@ -56,7 +56,7 @@ The dispatcher is an in-process singleton (`globalThis.__minderDispatcher`) that
 4. Claims and spawns up to 3 concurrent `classic` mode tasks (via `claude -p`)
 5. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
 
-The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. In-flight tasks survive short reloads because their PID files and DB rows persist.
+The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. Tasks that were `running` when the server stopped will remain stuck in that state; use the re-run endpoint to reset them to `pending`.
 
 ## Fields reference
 

--- a/docs/help/tasks.md
+++ b/docs/help/tasks.md
@@ -1,6 +1,6 @@
 # Tasks
 
-**Mission Control > Tasks** shows the queue of work items dispatched to Claude Code agents. Each task represents one unit of work — a prompt, a code review, a refactor — that Project Minder can track, schedule, and (in Wave 9.1b) execute automatically.
+**Mission Control > Tasks** shows the queue of work items dispatched to Claude Code agents. Each task represents one unit of work — a prompt, a code review, a refactor — that Project Minder tracks, schedules, and executes automatically.
 
 ## Task statuses
 
@@ -10,22 +10,25 @@
 | **Awaiting approval** | Requires human sign-off before the dispatcher will start it |
 | **Running** | A `claude` CLI process is actively working on it |
 | **Done** | Completed successfully |
-| **Failed** | The process exited non-zero or timed out |
+| **Failed** | The process exited non-zero; can be re-run |
 | **Cancelled** | Explicitly stopped or skipped |
-
-## Fields
-
-- **Priority** — P1 (critical) through P5 (low). Affects dispatcher pick order.
-- **Quadrant** — Eisenhower matrix: Do / Schedule / Delegate / Archive.
-- **Execution mode** — `stream` (default, shows live output) or `classic`.
-- **Risk level** — Low / Medium / High. High-risk tasks can require approval.
-- **Scheduled for** — ISO timestamp; cron-based schedules populate this automatically.
-- **Session** — Populated by the dispatcher when `claude` starts (Wave 9.1b).
-- **Cost / Duration** — Filled in by the dispatcher on completion.
 
 ## Creating tasks
 
-Use the REST API directly until the Task Composer modal ships in Wave 9.1b:
+Click **New task** in the toolbar to open the Task Composer. Fill in:
+
+- **Title** (required) — the main prompt for Claude
+- **Description** — additional context, constraints, or acceptance criteria
+- **Quadrant** — Eisenhower matrix (Do / Schedule / Delegate / Archive)
+- **Priority** — P1 (critical) through P5 (low)
+- **Skill** — optional assigned skill to use (e.g. `code-review`)
+- **Model** — optional model override (e.g. `claude-opus-4-7`)
+- **Risk level** — Low / Medium / High
+- **Run after** — optional datetime; the dispatcher won't pick up the task until then
+- **Requires approval** — task waits in `awaiting_approval` until you approve it
+- **Dry run** — dispatcher logs but does not spawn a child process
+
+You can also create tasks via the REST API:
 
 ```
 POST /api/tasks
@@ -38,14 +41,41 @@ POST /api/tasks
 }
 ```
 
+## Approving and re-running tasks
+
+- **Approve**: `POST /api/tasks/<id>/approve` — moves `awaiting_approval → pending`; dispatcher picks up on the next tick.
+- **Re-run**: `POST /api/tasks/<id>/rerun` — resets a `failed` task to `pending` and clears all output fields.
+
+## Dispatcher
+
+The dispatcher is an in-process singleton (`globalThis.__minderDispatcher`) that starts automatically when the server handles its first request to `/api/tasks`. It:
+
+1. Writes a heartbeat to `~/.minder/dispatcher-heartbeat.json` on each 30-second tick
+2. Materializes due schedules into `ops_tasks` rows
+3. Promotes `pending + requires_approval` tasks to `awaiting_approval`
+4. Claims and spawns up to 3 concurrent `classic` mode tasks (via `claude -p`)
+5. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
+
+The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. In-flight tasks survive short reloads because their PID files and DB rows persist.
+
+## Fields reference
+
+| Field | Description |
+|-------|-------------|
+| Priority | P1–P5; affects dispatcher pick order (P1 first) |
+| Quadrant | Eisenhower: Do / Schedule / Delegate / Archive |
+| Execution mode | `classic` (one-shot `claude -p`) or `stream` (Wave 9.1c) |
+| Risk level | Low / Medium / High |
+| Scheduled for | ISO timestamp; cron schedules populate this automatically |
+| Session | Populated in stream mode when `claude` emits the init event |
+| Cost / Duration | Written on completion |
+
 ## Schedules
 
-Recurring tasks are driven by cron schedules. Create one at `POST /api/schedules` with a standard 5-field cron expression (e.g. `0 9 * * 1-5` = 09:00 on weekdays). The cron materializer — which turns schedules into `ops_tasks` rows — ships in Wave 9.1b alongside the dispatcher loop.
+Recurring tasks are driven by cron schedules. Create one at `POST /api/schedules` with a standard 5-field cron expression (e.g. `0 9 * * 1-5` = 09:00 on weekdays). The dispatcher materializes due schedules on each tick.
 
-## What's coming in Wave 9.1b
+## What's coming
 
-- Dispatcher loop — picks up `pending` tasks and spawns `claude` CLI processes
-- Cron materializer — creates task rows from enabled schedules on each tick
-- Task Composer modal — create tasks from the UI
-- Approve / Re-run buttons on individual tasks
-- PID tracking and emergency-stop
+- **Wave 9.1c** — Stream mode (line-buffered JSON, `session_id` extraction)
+- **Wave 9.2** — HITL: `DECISION:` / `INBOX:` marker parsing, decision queue, emergency stop
+- **Wave 10** — Kanban board, task dependency graph, multi-agent swarm

--- a/public/help/tasks.md
+++ b/public/help/tasks.md
@@ -56,7 +56,7 @@ The dispatcher is an in-process singleton (`globalThis.__minderDispatcher`) that
 4. Claims and spawns up to 3 concurrent `classic` mode tasks (via `claude -p`)
 5. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
 
-The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. In-flight tasks survive short reloads because their PID files and DB rows persist.
+The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. Tasks that were `running` when the server stopped will remain stuck in that state; use the re-run endpoint to reset them to `pending`.
 
 ## Fields reference
 

--- a/public/help/tasks.md
+++ b/public/help/tasks.md
@@ -1,6 +1,6 @@
 # Tasks
 
-**Mission Control > Tasks** shows the queue of work items dispatched to Claude Code agents. Each task represents one unit of work — a prompt, a code review, a refactor — that Project Minder can track, schedule, and (in Wave 9.1b) execute automatically.
+**Mission Control > Tasks** shows the queue of work items dispatched to Claude Code agents. Each task represents one unit of work — a prompt, a code review, a refactor — that Project Minder tracks, schedules, and executes automatically.
 
 ## Task statuses
 
@@ -10,22 +10,25 @@
 | **Awaiting approval** | Requires human sign-off before the dispatcher will start it |
 | **Running** | A `claude` CLI process is actively working on it |
 | **Done** | Completed successfully |
-| **Failed** | The process exited non-zero or timed out |
+| **Failed** | The process exited non-zero; can be re-run |
 | **Cancelled** | Explicitly stopped or skipped |
-
-## Fields
-
-- **Priority** — P1 (critical) through P5 (low). Affects dispatcher pick order.
-- **Quadrant** — Eisenhower matrix: Do / Schedule / Delegate / Archive.
-- **Execution mode** — `stream` (default, shows live output) or `classic`.
-- **Risk level** — Low / Medium / High. High-risk tasks can require approval.
-- **Scheduled for** — ISO timestamp; cron-based schedules populate this automatically.
-- **Session** — Populated by the dispatcher when `claude` starts (Wave 9.1b).
-- **Cost / Duration** — Filled in by the dispatcher on completion.
 
 ## Creating tasks
 
-Use the REST API directly until the Task Composer modal ships in Wave 9.1b:
+Click **New task** in the toolbar to open the Task Composer. Fill in:
+
+- **Title** (required) — the main prompt for Claude
+- **Description** — additional context, constraints, or acceptance criteria
+- **Quadrant** — Eisenhower matrix (Do / Schedule / Delegate / Archive)
+- **Priority** — P1 (critical) through P5 (low)
+- **Skill** — optional assigned skill to use (e.g. `code-review`)
+- **Model** — optional model override (e.g. `claude-opus-4-7`)
+- **Risk level** — Low / Medium / High
+- **Run after** — optional datetime; the dispatcher won't pick up the task until then
+- **Requires approval** — task waits in `awaiting_approval` until you approve it
+- **Dry run** — dispatcher logs but does not spawn a child process
+
+You can also create tasks via the REST API:
 
 ```
 POST /api/tasks
@@ -38,14 +41,41 @@ POST /api/tasks
 }
 ```
 
+## Approving and re-running tasks
+
+- **Approve**: `POST /api/tasks/<id>/approve` — moves `awaiting_approval → pending`; dispatcher picks up on the next tick.
+- **Re-run**: `POST /api/tasks/<id>/rerun` — resets a `failed` task to `pending` and clears all output fields.
+
+## Dispatcher
+
+The dispatcher is an in-process singleton (`globalThis.__minderDispatcher`) that starts automatically when the server handles its first request to `/api/tasks`. It:
+
+1. Writes a heartbeat to `~/.minder/dispatcher-heartbeat.json` on each 30-second tick
+2. Materializes due schedules into `ops_tasks` rows
+3. Promotes `pending + requires_approval` tasks to `awaiting_approval`
+4. Claims and spawns up to 3 concurrent `classic` mode tasks (via `claude -p`)
+5. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
+
+The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. In-flight tasks survive short reloads because their PID files and DB rows persist.
+
+## Fields reference
+
+| Field | Description |
+|-------|-------------|
+| Priority | P1–P5; affects dispatcher pick order (P1 first) |
+| Quadrant | Eisenhower: Do / Schedule / Delegate / Archive |
+| Execution mode | `classic` (one-shot `claude -p`) or `stream` (Wave 9.1c) |
+| Risk level | Low / Medium / High |
+| Scheduled for | ISO timestamp; cron schedules populate this automatically |
+| Session | Populated in stream mode when `claude` emits the init event |
+| Cost / Duration | Written on completion |
+
 ## Schedules
 
-Recurring tasks are driven by cron schedules. Create one at `POST /api/schedules` with a standard 5-field cron expression (e.g. `0 9 * * 1-5` = 09:00 on weekdays). The cron materializer — which turns schedules into `ops_tasks` rows — ships in Wave 9.1b alongside the dispatcher loop.
+Recurring tasks are driven by cron schedules. Create one at `POST /api/schedules` with a standard 5-field cron expression (e.g. `0 9 * * 1-5` = 09:00 on weekdays). The dispatcher materializes due schedules on each tick.
 
-## What's coming in Wave 9.1b
+## What's coming
 
-- Dispatcher loop — picks up `pending` tasks and spawns `claude` CLI processes
-- Cron materializer — creates task rows from enabled schedules on each tick
-- Task Composer modal — create tasks from the UI
-- Approve / Re-run buttons on individual tasks
-- PID tracking and emergency-stop
+- **Wave 9.1c** — Stream mode (line-buffered JSON, `session_id` extraction)
+- **Wave 9.2** — HITL: `DECISION:` / `INBOX:` marker parsing, decision queue, emergency stop
+- **Wave 10** — Kanban board, task dependency graph, multi-agent swarm

--- a/src/app/api/tasks/[id]/approve/route.ts
+++ b/src/app/api/tasks/[id]/approve/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getTask, approveTask } from "@/lib/tasks/store";
+import { parseId } from "@/lib/tasks/routeUtils";
+
+export const dynamic = "force-dynamic";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: Request, { params }: Params): Promise<NextResponse> {
+  const { id: rawId } = await params;
+  const id = parseId(rawId);
+  if (id === null) {
+    return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
+  }
+  try {
+    const existing = await getTask(id);
+    if (!existing) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    if (existing.status !== "awaiting_approval") {
+      return NextResponse.json(
+        { error: `Task is '${existing.status}', not 'awaiting_approval'` },
+        { status: 409 }
+      );
+    }
+    const task = await approveTask(id);
+    if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    return NextResponse.json({ task });
+  } catch (err) {
+    console.error("[api/tasks/[id]/approve POST]", err);
+    return NextResponse.json({ error: "Failed to approve task" }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/approve/route.ts
+++ b/src/app/api/tasks/[id]/approve/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { approveTask } from "@/lib/tasks/store";
+import { getTask, approveTask } from "@/lib/tasks/store";
 import { parseId } from "@/lib/tasks/routeUtils";
 
 export const dynamic = "force-dynamic";
@@ -15,8 +15,10 @@ export async function POST(_request: Request, { params }: Params): Promise<NextR
   try {
     const task = await approveTask(id);
     if (!task) {
+      const exists = await getTask(id);
+      if (!exists) return NextResponse.json({ error: "Task not found" }, { status: 404 });
       return NextResponse.json(
-        { error: "Task not found or not in awaiting_approval state" },
+        { error: `Task is '${exists.status}', not 'awaiting_approval'` },
         { status: 409 }
       );
     }

--- a/src/app/api/tasks/[id]/approve/route.ts
+++ b/src/app/api/tasks/[id]/approve/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getTask, approveTask } from "@/lib/tasks/store";
+import { approveTask } from "@/lib/tasks/store";
 import { parseId } from "@/lib/tasks/routeUtils";
 
 export const dynamic = "force-dynamic";
@@ -13,16 +13,13 @@ export async function POST(_request: Request, { params }: Params): Promise<NextR
     return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
   }
   try {
-    const existing = await getTask(id);
-    if (!existing) return NextResponse.json({ error: "Task not found" }, { status: 404 });
-    if (existing.status !== "awaiting_approval") {
+    const task = await approveTask(id);
+    if (!task) {
       return NextResponse.json(
-        { error: `Task is '${existing.status}', not 'awaiting_approval'` },
+        { error: "Task not found or not in awaiting_approval state" },
         { status: 409 }
       );
     }
-    const task = await approveTask(id);
-    if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
     return NextResponse.json({ task });
   } catch (err) {
     console.error("[api/tasks/[id]/approve POST]", err);

--- a/src/app/api/tasks/[id]/rerun/route.ts
+++ b/src/app/api/tasks/[id]/rerun/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getTask, rerunTask } from "@/lib/tasks/store";
+import { parseId } from "@/lib/tasks/routeUtils";
+
+export const dynamic = "force-dynamic";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: Request, { params }: Params): Promise<NextResponse> {
+  const { id: rawId } = await params;
+  const id = parseId(rawId);
+  if (id === null) {
+    return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
+  }
+  try {
+    const existing = await getTask(id);
+    if (!existing) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    if (existing.status !== "failed") {
+      return NextResponse.json(
+        { error: `Task is '${existing.status}', not 'failed'` },
+        { status: 409 }
+      );
+    }
+    const task = await rerunTask(id);
+    if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    return NextResponse.json({ task });
+  } catch (err) {
+    console.error("[api/tasks/[id]/rerun POST]", err);
+    return NextResponse.json({ error: "Failed to rerun task" }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/rerun/route.ts
+++ b/src/app/api/tasks/[id]/rerun/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getTask, rerunTask } from "@/lib/tasks/store";
+import { rerunTask } from "@/lib/tasks/store";
 import { parseId } from "@/lib/tasks/routeUtils";
 
 export const dynamic = "force-dynamic";
@@ -13,16 +13,13 @@ export async function POST(_request: Request, { params }: Params): Promise<NextR
     return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
   }
   try {
-    const existing = await getTask(id);
-    if (!existing) return NextResponse.json({ error: "Task not found" }, { status: 404 });
-    if (existing.status !== "failed") {
+    const task = await rerunTask(id);
+    if (!task) {
       return NextResponse.json(
-        { error: `Task is '${existing.status}', not 'failed'` },
+        { error: "Task not found or not in failed state" },
         { status: 409 }
       );
     }
-    const task = await rerunTask(id);
-    if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
     return NextResponse.json({ task });
   } catch (err) {
     console.error("[api/tasks/[id]/rerun POST]", err);

--- a/src/app/api/tasks/[id]/rerun/route.ts
+++ b/src/app/api/tasks/[id]/rerun/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { rerunTask } from "@/lib/tasks/store";
+import { getTask, rerunTask } from "@/lib/tasks/store";
 import { parseId } from "@/lib/tasks/routeUtils";
 
 export const dynamic = "force-dynamic";
@@ -15,8 +15,10 @@ export async function POST(_request: Request, { params }: Params): Promise<NextR
   try {
     const task = await rerunTask(id);
     if (!task) {
+      const exists = await getTask(id);
+      if (!exists) return NextResponse.json({ error: "Task not found" }, { status: 404 });
       return NextResponse.json(
-        { error: "Task not found or not in failed state" },
+        { error: `Task is '${exists.status}', not 'failed'` },
         { status: 409 }
       );
     }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,10 +3,12 @@ import { listTasks, createTask } from "@/lib/tasks/store";
 import { validateCreateTask } from "@/lib/tasks/validation";
 import { isTaskStatus, isTaskQuadrant } from "@/lib/tasks/validation";
 import type { TaskListFilter } from "@/lib/tasks/types";
+import { initDispatcher } from "@/lib/tasks/dispatcher";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request): Promise<NextResponse> {
+  initDispatcher();
   try {
     const url = new URL(request.url);
     const filter: TaskListFilter = {};
@@ -36,6 +38,7 @@ export async function GET(request: Request): Promise<NextResponse> {
 }
 
 export async function POST(request: Request): Promise<NextResponse> {
+  initDispatcher();
   try {
     const body = await request.json().catch(() => null);
     const validated = validateCreateTask(body);

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -13,6 +13,7 @@ export default function TasksPage() {
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
+    setError(null);
     try {
       const [tasksRes, schedRes] = await Promise.all([
         fetch("/api/tasks"),

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -12,28 +12,27 @@ export default function TasksPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const [tasksRes, schedRes] = await Promise.all([
-          fetch("/api/tasks"),
-          fetch("/api/schedules"),
-        ]);
-        if (!tasksRes.ok || !schedRes.ok) throw new Error("Failed to load");
-        const [tasksData, schedData] = await Promise.all([
-          tasksRes.json() as Promise<{ tasks: Task[] }>,
-          schedRes.json() as Promise<{ schedules: Schedule[] }>,
-        ]);
-        setTasks(tasksData.tasks);
-        setSchedules(schedData.schedules);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
-      } finally {
-        setLoading(false);
-      }
+  async function load() {
+    try {
+      const [tasksRes, schedRes] = await Promise.all([
+        fetch("/api/tasks"),
+        fetch("/api/schedules"),
+      ]);
+      if (!tasksRes.ok || !schedRes.ok) throw new Error("Failed to load");
+      const [tasksData, schedData] = await Promise.all([
+        tasksRes.json() as Promise<{ tasks: Task[] }>,
+        schedRes.json() as Promise<{ schedules: Schedule[] }>,
+      ]);
+      setTasks(tasksData.tasks);
+      setSchedules(schedData.schedules);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
     }
-    load();
-  }, []);
+  }
+
+  useEffect(() => { load(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (loading) {
     return (
@@ -51,5 +50,5 @@ export default function TasksPage() {
     );
   }
 
-  return <TasksBrowser tasks={tasks} schedules={schedules} />;
+  return <TasksBrowser tasks={tasks} schedules={schedules} onRefresh={load} />;
 }

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { TasksBrowser } from "@/components/TasksBrowser";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import type { Task, Schedule } from "@/lib/tasks/types";
@@ -12,7 +12,7 @@ export default function TasksPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  async function load() {
+  const load = useCallback(async () => {
     try {
       const [tasksRes, schedRes] = await Promise.all([
         fetch("/api/tasks"),
@@ -30,9 +30,9 @@ export default function TasksPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
-  useEffect(() => { load(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { load(); }, [load]);
 
   if (loading) {
     return (

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -39,6 +39,7 @@ const slugTitles: Record<HelpSlug, string> = {
   "auto-title": "Auto-title",
   otel: "OpenTelemetry",
   cost: "Cost Settings",
+  tasks: "Task Queue & Dispatcher",
 };
 
 const iconBtnBase: React.CSSProperties = {

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { X } from "lucide-react";
 import type { TaskQuadrant, RiskLevel } from "@/lib/tasks/types";
+import { EXECUTION_MODES } from "@/lib/tasks/types";
 
 interface TaskComposerProps {
   onClose: () => void;
@@ -66,7 +67,7 @@ export function TaskComposer({ onClose, onSuccess }: TaskComposerProps) {
     try {
       const body: Record<string, unknown> = {
         title: title.trim(),
-        execution_mode: "classic",
+        execution_mode: EXECUTION_MODES[0],
       };
       if (description.trim()) body.description = description.trim();
       if (quadrant) body.quadrant = quadrant;

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { X } from "lucide-react";
+import { Modal } from "@/components/ui/modal";
 import type { TaskQuadrant, RiskLevel } from "@/lib/tasks/types";
 import { EXECUTION_MODES } from "@/lib/tasks/types";
 
 interface TaskComposerProps {
+  open: boolean;
   onClose: () => void;
   onSuccess: () => void;
 }
@@ -44,7 +45,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-export function TaskComposer({ onClose, onSuccess }: TaskComposerProps) {
+export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [quadrant, setQuadrant] = useState<TaskQuadrant>("do");
@@ -98,180 +99,140 @@ export function TaskComposer({ onClose, onSuccess }: TaskComposerProps) {
   }
 
   return (
-    <div
-      style={{
-        position: "fixed", inset: 0, zIndex: 9000,
-        background: "rgba(0,0,0,0.6)",
-        display: "flex", alignItems: "center", justifyContent: "center",
-        padding: "16px",
-      }}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div
-        style={{
-          background: "var(--bg-card)",
-          border: "1px solid var(--border)",
-          borderRadius: "8px",
-          width: "100%",
-          maxWidth: "520px",
-          maxHeight: "90vh",
-          overflowY: "auto",
-          boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
-        }}
-      >
-        <div
-          style={{
-            display: "flex", alignItems: "center", justifyContent: "space-between",
-            padding: "16px 20px",
-            borderBottom: "1px solid var(--border-subtle)",
-          }}
-        >
-          <span style={{ fontSize: "0.9rem", fontWeight: 600, color: "var(--text-primary)" }}>
-            New Task
-          </span>
-          <button
-            onClick={onClose}
-            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-muted)", padding: "2px" }}
-            aria-label="Close"
-          >
-            <X style={{ width: "16px", height: "16px" }} />
-          </button>
+    <Modal open={open} onClose={onClose} title="New Task" maxWidthClass="max-w-lg">
+      <form onSubmit={handleSubmit} style={{ padding: "20px", display: "flex", flexDirection: "column", gap: "14px" }}>
+        <Field label="Title *">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Describe the task for Claude…"
+            style={inputStyle}
+            autoFocus
+          />
+        </Field>
+
+        <Field label="Description">
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Additional context, constraints, or acceptance criteria…"
+            rows={3}
+            style={{ ...inputStyle, resize: "vertical" }}
+          />
+        </Field>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+          <Field label="Quadrant">
+            <select value={quadrant} onChange={(e) => setQuadrant(e.target.value as TaskQuadrant)} style={selectStyle}>
+              <option value="do">Do (urgent + important)</option>
+              <option value="schedule">Schedule (important)</option>
+              <option value="delegate">Delegate</option>
+              <option value="archive">Archive</option>
+            </select>
+          </Field>
+
+          <Field label="Priority">
+            <select value={priority} onChange={(e) => setPriority(Number(e.target.value))} style={selectStyle}>
+              <option value={1}>P1 — critical</option>
+              <option value={2}>P2 — high</option>
+              <option value={3}>P3 — normal</option>
+              <option value={4}>P4 — low</option>
+              <option value={5}>P5 — someday</option>
+            </select>
+          </Field>
         </div>
 
-        <form onSubmit={handleSubmit} style={{ padding: "20px", display: "flex", flexDirection: "column", gap: "14px" }}>
-          <Field label="Title *">
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+          <Field label="Skill (optional)">
             <input
               type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Describe the task for Claude…"
+              value={assignedSkill}
+              onChange={(e) => setAssignedSkill(e.target.value)}
+              placeholder="e.g. code-review"
               style={inputStyle}
-              autoFocus
             />
           </Field>
 
-          <Field label="Description">
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Additional context, constraints, or acceptance criteria…"
-              rows={3}
-              style={{ ...inputStyle, resize: "vertical" }}
+          <Field label="Model (optional)">
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="e.g. claude-opus-4-7"
+              style={inputStyle}
             />
           </Field>
+        </div>
 
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
-            <Field label="Quadrant">
-              <select value={quadrant} onChange={(e) => setQuadrant(e.target.value as TaskQuadrant)} style={selectStyle}>
-                <option value="do">Do (urgent + important)</option>
-                <option value="schedule">Schedule (important)</option>
-                <option value="delegate">Delegate</option>
-                <option value="archive">Archive</option>
-              </select>
-            </Field>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+          <Field label="Risk level">
+            <select value={riskLevel} onChange={(e) => setRiskLevel(e.target.value as RiskLevel)} style={selectStyle}>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+          </Field>
 
-            <Field label="Priority">
-              <select value={priority} onChange={(e) => setPriority(Number(e.target.value))} style={selectStyle}>
-                <option value={1}>P1 — critical</option>
-                <option value={2}>P2 — high</option>
-                <option value={3}>P3 — normal</option>
-                <option value={4}>P4 — low</option>
-                <option value={5}>P5 — someday</option>
-              </select>
-            </Field>
+          <Field label="Run after (optional)">
+            <input
+              type="datetime-local"
+              value={scheduledFor}
+              onChange={(e) => setScheduledFor(e.target.value)}
+              style={inputStyle}
+            />
+          </Field>
+        </div>
+
+        <div style={{ display: "flex", gap: "20px", fontSize: "0.82rem", color: "var(--text-secondary)" }}>
+          <label style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={requiresApproval}
+              onChange={(e) => setRequiresApproval(e.target.checked)}
+            />
+            Requires approval before running
+          </label>
+          <label style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              checked={dryRun}
+              onChange={(e) => setDryRun(e.target.checked)}
+            />
+            Dry run (log only, no spawn)
+          </label>
+        </div>
+
+        {error && (
+          <div style={{ fontSize: "0.78rem", color: "var(--error)", padding: "8px 10px", background: "color-mix(in srgb, var(--error) 10%, transparent)", borderRadius: "4px" }}>
+            {error}
           </div>
+        )}
 
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
-            <Field label="Skill (optional)">
-              <input
-                type="text"
-                value={assignedSkill}
-                onChange={(e) => setAssignedSkill(e.target.value)}
-                placeholder="e.g. code-review"
-                style={inputStyle}
-              />
-            </Field>
-
-            <Field label="Model (optional)">
-              <input
-                type="text"
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                placeholder="e.g. claude-opus-4-7"
-                style={inputStyle}
-              />
-            </Field>
-          </div>
-
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
-            <Field label="Risk level">
-              <select value={riskLevel} onChange={(e) => setRiskLevel(e.target.value as RiskLevel)} style={selectStyle}>
-                <option value="low">Low</option>
-                <option value="medium">Medium</option>
-                <option value="high">High</option>
-              </select>
-            </Field>
-
-            <Field label="Run after (optional)">
-              <input
-                type="datetime-local"
-                value={scheduledFor}
-                onChange={(e) => setScheduledFor(e.target.value)}
-                style={inputStyle}
-              />
-            </Field>
-          </div>
-
-          <div style={{ display: "flex", gap: "20px", fontSize: "0.82rem", color: "var(--text-secondary)" }}>
-            <label style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" }}>
-              <input
-                type="checkbox"
-                checked={requiresApproval}
-                onChange={(e) => setRequiresApproval(e.target.checked)}
-              />
-              Requires approval before running
-            </label>
-            <label style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" }}>
-              <input
-                type="checkbox"
-                checked={dryRun}
-                onChange={(e) => setDryRun(e.target.checked)}
-              />
-              Dry run (log only, no spawn)
-            </label>
-          </div>
-
-          {error && (
-            <div style={{ fontSize: "0.78rem", color: "var(--error)", padding: "8px 10px", background: "color-mix(in srgb, var(--error) 10%, transparent)", borderRadius: "4px" }}>
-              {error}
-            </div>
-          )}
-
-          <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end", paddingTop: "4px" }}>
-            <button
-              type="button"
-              onClick={onClose}
-              style={{
-                padding: "7px 16px", fontSize: "0.8rem", borderRadius: "4px", cursor: "pointer",
-                background: "none", border: "1px solid var(--border)", color: "var(--text-secondary)",
-              }}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={submitting || !title.trim()}
-              style={{
-                padding: "7px 16px", fontSize: "0.8rem", borderRadius: "4px", cursor: submitting ? "not-allowed" : "pointer",
-                background: "var(--accent)", border: "none", color: "white", fontWeight: 600,
-                opacity: submitting || !title.trim() ? 0.6 : 1,
-              }}
-            >
-              {submitting ? "Creating…" : "Create task"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end", paddingTop: "4px" }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              padding: "7px 16px", fontSize: "0.8rem", borderRadius: "4px", cursor: "pointer",
+              background: "none", border: "1px solid var(--border)", color: "var(--text-secondary)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !title.trim()}
+            style={{
+              padding: "7px 16px", fontSize: "0.8rem", borderRadius: "4px", cursor: submitting ? "not-allowed" : "pointer",
+              background: "var(--accent)", border: "none", color: "white", fontWeight: 600,
+              opacity: submitting || !title.trim() ? 0.6 : 1,
+            }}
+          >
+            {submitting ? "Creating…" : "Create task"}
+          </button>
+        </div>
+      </form>
+    </Modal>
   );
 }

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import type { TaskQuadrant, RiskLevel } from "@/lib/tasks/types";
+
+interface TaskComposerProps {
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "6px 10px",
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: "4px",
+  fontSize: "0.82rem",
+  fontFamily: "var(--font-body)",
+  color: "var(--text-primary)",
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+const selectStyle: React.CSSProperties = { ...inputStyle, cursor: "pointer" };
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "0.7rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "var(--text-muted)",
+  marginBottom: "4px",
+};
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label style={labelStyle}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+export function TaskComposer({ onClose, onSuccess }: TaskComposerProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [quadrant, setQuadrant] = useState<TaskQuadrant>("do");
+  const [priority, setPriority] = useState(3);
+  const [assignedSkill, setAssignedSkill] = useState("");
+  const [model, setModel] = useState("");
+  const [riskLevel, setRiskLevel] = useState<RiskLevel>("low");
+  const [requiresApproval, setRequiresApproval] = useState(false);
+  const [dryRun, setDryRun] = useState(false);
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.SyntheticEvent) {
+    e.preventDefault();
+    if (!title.trim()) { setError("Title is required"); return; }
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const body: Record<string, unknown> = {
+        title: title.trim(),
+        execution_mode: "classic",
+      };
+      if (description.trim()) body.description = description.trim();
+      if (quadrant) body.quadrant = quadrant;
+      if (priority !== 3) body.priority = priority;
+      if (assignedSkill.trim()) body.assigned_skill = assignedSkill.trim();
+      if (model.trim()) body.model = model.trim();
+      if (riskLevel !== "low") body.risk_level = riskLevel;
+      if (requiresApproval) body.requires_approval = true;
+      if (dryRun) body.dry_run = true;
+      if (scheduledFor) body.scheduled_for = new Date(scheduledFor).toISOString();
+
+      const res = await fetch("/api/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? `Request failed (${res.status})`);
+        return;
+      }
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, zIndex: 9000,
+        background: "rgba(0,0,0,0.6)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        padding: "16px",
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        style={{
+          background: "var(--bg-card)",
+          border: "1px solid var(--border)",
+          borderRadius: "8px",
+          width: "100%",
+          maxWidth: "520px",
+          maxHeight: "90vh",
+          overflowY: "auto",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+            padding: "16px 20px",
+            borderBottom: "1px solid var(--border-subtle)",
+          }}
+        >
+          <span style={{ fontSize: "0.9rem", fontWeight: 600, color: "var(--text-primary)" }}>
+            New Task
+          </span>
+          <button
+            onClick={onClose}
+            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-muted)", padding: "2px" }}
+            aria-label="Close"
+          >
+            <X style={{ width: "16px", height: "16px" }} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} style={{ padding: "20px", display: "flex", flexDirection: "column", gap: "14px" }}>
+          <Field label="Title *">
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Describe the task for Claude…"
+              style={inputStyle}
+              autoFocus
+            />
+          </Field>
+
+          <Field label="Description">
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Additional context, constraints, or acceptance criteria…"
+              rows={3}
+              style={{ ...inputStyle, resize: "vertical" }}
+            />
+          </Field>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+            <Field label="Quadrant">
+              <select value={quadrant} onChange={(e) => setQuadrant(e.target.value as TaskQuadrant)} style={selectStyle}>
+                <option value="do">Do (urgent + important)</option>
+                <option value="schedule">Schedule (important)</option>
+                <option value="delegate">Delegate</option>
+                <option value="archive">Archive</option>
+              </select>
+            </Field>
+
+            <Field label="Priority">
+              <select value={priority} onChange={(e) => setPriority(Number(e.target.value))} style={selectStyle}>
+                <option value={1}>P1 — critical</option>
+                <option value={2}>P2 — high</option>
+                <option value={3}>P3 — normal</option>
+                <option value={4}>P4 — low</option>
+                <option value={5}>P5 — someday</option>
+              </select>
+            </Field>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+            <Field label="Skill (optional)">
+              <input
+                type="text"
+                value={assignedSkill}
+                onChange={(e) => setAssignedSkill(e.target.value)}
+                placeholder="e.g. code-review"
+                style={inputStyle}
+              />
+            </Field>
+
+            <Field label="Model (optional)">
+              <input
+                type="text"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="e.g. claude-opus-4-7"
+                style={inputStyle}
+              />
+            </Field>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+            <Field label="Risk level">
+              <select value={riskLevel} onChange={(e) => setRiskLevel(e.target.value as RiskLevel)} style={selectStyle}>
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
+            </Field>
+
+            <Field label="Run after (optional)">
+              <input
+                type="datetime-local"
+                value={scheduledFor}
+                onChange={(e) => setScheduledFor(e.target.value)}
+                style={inputStyle}
+              />
+            </Field>
+          </div>
+
+          <div style={{ display: "flex", gap: "20px", fontSize: "0.82rem", color: "var(--text-secondary)" }}>
+            <label style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={requiresApproval}
+                onChange={(e) => setRequiresApproval(e.target.checked)}
+              />
+              Requires approval before running
+            </label>
+            <label style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={dryRun}
+                onChange={(e) => setDryRun(e.target.checked)}
+              />
+              Dry run (log only, no spawn)
+            </label>
+          </div>
+
+          {error && (
+            <div style={{ fontSize: "0.78rem", color: "var(--error)", padding: "8px 10px", background: "color-mix(in srgb, var(--error) 10%, transparent)", borderRadius: "4px" }}>
+              {error}
+            </div>
+          )}
+
+          <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end", paddingTop: "4px" }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                padding: "7px 16px", fontSize: "0.8rem", borderRadius: "4px", cursor: "pointer",
+                background: "none", border: "1px solid var(--border)", color: "var(--text-secondary)",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !title.trim()}
+              style={{
+                padding: "7px 16px", fontSize: "0.8rem", borderRadius: "4px", cursor: submitting ? "not-allowed" : "pointer",
+                background: "var(--accent)", border: "none", color: "white", fontWeight: 600,
+                opacity: submitting || !title.trim() ? 0.6 : 1,
+              }}
+            >
+              {submitting ? "Creating…" : "Create task"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TasksBrowser.tsx
+++ b/src/components/TasksBrowser.tsx
@@ -414,15 +414,14 @@ export function TasksBrowser({ tasks, schedules, onRefresh }: Props) {
         </button>
       </div>
 
-      {composerOpen && (
-        <TaskComposer
-          onClose={() => setComposerOpen(false)}
-          onSuccess={() => {
-            setComposerOpen(false);
-            onRefresh?.();
-          }}
-        />
-      )}
+      <TaskComposer
+        open={composerOpen}
+        onClose={() => setComposerOpen(false)}
+        onSuccess={() => {
+          setComposerOpen(false);
+          onRefresh?.();
+        }}
+      />
 
       {/* Tasks list */}
       {tasks.length === 0 ? (

--- a/src/components/TasksBrowser.tsx
+++ b/src/components/TasksBrowser.tsx
@@ -12,9 +12,11 @@ import {
   Circle,
   XCircle,
   HelpCircle,
+  Plus,
 } from "lucide-react";
 import type { Task, Schedule, TaskStatus, TaskQuadrant } from "@/lib/tasks/types";
 import { TASK_STATUSES, TASK_QUADRANTS } from "@/lib/tasks/types";
+import { TaskComposer } from "./TaskComposer";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -286,14 +288,16 @@ const SELECT_STYLE: React.CSSProperties = {
 interface Props {
   tasks: Task[];
   schedules: Schedule[];
+  onRefresh?: () => void;
 }
 
-export function TasksBrowser({ tasks, schedules }: Props) {
+export function TasksBrowser({ tasks, schedules, onRefresh }: Props) {
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<TaskStatus | "">("");
   const [quadrantFilter, setQuadrantFilter] = useState<TaskQuadrant | "">("");
   const [sortKey, setSortKey] = useState<SortKey>("created_at");
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
+  const [composerOpen, setComposerOpen] = useState(false);
 
   const filtered = useMemo(() => {
     let result = tasks;
@@ -389,7 +393,36 @@ export function TasksBrowser({ tasks, schedules }: Props) {
         <span style={{ fontSize: "0.68rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
           {filtered.length} / {tasks.length}
         </span>
+
+        <button
+          onClick={() => setComposerOpen(true)}
+          style={{
+            display: "flex", alignItems: "center", gap: "5px",
+            padding: "5px 12px",
+            background: "var(--accent)",
+            border: "none",
+            borderRadius: "4px",
+            fontSize: "0.78rem",
+            fontWeight: 600,
+            color: "white",
+            cursor: "pointer",
+            marginLeft: "auto",
+          }}
+        >
+          <Plus style={{ width: "12px", height: "12px" }} />
+          New task
+        </button>
       </div>
+
+      {composerOpen && (
+        <TaskComposer
+          onClose={() => setComposerOpen(false)}
+          onSuccess={() => {
+            setComposerOpen(false);
+            onRefresh?.();
+          }}
+        />
+      )}
 
       {/* Tasks list */}
       {tasks.length === 0 ? (
@@ -397,7 +430,7 @@ export function TasksBrowser({ tasks, schedules }: Props) {
           <div style={{ fontSize: "2rem", marginBottom: "8px" }}>📋</div>
           <div style={{ fontWeight: 500, marginBottom: "4px" }}>No tasks yet</div>
           <div style={{ fontSize: "0.75rem" }}>
-            Tasks dispatched to Claude Code will appear here. The Task Composer and dispatcher loop ship in Wave 9.1b.
+            Create a task with "New task" — the dispatcher will pick it up and run it with Claude Code.
           </div>
         </div>
       ) : filtered.length === 0 ? (

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -133,10 +133,10 @@ export const FEATURE_FLAG_META: readonly FeatureFlagMeta[] = [
   {
     key: "taskDispatcher",
     label: "Task dispatcher",
-    description: "Dispatcher loop that spawns claude CLI child processes and tracks runs. Wired in Wave 9.1b.",
+    description: "Dispatcher loop that spawns claude CLI child processes and tracks runs (classic mode). Stream mode ships in Wave 9.1c.",
     group: "active",
     appliesAt: "ingest",
-    wired: false,
+    wired: true,
   },
 ];
 

--- a/src/lib/tasks/dispatcher.ts
+++ b/src/lib/tasks/dispatcher.ts
@@ -1,0 +1,119 @@
+import "server-only";
+import os from "os";
+import path from "path";
+import fs from "fs";
+import { claimPendingTask, materializeSchedules, promoteApprovalTasks, completeTask } from "./store";
+import { runClassicTask, sweepStalePids, type SpawnFn } from "./spawner";
+import type { Task } from "./types";
+
+const HEARTBEAT_PATH = path.join(os.homedir(), ".minder", "dispatcher-heartbeat.json");
+const TICK_INTERVAL_MS = 30_000;
+const MAX_CONCURRENT = 3;
+
+interface DispatcherHandle {
+  dispose: () => void;
+  getStats: () => DispatcherStats;
+}
+
+interface DispatcherStats {
+  running: number;
+  tickCount: number;
+  lastTickAt: string | null;
+  startedAt: string;
+}
+
+declare const globalThis: {
+  __minderDispatcher?: DispatcherHandle;
+} & typeof global;
+
+export function getDispatcherStats(): DispatcherStats | null {
+  return globalThis.__minderDispatcher?.getStats() ?? null;
+}
+
+export function isDispatcherRunning(): boolean {
+  return !!globalThis.__minderDispatcher;
+}
+
+/**
+ * Initialize the dispatcher singleton if not already running.
+ * Safe to call multiple times — no-ops if already initialized.
+ */
+export function initDispatcher(spawnFn?: SpawnFn): void {
+  if (globalThis.__minderDispatcher) return;
+
+  const startedAt = new Date().toISOString();
+  let tickCount = 0;
+  let lastTickAt: string | null = null;
+  const inFlight = new Map<number, Promise<void>>();
+
+  async function tick() {
+    lastTickAt = new Date().toISOString();
+    tickCount++;
+
+    writeHeartbeat(lastTickAt, inFlight.size);
+    sweepStalePids();
+
+    try {
+      await materializeSchedules();
+    } catch (err) {
+      console.error("[dispatcher] schedule materialization error:", err);
+    }
+
+    try {
+      await promoteApprovalTasks();
+    } catch (err) {
+      console.error("[dispatcher] promoteApprovalTasks error:", err);
+    }
+
+    while (inFlight.size < MAX_CONCURRENT) {
+      let task: Task | null = null;
+      try {
+        task = await claimPendingTask();
+      } catch (err) {
+        console.error("[dispatcher] claimPendingTask error:", err);
+        break;
+      }
+      if (!task) break;
+
+      if (task.dry_run) {
+        console.log(`[dispatcher] dry_run task ${task.id} "${task.title}" — skipping spawn`);
+        await completeTask(task.id, { output_summary: "dry-run: spawn skipped" }).catch(console.error);
+        continue;
+      }
+
+      const promise: Promise<void> = runClassicTask(task, spawnFn)
+        .then(() => { /* result already written to DB by completeTask/failTask */ })
+        .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
+        .finally(() => inFlight.delete(task!.id));
+
+      inFlight.set(task.id, promise);
+    }
+  }
+
+  const interval = setInterval(() => { tick().catch(console.error); }, TICK_INTERVAL_MS);
+  // Run first tick after a short delay so the server is fully initialized
+  setTimeout(() => { tick().catch(console.error); }, 2_000);
+
+  globalThis.__minderDispatcher = {
+    dispose() {
+      clearInterval(interval);
+      globalThis.__minderDispatcher = undefined;
+    },
+    getStats() {
+      return { running: inFlight.size, tickCount, lastTickAt, startedAt };
+    },
+  };
+}
+
+function writeHeartbeat(lastTickAt: string, running: number) {
+  try {
+    fs.mkdirSync(path.dirname(HEARTBEAT_PATH), { recursive: true });
+    fs.writeFileSync(
+      HEARTBEAT_PATH,
+      JSON.stringify({ lastTickAt, running, pid: process.pid }),
+      "utf8"
+    );
+  } catch {
+    // Non-fatal
+  }
+}

--- a/src/lib/tasks/dispatcher.ts
+++ b/src/lib/tasks/dispatcher.ts
@@ -22,16 +22,14 @@ interface DispatcherStats {
   startedAt: string;
 }
 
-declare const globalThis: {
-  __minderDispatcher?: DispatcherHandle;
-} & typeof global;
+const g = globalThis as unknown as { __minderDispatcher?: DispatcherHandle };
 
 export function getDispatcherStats(): DispatcherStats | null {
-  return globalThis.__minderDispatcher?.getStats() ?? null;
+  return g.__minderDispatcher?.getStats() ?? null;
 }
 
 export function isDispatcherRunning(): boolean {
-  return !!globalThis.__minderDispatcher;
+  return !!g.__minderDispatcher;
 }
 
 /**
@@ -39,67 +37,74 @@ export function isDispatcherRunning(): boolean {
  * Safe to call multiple times — no-ops if already initialized.
  */
 export function initDispatcher(spawnFn?: SpawnFn): void {
-  if (globalThis.__minderDispatcher) return;
+  if (g.__minderDispatcher) return;
 
   try { fs.mkdirSync(path.dirname(HEARTBEAT_PATH), { recursive: true }); } catch { /* non-fatal */ }
 
   const startedAt = new Date().toISOString();
   let tickCount = 0;
   let lastTickAt: string | null = null;
+  let tickInProgress = false;
   const inFlight = new Map<number, Promise<void>>();
 
   async function tick() {
-    lastTickAt = new Date().toISOString();
-    tickCount++;
-
-    writeHeartbeat(lastTickAt, inFlight.size);
-    sweepStalePids();
-
+    if (tickInProgress) return;
+    tickInProgress = true;
     try {
-      await materializeSchedules();
-    } catch (err) {
-      console.error("[dispatcher] schedule materialization error:", err);
-    }
+      lastTickAt = new Date().toISOString();
+      tickCount++;
 
-    try {
-      await promoteApprovalTasks();
-    } catch (err) {
-      console.error("[dispatcher] promoteApprovalTasks error:", err);
-    }
+      writeHeartbeat(lastTickAt, inFlight.size);
+      sweepStalePids();
 
-    while (inFlight.size < MAX_CONCURRENT) {
-      let task: Task | null = null;
       try {
-        task = await claimPendingTask();
+        await materializeSchedules();
       } catch (err) {
-        console.error("[dispatcher] claimPendingTask error:", err);
-        break;
-      }
-      if (!task) break;
-
-      if (task.dry_run) {
-        console.log(`[dispatcher] dry_run task ${task.id} "${task.title}" — skipping spawn`);
-        await completeTask(task.id, { output_summary: "dry-run: spawn skipped" }).catch(console.error);
-        continue;
+        console.error("[dispatcher] schedule materialization error:", err);
       }
 
-      const promise: Promise<void> = runClassicTask(task, spawnFn)
-        .then(() => {})
-        .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
-        .finally(() => inFlight.delete(task!.id));
+      try {
+        await promoteApprovalTasks();
+      } catch (err) {
+        console.error("[dispatcher] promoteApprovalTasks error:", err);
+      }
 
-      inFlight.set(task.id, promise);
+      while (inFlight.size < MAX_CONCURRENT) {
+        let task: Task | null = null;
+        try {
+          task = await claimPendingTask();
+        } catch (err) {
+          console.error("[dispatcher] claimPendingTask error:", err);
+          break;
+        }
+        if (!task) break;
+
+        if (task.dry_run) {
+          console.log(`[dispatcher] dry_run task ${task.id} "${task.title}" — skipping spawn`);
+          await completeTask(task.id, { output_summary: "dry-run: spawn skipped" }).catch(console.error);
+          continue;
+        }
+
+        const promise: Promise<void> = runClassicTask(task, spawnFn)
+          .then(() => {})
+          .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
+          .finally(() => inFlight.delete(task!.id));
+
+        inFlight.set(task.id, promise);
+      }
+    } finally {
+      tickInProgress = false;
     }
   }
 
   const interval = setInterval(() => { tick().catch(console.error); }, TICK_INTERVAL_MS);
-  // Run first tick after a short delay so the server is fully initialized
-  setTimeout(() => { tick().catch(console.error); }, 2_000);
+  const initialTimeout = setTimeout(() => { tick().catch(console.error); }, 2_000);
 
-  globalThis.__minderDispatcher = {
+  g.__minderDispatcher = {
     dispose() {
       clearInterval(interval);
-      globalThis.__minderDispatcher = undefined;
+      clearTimeout(initialTimeout);
+      g.__minderDispatcher = undefined;
     },
     getStats() {
       return { running: inFlight.size, tickCount, lastTickAt, startedAt };

--- a/src/lib/tasks/dispatcher.ts
+++ b/src/lib/tasks/dispatcher.ts
@@ -41,6 +41,8 @@ export function isDispatcherRunning(): boolean {
 export function initDispatcher(spawnFn?: SpawnFn): void {
   if (globalThis.__minderDispatcher) return;
 
+  try { fs.mkdirSync(path.dirname(HEARTBEAT_PATH), { recursive: true }); } catch { /* non-fatal */ }
+
   const startedAt = new Date().toISOString();
   let tickCount = 0;
   let lastTickAt: string | null = null;
@@ -82,7 +84,7 @@ export function initDispatcher(spawnFn?: SpawnFn): void {
       }
 
       const promise: Promise<void> = runClassicTask(task, spawnFn)
-        .then(() => { /* result already written to DB by completeTask/failTask */ })
+        .then(() => {})
         .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
         .finally(() => inFlight.delete(task!.id));
 
@@ -107,7 +109,6 @@ export function initDispatcher(spawnFn?: SpawnFn): void {
 
 function writeHeartbeat(lastTickAt: string, running: number) {
   try {
-    fs.mkdirSync(path.dirname(HEARTBEAT_PATH), { recursive: true });
     fs.writeFileSync(
       HEARTBEAT_PATH,
       JSON.stringify({ lastTickAt, running, pid: process.pid }),

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -9,6 +9,8 @@ import { isWindows } from "../platform";
 
 const PID_DIR = path.join(os.homedir(), ".minder", "pids");
 
+try { fs.mkdirSync(PID_DIR, { recursive: true }); } catch { /* non-fatal */ }
+
 export type SpawnFn = typeof spawn;
 
 function ensurePidDir() {
@@ -38,7 +40,6 @@ function deletePidFile(pid: number) {
  */
 export function sweepStalePids(): void {
   try {
-    ensurePidDir();
     const files = fs.readdirSync(PID_DIR);
     for (const f of files) {
       const pid = parseInt(f, 10);
@@ -60,7 +61,6 @@ export function sweepStalePids(): void {
 /** List PIDs currently tracked in PID_DIR. Used by emergency stop (Wave 9.2). */
 export function listTrackedPids(): number[] {
   try {
-    ensurePidDir();
     return fs
       .readdirSync(PID_DIR)
       .map((f) => parseInt(f, 10))

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -116,9 +116,11 @@ export async function runClassicTask(
 
     let stdout = "";
     let stderr = "";
+    const STDOUT_CAP = 50_000;
+    const STDERR_CAP = 10_000;
 
-    child.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
-    child.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.stdout?.on("data", (chunk: Buffer) => { if (stdout.length < STDOUT_CAP) stdout += chunk.toString(); });
+    child.stderr?.on("data", (chunk: Buffer) => { if (stderr.length < STDERR_CAP) stderr += chunk.toString(); });
 
     child.on("close", async (code) => {
       if (pid) deletePidFile(pid);
@@ -126,14 +128,22 @@ export async function runClassicTask(
 
       if (code === 0) {
         const trimmed = stdout.trim();
-        await completeTask(task.id, {
-          output_summary: trimmed.slice(0, 4000) || undefined,
-          duration_ms: durationMs,
-        });
+        try {
+          await completeTask(task.id, {
+            output_summary: trimmed.slice(0, 4000) || undefined,
+            duration_ms: durationMs,
+          });
+        } catch (err) {
+          console.error(`[spawner] completeTask failed for task ${task.id}:`, err);
+        }
         resolve({ taskId: task.id, status: "done", output: trimmed, durationMs });
       } else {
         const errMsg = stderr.trim() || `claude exited with code ${code}`;
-        await failTask(task.id, { error_message: errMsg.slice(0, 2000), duration_ms: durationMs });
+        try {
+          await failTask(task.id, { error_message: errMsg.slice(0, 2000), duration_ms: durationMs });
+        } catch (err) {
+          console.error(`[spawner] failTask failed for task ${task.id}:`, err);
+        }
         resolve({ taskId: task.id, status: "failed", error: errMsg, durationMs });
       }
     });
@@ -141,7 +151,11 @@ export async function runClassicTask(
     child.on("error", async (err) => {
       if (pid) deletePidFile(pid);
       const durationMs = Date.now() - startMs;
-      await failTask(task.id, { error_message: err.message.slice(0, 2000), duration_ms: durationMs });
+      try {
+        await failTask(task.id, { error_message: err.message.slice(0, 2000), duration_ms: durationMs });
+      } catch (storeErr) {
+        console.error(`[spawner] failTask failed for task ${task.id}:`, storeErr);
+      }
       resolve({ taskId: task.id, status: "failed", error: err.message, durationMs });
     });
   });

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -1,0 +1,148 @@
+import "server-only";
+import { spawn } from "child_process";
+import os from "os";
+import path from "path";
+import fs from "fs";
+import type { Task } from "./types";
+import { completeTask, failTask } from "./store";
+import { isWindows } from "../platform";
+
+const PID_DIR = path.join(os.homedir(), ".minder", "pids");
+
+export type SpawnFn = typeof spawn;
+
+function ensurePidDir() {
+  fs.mkdirSync(PID_DIR, { recursive: true });
+}
+
+function writePidFile(pid: number) {
+  try {
+    ensurePidDir();
+    fs.writeFileSync(path.join(PID_DIR, String(pid)), String(pid), "utf8");
+  } catch {
+    // Non-fatal — PID files are best-effort for emergency stop
+  }
+}
+
+function deletePidFile(pid: number) {
+  try {
+    fs.unlinkSync(path.join(PID_DIR, String(pid)));
+  } catch {
+    // Already gone — ignore
+  }
+}
+
+/**
+ * Scan PID_DIR and unlink files for processes that are no longer alive.
+ * Called at the start of each dispatcher tick.
+ */
+export function sweepStalePids(): void {
+  try {
+    ensurePidDir();
+    const files = fs.readdirSync(PID_DIR);
+    for (const f of files) {
+      const pid = parseInt(f, 10);
+      if (!Number.isFinite(pid) || pid <= 0) {
+        fs.unlinkSync(path.join(PID_DIR, f));
+        continue;
+      }
+      try {
+        process.kill(pid, 0); // throws ESRCH if dead (works on Windows + Unix)
+      } catch {
+        fs.unlinkSync(path.join(PID_DIR, f));
+      }
+    }
+  } catch {
+    // PID dir unreadable — ignore
+  }
+}
+
+/** List PIDs currently tracked in PID_DIR. Used by emergency stop (Wave 9.2). */
+export function listTrackedPids(): number[] {
+  try {
+    ensurePidDir();
+    return fs
+      .readdirSync(PID_DIR)
+      .map((f) => parseInt(f, 10))
+      .filter((n) => Number.isFinite(n) && n > 0);
+  } catch {
+    return [];
+  }
+}
+
+export interface RunTaskResult {
+  taskId: number;
+  status: "done" | "failed";
+  output?: string;
+  error?: string;
+  durationMs: number;
+}
+
+/**
+ * Spawn `claude -p "<prompt>"` for the task (classic mode).
+ * Writes a PID marker file while the child is alive.
+ * Updates the task row on completion via completeTask() / failTask().
+ */
+export async function runClassicTask(
+  task: Task,
+  spawnFn: SpawnFn = spawn
+): Promise<RunTaskResult> {
+  const startMs = Date.now();
+  const prompt = [task.title, task.description].filter(Boolean).join("\n\n");
+
+  const spawnArgs = ["-p", prompt, "--output-format", "text"];
+  if (task.assigned_skill) {
+    spawnArgs.push("--allowedTools", `mcp__skills__${task.assigned_skill}`);
+  }
+  if (task.model) {
+    spawnArgs.push("--model", task.model);
+  }
+
+  const opts = {
+    stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+    env: { ...process.env, MINDER_DISPATCHED: "1" },
+  };
+
+  // On Windows, `claude` is a .cmd file; must invoke via cmd.exe
+  const [cmd, extraArgs]: [string, string[]] = isWindows
+    ? ["cmd.exe", ["/c", "claude", ...spawnArgs]]
+    : ["claude", spawnArgs];
+
+  return new Promise<RunTaskResult>((resolve) => {
+    const child = spawnFn(cmd, extraArgs, opts);
+    const pid = child.pid;
+
+    if (pid) writePidFile(pid);
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    child.on("close", async (code) => {
+      if (pid) deletePidFile(pid);
+      const durationMs = Date.now() - startMs;
+
+      if (code === 0) {
+        const trimmed = stdout.trim();
+        await completeTask(task.id, {
+          output_summary: trimmed.slice(0, 4000) || undefined,
+          duration_ms: durationMs,
+        });
+        resolve({ taskId: task.id, status: "done", output: trimmed, durationMs });
+      } else {
+        const errMsg = stderr.trim() || `claude exited with code ${code}`;
+        await failTask(task.id, { error_message: errMsg.slice(0, 2000), duration_ms: durationMs });
+        resolve({ taskId: task.id, status: "failed", error: errMsg, durationMs });
+      }
+    });
+
+    child.on("error", async (err) => {
+      if (pid) deletePidFile(pid);
+      const durationMs = Date.now() - startMs;
+      await failTask(task.id, { error_message: err.message.slice(0, 2000), duration_ms: durationMs });
+      resolve({ taskId: task.id, status: "failed", error: err.message, durationMs });
+    });
+  });
+}

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -128,11 +128,9 @@ export async function deleteTask(id: number): Promise<boolean> {
 }
 
 /**
- * Atomically claim the next pending task for the dispatcher.
- * Uses UPDATE...WHERE status='pending' to prevent race conditions.
- * Returns the claimed task or null if no pending tasks exist.
- * Used by Wave 9.1b dispatcher — exported here so the schema round-trips
- * can be tested independently of the dispatcher singleton.
+ * Atomically claim the next pending task that does NOT require approval.
+ * Tasks with requires_approval=1 are promoted to awaiting_approval instead.
+ * Returns the claimed (now running) task, or null if no eligible tasks exist.
  */
 export async function claimPendingTask(): Promise<Task | null> {
   const db = await ensureReady();
@@ -143,6 +141,7 @@ export async function claimPendingTask(): Promise<Task | null> {
      WHERE id = (
        SELECT id FROM ops_tasks
        WHERE status = 'pending'
+         AND requires_approval = 0
          AND (scheduled_for IS NULL OR scheduled_for <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
        ORDER BY priority ASC, created_at ASC
        LIMIT 1
@@ -150,6 +149,23 @@ export async function claimPendingTask(): Promise<Task | null> {
      RETURNING *`
   ).get() as Task | undefined;
   return row ?? null;
+}
+
+/**
+ * Promote tasks with requires_approval=1 from pending → awaiting_approval.
+ * Called on each dispatcher tick before claiming runnable tasks.
+ * Returns the number of tasks promoted.
+ */
+export async function promoteApprovalTasks(): Promise<number> {
+  const db = await ensureReady();
+  const result = db.prepare(
+    `UPDATE ops_tasks
+     SET status = 'awaiting_approval'
+     WHERE status = 'pending'
+       AND requires_approval = 1
+       AND (scheduled_for IS NULL OR scheduled_for <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`
+  ).run();
+  return result.changes;
 }
 
 // ---------------------------------------------------------------------------
@@ -235,4 +251,137 @@ export async function deleteSchedule(id: number): Promise<boolean> {
     "DELETE FROM ops_schedules WHERE id = ?"
   ).run(id);
   return result.changes > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher lifecycle helpers
+// ---------------------------------------------------------------------------
+
+/** Mark awaiting_approval → pending; set approved_at. Returns null if task not found or wrong status. */
+export async function approveTask(id: number): Promise<Task | null> {
+  const db = await ensureReady();
+  const row = db.prepare(
+    `UPDATE ops_tasks
+     SET status = 'pending', approved_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+     WHERE id = ? AND status = 'awaiting_approval'
+     RETURNING *`
+  ).get(id) as Task | undefined;
+  return row ?? null;
+}
+
+/** Reset failed task to pending; clear all output fields. Returns null if task not found or wrong status. */
+export async function rerunTask(id: number): Promise<Task | null> {
+  const db = await ensureReady();
+  const row = db.prepare(
+    `UPDATE ops_tasks
+     SET status = 'pending',
+         error_message = NULL,
+         started_at = NULL,
+         completed_at = NULL,
+         duration_ms = NULL,
+         cost_usd = NULL,
+         output_summary = NULL,
+         session_id = NULL
+     WHERE id = ? AND status = 'failed'
+     RETURNING *`
+  ).get(id) as Task | undefined;
+  return row ?? null;
+}
+
+export interface CompleteTaskInput {
+  output_summary?: string;
+  duration_ms?: number;
+  cost_usd?: number;
+  session_id?: string;
+}
+
+/** Mark a running task as done with captured output. */
+export async function completeTask(id: number, result: CompleteTaskInput): Promise<Task | null> {
+  const db = await ensureReady();
+  const row = db.prepare(
+    `UPDATE ops_tasks
+     SET status = 'done',
+         completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+         consecutive_failures = 0,
+         output_summary = ?,
+         duration_ms = ?,
+         cost_usd = ?,
+         session_id = ?
+     WHERE id = ? AND status = 'running'
+     RETURNING *`
+  ).get(
+    result.output_summary ?? null,
+    result.duration_ms ?? null,
+    result.cost_usd ?? null,
+    result.session_id ?? null,
+    id
+  ) as Task | undefined;
+  return row ?? null;
+}
+
+export interface FailTaskInput {
+  error_message?: string;
+  duration_ms?: number;
+}
+
+/** Mark a running task as failed. Increments consecutive_failures. */
+export async function failTask(id: number, info: FailTaskInput): Promise<Task | null> {
+  const db = await ensureReady();
+  const row = db.prepare(
+    `UPDATE ops_tasks
+     SET status = 'failed',
+         completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+         consecutive_failures = consecutive_failures + 1,
+         error_message = ?,
+         duration_ms = ?
+     WHERE id = ? AND status = 'running'
+     RETURNING *`
+  ).get(
+    info.error_message ?? null,
+    info.duration_ms ?? null,
+    id
+  ) as Task | undefined;
+  return row ?? null;
+}
+
+/**
+ * Materialize due schedules into ops_tasks rows.
+ * Wrapped in BEGIN IMMEDIATE to prevent double-materialization across concurrent ticks.
+ * Returns the number of tasks created.
+ */
+export async function materializeSchedules(): Promise<number> {
+  const db = await ensureReady();
+  const now = new Date().toISOString();
+
+  const insertScheduleTask = db.prepare(
+    `INSERT INTO ops_tasks (title, description, assigned_skill, schedule_id)
+     VALUES (?, ?, ?, ?)`
+  );
+  const updateNextRun = db.prepare(
+    `UPDATE ops_schedules SET last_run_at = ?, next_run_at = ? WHERE id = ?`
+  );
+  const selectDue = db.prepare(
+    `SELECT * FROM ops_schedules
+     WHERE enabled = 1
+       AND (next_run_at IS NULL OR next_run_at <= ?)
+     ORDER BY next_run_at ASC`
+  );
+
+  let count = 0;
+  const txn = db.transaction(() => {
+    const due = selectDue.all(now) as Schedule[];
+    for (const sched of due) {
+      insertScheduleTask.run(
+        sched.task_title,
+        sched.task_description ?? "",
+        sched.assigned_skill ?? null,
+        sched.id
+      );
+      const next = computeNextRun(sched.cron_expression);
+      updateNextRun.run(now, next ? next.toISOString() : null, sched.id);
+      count++;
+    }
+  });
+  txn();
+  return count;
 }

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -83,7 +83,7 @@ export async function createTask(input: CreateTaskInput): Promise<Task> {
     input.quadrant ?? "do",
     input.assigned_skill ?? null,
     input.model ?? null,
-    input.execution_mode ?? "stream",
+    input.execution_mode ?? "classic",
     input.scheduled_for ?? null,
     input.requires_approval ? 1 : 0,
     input.risk_level ?? "low",
@@ -158,11 +158,13 @@ export async function claimPendingTask(): Promise<Task | null> {
  */
 export async function promoteApprovalTasks(): Promise<number> {
   const db = await ensureReady();
-  const result = db.prepare(
+  const result = prepTasksCached(
+    db,
     `UPDATE ops_tasks
      SET status = 'awaiting_approval'
      WHERE status = 'pending'
        AND requires_approval = 1
+       AND approved_at IS NULL
        AND (scheduled_for IS NULL OR scheduled_for <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`
   ).run();
   return result.changes;
@@ -257,12 +259,15 @@ export async function deleteSchedule(id: number): Promise<boolean> {
 // Dispatcher lifecycle helpers
 // ---------------------------------------------------------------------------
 
-/** Mark awaiting_approval → pending; set approved_at. Returns null if task not found or wrong status. */
+/** Mark awaiting_approval → pending; set approved_at and clear requires_approval so dispatcher can claim it. */
 export async function approveTask(id: number): Promise<Task | null> {
   const db = await ensureReady();
-  const row = db.prepare(
+  const row = prepTasksCached(
+    db,
     `UPDATE ops_tasks
-     SET status = 'pending', approved_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+     SET status = 'pending',
+         approved_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+         requires_approval = 0
      WHERE id = ? AND status = 'awaiting_approval'
      RETURNING *`
   ).get(id) as Task | undefined;
@@ -272,7 +277,8 @@ export async function approveTask(id: number): Promise<Task | null> {
 /** Reset failed task to pending; clear all output fields. Returns null if task not found or wrong status. */
 export async function rerunTask(id: number): Promise<Task | null> {
   const db = await ensureReady();
-  const row = db.prepare(
+  const row = prepTasksCached(
+    db,
     `UPDATE ops_tasks
      SET status = 'pending',
          error_message = NULL,
@@ -298,7 +304,8 @@ export interface CompleteTaskInput {
 /** Mark a running task as done with captured output. */
 export async function completeTask(id: number, result: CompleteTaskInput): Promise<Task | null> {
   const db = await ensureReady();
-  const row = db.prepare(
+  const row = prepTasksCached(
+    db,
     `UPDATE ops_tasks
      SET status = 'done',
          completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
@@ -327,7 +334,8 @@ export interface FailTaskInput {
 /** Mark a running task as failed. Increments consecutive_failures. */
 export async function failTask(id: number, info: FailTaskInput): Promise<Task | null> {
   const db = await ensureReady();
-  const row = db.prepare(
+  const row = prepTasksCached(
+    db,
     `UPDATE ops_tasks
      SET status = 'failed',
          completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -346,7 +346,7 @@ export async function failTask(id: number, info: FailTaskInput): Promise<Task | 
 
 /**
  * Materialize due schedules into ops_tasks rows.
- * Wrapped in BEGIN IMMEDIATE to prevent double-materialization across concurrent ticks.
+ * Wrapped in a serialized transaction (DEFERRED) — safe because the dispatcher is single-threaded JS.
  * Returns the number of tasks created.
  */
 export async function materializeSchedules(): Promise<number> {

--- a/tests/tasksDispatcher.test.ts
+++ b/tests/tasksDispatcher.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("fs", () => ({
+  default: {
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+    readdirSync: vi.fn(() => []),
+  },
+}));
+
+// Mock store functions the dispatcher calls
+vi.mock("../src/lib/tasks/store", () => ({
+  claimPendingTask: vi.fn().mockResolvedValue(null),
+  materializeSchedules: vi.fn().mockResolvedValue(0),
+  promoteApprovalTasks: vi.fn().mockResolvedValue(0),
+}));
+
+// Mock spawner
+vi.mock("../src/lib/tasks/spawner", () => ({
+  sweepStalePids: vi.fn(),
+  runClassicTask: vi.fn().mockResolvedValue({ taskId: 1, status: "done", durationMs: 100 }),
+}));
+
+import { initDispatcher, isDispatcherRunning, getDispatcherStats } from "../src/lib/tasks/dispatcher";
+import { claimPendingTask, materializeSchedules, promoteApprovalTasks } from "../src/lib/tasks/store";
+import { sweepStalePids } from "../src/lib/tasks/spawner";
+
+// Patch globalThis between tests
+function cleanupDispatcher() {
+  const g = globalThis as Record<string, unknown>;
+  if (g.__minderDispatcher && typeof (g.__minderDispatcher as { dispose?: () => void }).dispose === "function") {
+    (g.__minderDispatcher as { dispose: () => void }).dispose();
+  }
+  delete g.__minderDispatcher;
+}
+
+describe("dispatcher singleton", () => {
+  beforeEach(() => {
+    cleanupDispatcher();
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanupDispatcher();
+    vi.useRealTimers();
+  });
+
+  it("initializes when not running", () => {
+    expect(isDispatcherRunning()).toBe(false);
+    initDispatcher();
+    expect(isDispatcherRunning()).toBe(true);
+  });
+
+  it("is idempotent — second init call is a no-op", () => {
+    initDispatcher();
+    initDispatcher();
+    expect(isDispatcherRunning()).toBe(true);
+    const stats = getDispatcherStats();
+    // Only one dispatcher should exist
+    expect(stats).not.toBeNull();
+  });
+
+  it("dispose() stops the dispatcher", () => {
+    initDispatcher();
+    expect(isDispatcherRunning()).toBe(true);
+    cleanupDispatcher();
+    expect(isDispatcherRunning()).toBe(false);
+  });
+
+  it("first tick fires after 2s delay", async () => {
+    initDispatcher();
+    expect(materializeSchedules).not.toHaveBeenCalled();
+
+    // Fast-forward past the 2s initial delay
+    await vi.advanceTimersByTimeAsync(2_100);
+    expect(materializeSchedules).toHaveBeenCalledOnce();
+    expect(promoteApprovalTasks).toHaveBeenCalledOnce();
+    expect(sweepStalePids).toHaveBeenCalledOnce();
+  });
+
+  it("subsequent ticks fire every 30s", async () => {
+    initDispatcher();
+    await vi.advanceTimersByTimeAsync(2_100); // first tick
+    vi.clearAllMocks();
+    await vi.advanceTimersByTimeAsync(30_000); // second tick
+    expect(materializeSchedules).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(30_000); // third tick
+    expect(materializeSchedules).toHaveBeenCalledTimes(2);
+  });
+
+  it("claims and runs eligible pending tasks on tick", async () => {
+    const { runClassicTask } = await import("../src/lib/tasks/spawner");
+    const mockTask = {
+      id: 5, title: "x", description: "", status: "running", priority: 3, quadrant: "do",
+      assigned_skill: null, model: null, execution_mode: "classic", scheduled_for: null,
+      requires_approval: 0, risk_level: "low", dry_run: 0, schedule_id: null,
+      approved_at: null, session_id: null, started_at: null, completed_at: null,
+      duration_ms: null, cost_usd: null, output_summary: null, error_message: null,
+      consecutive_failures: 0, created_at: new Date().toISOString(),
+    };
+
+    vi.mocked(claimPendingTask).mockResolvedValueOnce(mockTask as never).mockResolvedValue(null);
+
+    initDispatcher();
+    await vi.advanceTimersByTimeAsync(2_100);
+    // Let microtask queue drain so in-flight promises resolve
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(runClassicTask).toHaveBeenCalledWith(mockTask, undefined);
+  });
+
+  it("skips dry_run tasks without spawning", async () => {
+    const { runClassicTask } = await import("../src/lib/tasks/spawner");
+    const dryRunTask = {
+      id: 6, title: "dry", description: "", status: "running", priority: 3, quadrant: "do",
+      assigned_skill: null, model: null, execution_mode: "classic", scheduled_for: null,
+      requires_approval: 0, risk_level: "low", dry_run: 1, schedule_id: null,
+      approved_at: null, session_id: null, started_at: null, completed_at: null,
+      duration_ms: null, cost_usd: null, output_summary: null, error_message: null,
+      consecutive_failures: 0, created_at: new Date().toISOString(),
+    };
+
+    vi.mocked(claimPendingTask).mockResolvedValueOnce(dryRunTask as never).mockResolvedValue(null);
+
+    initDispatcher();
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    expect(runClassicTask).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tasksSpawner.test.ts
+++ b/tests/tasksSpawner.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+
+// Mock server-only and filesystem before importing spawner
+vi.mock("server-only", () => ({}));
+vi.mock("fs", () => {
+  const files = new Map<string, string>();
+  return {
+    default: {
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn((p: string, v: string) => files.set(p, v)),
+      unlinkSync: vi.fn((p: string) => files.delete(p)),
+      readdirSync: vi.fn((): string[] => [...files.keys()].map((k) => k.split("/").pop()!)),
+    },
+  };
+});
+vi.mock("../src/lib/platform", () => ({ isWindows: false }));
+vi.mock("../src/lib/tasks/store", () => ({
+  completeTask: vi.fn().mockResolvedValue(null),
+  failTask: vi.fn().mockResolvedValue(null),
+}));
+
+import { runClassicTask, sweepStalePids } from "../src/lib/tasks/spawner";
+import { completeTask, failTask } from "../src/lib/tasks/store";
+import type { Task } from "../src/lib/tasks/types";
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 1,
+    title: "Test task",
+    description: "do something",
+    status: "running",
+    priority: 3,
+    quadrant: "do",
+    assigned_skill: null,
+    model: null,
+    execution_mode: "classic",
+    scheduled_for: null,
+    requires_approval: 0,
+    risk_level: "low",
+    dry_run: 0,
+    schedule_id: null,
+    approved_at: null,
+    session_id: null,
+    started_at: null,
+    completed_at: null,
+    duration_ms: null,
+    cost_usd: null,
+    output_summary: null,
+    error_message: null,
+    consecutive_failures: 0,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeChildProcess(pid = 1234): {
+  proc: Partial<ChildProcess>;
+  emitOutput: (data: string) => void;
+  emitError: (err: Error) => void;
+  emitClose: (code: number) => void;
+} {
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  const procEmitter = new EventEmitter();
+  const proc: Partial<ChildProcess> = {
+    pid,
+    stdout: stdoutEmitter as unknown as NodeJS.ReadableStream,
+    stderr: stderrEmitter as unknown as NodeJS.ReadableStream,
+    on: procEmitter.on.bind(procEmitter) as ChildProcess["on"],
+  } as Partial<ChildProcess>;
+
+  return {
+    proc,
+    emitOutput: (data) => stdoutEmitter.emit("data", Buffer.from(data)),
+    emitError: (err) => procEmitter.emit("error", err),
+    emitClose: (code) => procEmitter.emit("close", code),
+  };
+}
+
+describe("runClassicTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls completeTask on exit code 0", async () => {
+    const { proc, emitOutput, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 42 });
+    const promise = runClassicTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitOutput("Task complete: all done");
+    emitClose(0);
+
+    const result = await promise;
+    expect(result.status).toBe("done");
+    expect(result.taskId).toBe(42);
+    expect(completeTask).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ output_summary: "Task complete: all done" })
+    );
+  });
+
+  it("calls failTask on non-zero exit code", async () => {
+    const { proc, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 7 });
+    const promise = runClassicTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitClose(1);
+
+    const result = await promise;
+    expect(result.status).toBe("failed");
+    expect(failTask).toHaveBeenCalledWith(7, expect.objectContaining({ error_message: expect.any(String) }));
+  });
+
+  it("calls failTask on spawn error", async () => {
+    const { proc, emitError } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 99 });
+    const promise = runClassicTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitError(new Error("ENOENT: claude not found"));
+
+    const result = await promise;
+    expect(result.status).toBe("failed");
+    expect(failTask).toHaveBeenCalledWith(99, expect.objectContaining({ error_message: "ENOENT: claude not found" }));
+  });
+
+  it("passes model to spawn args when set", async () => {
+    const { proc, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ model: "claude-haiku-4-5" });
+    const promise = runClassicTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitClose(0);
+    await promise;
+
+    const [, args] = spawnFn.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--model");
+    expect(args).toContain("claude-haiku-4-5");
+  });
+});
+
+describe("sweepStalePids", () => {
+  it("runs without throwing", () => {
+    expect(() => sweepStalePids()).not.toThrow();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+});

--- a/tests/tasksStore.test.ts
+++ b/tests/tasksStore.test.ts
@@ -212,4 +212,115 @@ describe.skipIf(!Database)("tasksStore CRUD", () => {
   it("deleteSchedule returns false for unknown id", async () => {
     expect(await store.deleteSchedule(99999)).toBe(false);
   });
+
+  // -------------------------------------------------------------------------
+  // Dispatcher lifecycle helpers
+  // -------------------------------------------------------------------------
+
+  it("approveTask transitions awaiting_approval → pending and sets approved_at", async () => {
+    const t = await store.createTask({ title: "Needs approval", requires_approval: true });
+    // Manually set to awaiting_approval (simulating dispatcher promotion)
+    await store.patchTask(t.id, { status: "awaiting_approval" });
+
+    const approved = await store.approveTask(t.id);
+    expect(approved).not.toBeNull();
+    expect(approved!.status).toBe("pending");
+    expect(approved!.approved_at).toBeTruthy();
+  });
+
+  it("approveTask returns null when task is not awaiting_approval", async () => {
+    const t = await store.createTask({ title: "Still pending" });
+    const result = await store.approveTask(t.id);
+    expect(result).toBeNull(); // pending ≠ awaiting_approval
+  });
+
+  it("rerunTask transitions failed → pending and clears output fields", async () => {
+    const t = await store.createTask({ title: "Will fail" });
+    // Simulate running then failing
+    await store.patchTask(t.id, { status: "running" });
+    await store.failTask(t.id, { error_message: "Some error", duration_ms: 500 });
+
+    const rerun = await store.rerunTask(t.id);
+    expect(rerun).not.toBeNull();
+    expect(rerun!.status).toBe("pending");
+    expect(rerun!.error_message).toBeNull();
+    expect(rerun!.started_at).toBeNull();
+    expect(rerun!.completed_at).toBeNull();
+    expect(rerun!.duration_ms).toBeNull();
+  });
+
+  it("rerunTask returns null when task is not failed", async () => {
+    const t = await store.createTask({ title: "Pending task" });
+    expect(await store.rerunTask(t.id)).toBeNull();
+  });
+
+  it("completeTask marks running task as done with output", async () => {
+    const t = await store.createTask({ title: "Will complete" });
+    await store.patchTask(t.id, { status: "running" });
+
+    const done = await store.completeTask(t.id, {
+      output_summary: "All tasks done",
+      duration_ms: 1234,
+      cost_usd: 0.0005,
+    });
+    expect(done).not.toBeNull();
+    expect(done!.status).toBe("done");
+    expect(done!.output_summary).toBe("All tasks done");
+    expect(done!.duration_ms).toBe(1234);
+    expect(done!.cost_usd).toBe(0.0005);
+    expect(done!.consecutive_failures).toBe(0);
+    expect(done!.completed_at).toBeTruthy();
+  });
+
+  it("failTask marks running task as failed and increments consecutive_failures", async () => {
+    const t = await store.createTask({ title: "Will fail" });
+    await store.patchTask(t.id, { status: "running" });
+
+    const failed = await store.failTask(t.id, { error_message: "oops", duration_ms: 100 });
+    expect(failed).not.toBeNull();
+    expect(failed!.status).toBe("failed");
+    expect(failed!.error_message).toBe("oops");
+    expect(failed!.consecutive_failures).toBe(1);
+
+    // Rerun and fail again to verify increment
+    await store.rerunTask(t.id);
+    await store.patchTask(t.id, { status: "running" });
+    const failed2 = await store.failTask(t.id, { error_message: "oops again" });
+    expect(failed2!.consecutive_failures).toBe(2);
+  });
+
+  it("promoteApprovalTasks transitions pending+requires_approval tasks to awaiting_approval", async () => {
+    const t = await store.createTask({ title: "Needs HITL", requires_approval: true });
+    expect(t.status).toBe("pending");
+
+    const count = await store.promoteApprovalTasks();
+    expect(count).toBeGreaterThanOrEqual(1);
+
+    const updated = await store.getTask(t.id);
+    expect(updated!.status).toBe("awaiting_approval");
+  });
+
+  it("materializeSchedules creates a task row for each due schedule", async () => {
+    const sched = await store.createSchedule({
+      name: "Instant run",
+      cron_expression: "* * * * *",
+      task_title: "Materialized task",
+    });
+    // Force next_run_at to the past so it's immediately due
+    memDb!.prepare("UPDATE ops_schedules SET next_run_at = ? WHERE id = ?").run(
+      new Date(Date.now() - 60_000).toISOString(),
+      sched.id
+    );
+
+    const before = await store.listTasks();
+    const created = await store.materializeSchedules();
+    expect(created).toBeGreaterThanOrEqual(1);
+
+    const after = await store.listTasks();
+    expect(after.length).toBe(before.length + created);
+
+    const newTask = after.find((t) => t.schedule_id === sched.id);
+    expect(newTask).toBeDefined();
+    expect(newTask!.title).toBe("Materialized task");
+  });
 });

--- a/tests/tasksStore.test.ts
+++ b/tests/tasksStore.test.ts
@@ -71,7 +71,7 @@ describe.skipIf(!Database)("tasksStore CRUD", () => {
     expect(task.status).toBe("pending");
     expect(task.priority).toBe(3);
     expect(task.quadrant).toBe("do");
-    expect(task.execution_mode).toBe("stream");
+    expect(task.execution_mode).toBe("classic");
     expect(task.risk_level).toBe("low");
   });
 


### PR DESCRIPTION
## Summary

- **Dispatcher singleton** (`globalThis.__minderDispatcher`) — 30s tick, 2s initial delay, `MAX_CONCURRENT=3`. Starts automatically on first `/api/tasks` request (inside handler body, not module scope). Writes heartbeat to `~/.minder/dispatcher-heartbeat.json`.
- **Classic spawner** — `claude -p <prompt>` via `cmd.exe /c` on Windows, direct on Unix. PID marker files at `~/.minder/pids/<pid>` written on spawn, deleted on exit. `sweepStalePids()` cleans dead markers each tick.
- **Store lifecycle helpers** — `approveTask`, `rerunTask`, `completeTask`, `failTask`, `promoteApprovalTasks` (pending+requires_approval → awaiting_approval), `materializeSchedules` (serialized transaction, prevents double-materialization).
- **`claimPendingTask`** now excludes `requires_approval=1` rows so approval tasks are never accidentally claimed.
- **`POST /api/tasks/[id]/approve`** — `awaiting_approval → pending`, sets `approved_at`. Returns 409 if wrong state (atomic, no pre-fetch race).
- **`POST /api/tasks/[id]/rerun`** — `failed → pending`, clears all output fields. Returns 409 if wrong state.
- **Task Composer modal** — "New task" button in TasksBrowser toolbar. All fields: title, description, quadrant, priority, skill, model, risk level, run-after, requires_approval, dry_run. Refreshes list on success.
- **`taskDispatcher` feature flag** flipped to `wired: true`.
- **dry_run** tasks now call `completeTask()` instead of getting stuck in `running`.

## Simplify fixes (second commit)
- approve/rerun routes: removed `getTask` pre-fetch (TOCTOU); trust atomic SQL `WHERE status=X`
- `ensurePidDir()` / heartbeat `mkdirSync` moved to init — was running every 30s tick
- `load()` in tasks page wrapped in `useCallback` — removes masked `eslint-disable`
- `"classic"` literal → `EXECUTION_MODES[0]` in TaskComposer
- Fixed misleading JSDoc claiming `BEGIN IMMEDIATE` (actual: DEFERRED)

## Test plan
- [ ] 1539 tests pass, typecheck clean (verified pre-commit)
- [ ] `GET /api/tasks` returns task list; dispatcher starts on first request
- [ ] "New task" button opens Composer; submitting creates a pending task and refreshes list
- [ ] `POST /api/tasks/[id]/approve` on awaiting_approval → 200 pending; on pending → 409
- [ ] `POST /api/tasks/[id]/rerun` on failed → 200 pending; on pending → 409
- [ ] dry_run tasks complete (status=done) without spawning a child process
- [ ] `~/.minder/dispatcher-heartbeat.json` written within 32s of first `/api/tasks` request
- [ ] Stream mode (9.1c) and HITL (9.2) remain deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)