### PR TITLE
feat(wave9.1c): stream-json spawning — session_id + cost tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 9.1c — Stream mode spawning.** `execution_mode: "stream"` tasks now use `claude -p --output-format stream-json --verbose` instead of `--output-format text`. NDJSON events are parsed from stdout: the `init` event writes `session_id` to the task row mid-run via a new `setSessionId()` store helper; the `result` event captures output text and `total_cost_usd`. Chunk-boundary safety is guaranteed by a line buffer that accumulates across `data` events with UTF-8 stream encoding. Non-JSON lines (hook output, warnings) are silently skipped. Task Composer now exposes an "Execution mode" selector (Classic / Stream). Dispatcher routes tasks by `execution_mode` field. 7 new `runStreamTask` tests.
 - **Wave 9.1b — Cluster U (continued): Dispatcher loop + classic spawning + Task Composer.** TODO #244.
   - Dispatcher loop singleton (`globalThis.__minderDispatcher`) starts automatically on the first `/api/tasks` request. 30-second tick: writes heartbeat to `~/.minder/dispatcher-heartbeat.json`, materializes due cron schedules into `ops_tasks` rows (serialized transaction), promotes `requires_approval` tasks to `awaiting_approval`, claims up to 3 pending tasks and spawns `claude -p` (classic mode).
   - PID marker files at `~/.minder/pids/<pid>` — written on spawn, deleted on exit. `sweepStalePids()` on each tick cleans dead files via `process.kill(pid, 0)` (cross-platform, throws ESRCH if dead).

--- a/docs/help/tasks.md
+++ b/docs/help/tasks.md
@@ -24,6 +24,7 @@ Click **New task** in the toolbar to open the Task Composer. Fill in:
 - **Skill** — optional assigned skill to use (e.g. `code-review`)
 - **Model** — optional model override (e.g. `claude-opus-4-7`)
 - **Risk level** — Low / Medium / High
+- **Execution mode** — `Classic (text)` uses `claude -p --output-format text`; `Stream (JSON)` uses `--output-format stream-json --verbose` and captures the `session_id` mid-run
 - **Run after** — optional datetime; the dispatcher won't pick up the task until then
 - **Requires approval** — task waits in `awaiting_approval` until you approve it
 - **Dry run** — dispatcher logs but does not spawn a child process
@@ -53,8 +54,9 @@ The dispatcher is an in-process singleton (`globalThis.__minderDispatcher`) that
 1. Writes a heartbeat to `~/.minder/dispatcher-heartbeat.json` on each 30-second tick
 2. Materializes due schedules into `ops_tasks` rows
 3. Promotes `pending + requires_approval` tasks to `awaiting_approval`
-4. Claims and spawns up to 3 concurrent `classic` mode tasks (via `claude -p`)
-5. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
+4. Claims and spawns up to 3 concurrent tasks — `classic` mode via `claude -p --output-format text`, `stream` mode via `claude -p --output-format stream-json --verbose`
+5. In stream mode, writes `session_id` to the task row as soon as the init event arrives (before the task completes)
+6. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
 
 The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. Tasks that were `running` when the server stopped will remain stuck in that state; use the re-run endpoint to reset them to `pending`.
 
@@ -76,6 +78,5 @@ Recurring tasks are driven by cron schedules. Create one at `POST /api/schedules
 
 ## What's coming
 
-- **Wave 9.1c** — Stream mode (line-buffered JSON, `session_id` extraction)
 - **Wave 9.2** — HITL: `DECISION:` / `INBOX:` marker parsing, decision queue, emergency stop
 - **Wave 10** — Kanban board, task dependency graph, multi-agent swarm

--- a/public/help/tasks.md
+++ b/public/help/tasks.md
@@ -24,6 +24,7 @@ Click **New task** in the toolbar to open the Task Composer. Fill in:
 - **Skill** — optional assigned skill to use (e.g. `code-review`)
 - **Model** — optional model override (e.g. `claude-opus-4-7`)
 - **Risk level** — Low / Medium / High
+- **Execution mode** — `Classic (text)` uses `claude -p --output-format text`; `Stream (JSON)` uses `--output-format stream-json --verbose` and captures the `session_id` mid-run
 - **Run after** — optional datetime; the dispatcher won't pick up the task until then
 - **Requires approval** — task waits in `awaiting_approval` until you approve it
 - **Dry run** — dispatcher logs but does not spawn a child process
@@ -53,8 +54,9 @@ The dispatcher is an in-process singleton (`globalThis.__minderDispatcher`) that
 1. Writes a heartbeat to `~/.minder/dispatcher-heartbeat.json` on each 30-second tick
 2. Materializes due schedules into `ops_tasks` rows
 3. Promotes `pending + requires_approval` tasks to `awaiting_approval`
-4. Claims and spawns up to 3 concurrent `classic` mode tasks (via `claude -p`)
-5. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
+4. Claims and spawns up to 3 concurrent tasks — `classic` mode via `claude -p --output-format text`, `stream` mode via `claude -p --output-format stream-json --verbose`
+5. In stream mode, writes `session_id` to the task row as soon as the init event arrives (before the task completes)
+6. Writes a PID file to `~/.minder/pids/<pid>` for each spawned child (used by the Wave 9.2 emergency stop)
 
 The dispatcher lifecycle is bound to the Next.js server process — restarting the server restarts the dispatcher. Tasks that were `running` when the server stopped will remain stuck in that state; use the re-run endpoint to reset them to `pending`.
 
@@ -76,6 +78,5 @@ Recurring tasks are driven by cron schedules. Create one at `POST /api/schedules
 
 ## What's coming
 
-- **Wave 9.1c** — Stream mode (line-buffered JSON, `session_id` extraction)
 - **Wave 9.2** — HITL: `DECISION:` / `INBOX:` marker parsing, decision queue, emergency stop
 - **Wave 10** — Kanban board, task dependency graph, multi-agent swarm

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import type { TaskQuadrant, RiskLevel, ExecutionMode } from "@/lib/tasks/types";
-import { EXECUTION_MODES } from "@/lib/tasks/types";
+import { EXECUTION_MODES, EXECUTION_MODE_LABELS } from "@/lib/tasks/types";
 
 interface TaskComposerProps {
   open: boolean;
@@ -178,7 +178,7 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
           <Field label="Execution mode">
             <select value={executionMode} onChange={(e) => setExecutionMode(e.target.value as ExecutionMode)} style={selectStyle}>
               {EXECUTION_MODES.map((m) => (
-                <option key={m} value={m}>{m === "classic" ? "Classic (text)" : "Stream (JSON)"}</option>
+                <option key={m} value={m}>{EXECUTION_MODE_LABELS[m]}</option>
               ))}
             </select>
           </Field>

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Modal } from "@/components/ui/modal";
-import type { TaskQuadrant, RiskLevel } from "@/lib/tasks/types";
+import type { TaskQuadrant, RiskLevel, ExecutionMode } from "@/lib/tasks/types";
 import { EXECUTION_MODES } from "@/lib/tasks/types";
 
 interface TaskComposerProps {
@@ -53,6 +53,7 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
   const [assignedSkill, setAssignedSkill] = useState("");
   const [model, setModel] = useState("");
   const [riskLevel, setRiskLevel] = useState<RiskLevel>("low");
+  const [executionMode, setExecutionMode] = useState<ExecutionMode>("classic");
   const [requiresApproval, setRequiresApproval] = useState(false);
   const [dryRun, setDryRun] = useState(false);
   const [scheduledFor, setScheduledFor] = useState("");
@@ -68,7 +69,7 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
     try {
       const body: Record<string, unknown> = {
         title: title.trim(),
-        execution_mode: EXECUTION_MODES[0],
+        execution_mode: executionMode,
       };
       if (description.trim()) body.description = description.trim();
       if (quadrant) body.quadrant = quadrant;
@@ -165,12 +166,20 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
           </Field>
         </div>
 
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "12px" }}>
           <Field label="Risk level">
             <select value={riskLevel} onChange={(e) => setRiskLevel(e.target.value as RiskLevel)} style={selectStyle}>
               <option value="low">Low</option>
               <option value="medium">Medium</option>
               <option value="high">High</option>
+            </select>
+          </Field>
+
+          <Field label="Execution mode">
+            <select value={executionMode} onChange={(e) => setExecutionMode(e.target.value as ExecutionMode)} style={selectStyle}>
+              {EXECUTION_MODES.map((m) => (
+                <option key={m} value={m}>{m === "classic" ? "Classic (text)" : "Stream (JSON)"}</option>
+              ))}
             </select>
           </Field>
 

--- a/src/components/TasksBrowser.tsx
+++ b/src/components/TasksBrowser.tsx
@@ -429,7 +429,7 @@ export function TasksBrowser({ tasks, schedules, onRefresh }: Props) {
           <div style={{ fontSize: "2rem", marginBottom: "8px" }}>📋</div>
           <div style={{ fontWeight: 500, marginBottom: "4px" }}>No tasks yet</div>
           <div style={{ fontSize: "0.75rem" }}>
-            Create a task with "New task" — the dispatcher will pick it up and run it with Claude Code.
+            Create a task with &ldquo;New task&rdquo; — the dispatcher will pick it up and run it with Claude Code.
           </div>
         </div>
       ) : filtered.length === 0 ? (

--- a/src/lib/tasks/dispatcher.ts
+++ b/src/lib/tasks/dispatcher.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path from "path";
 import fs from "fs";
 import { claimPendingTask, materializeSchedules, promoteApprovalTasks, completeTask } from "./store";
-import { runClassicTask, sweepStalePids, type SpawnFn } from "./spawner";
+import { runClassicTask, runStreamTask, sweepStalePids, type SpawnFn } from "./spawner";
 import type { Task } from "./types";
 
 const HEARTBEAT_PATH = path.join(os.homedir(), ".minder", "dispatcher-heartbeat.json");
@@ -85,7 +85,8 @@ export function initDispatcher(spawnFn?: SpawnFn): void {
           continue;
         }
 
-        const promise: Promise<void> = runClassicTask(task, spawnFn)
+        const runFn = task.execution_mode === "stream" ? runStreamTask : runClassicTask;
+        const promise: Promise<void> = runFn(task, spawnFn)
           .then(() => {})
           .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
           .finally(() => inFlight.delete(task!.id));

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -78,6 +78,20 @@ export interface RunTaskResult {
   durationMs: number;
 }
 
+function buildPrompt(task: Task): string {
+  return [task.title, task.description].filter(Boolean).join("\n\n");
+}
+
+function appendTaskFlags(args: string[], task: Task): void {
+  if (task.assigned_skill) args.push("--allowedTools", `mcp__skills__${task.assigned_skill}`);
+  if (task.model) args.push("--model", task.model);
+}
+
+// On Windows, `claude` is a .cmd file; must invoke via cmd.exe
+function buildSpawnTarget(args: string[]): [string, string[]] {
+  return isWindows ? ["cmd.exe", ["/c", "claude", ...args]] : ["claude", args];
+}
+
 /**
  * Spawn `claude -p "<prompt>"` for the task (classic mode).
  * Writes a PID marker file while the child is alive.
@@ -88,34 +102,21 @@ export async function runClassicTask(
   spawnFn: SpawnFn = spawn
 ): Promise<RunTaskResult> {
   const startMs = Date.now();
-  const prompt = [task.title, task.description].filter(Boolean).join("\n\n");
-
-  const spawnArgs = ["-p", prompt, "--output-format", "text"];
-  if (task.assigned_skill) {
-    spawnArgs.push("--allowedTools", `mcp__skills__${task.assigned_skill}`);
-  }
-  if (task.model) {
-    spawnArgs.push("--model", task.model);
-  }
-
-  const opts = {
-    stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
-    env: { ...process.env, MINDER_DISPATCHED: "1" },
-  };
-
-  // On Windows, `claude` is a .cmd file; must invoke via cmd.exe
-  const [cmd, extraArgs]: [string, string[]] = isWindows
-    ? ["cmd.exe", ["/c", "claude", ...spawnArgs]]
-    : ["claude", spawnArgs];
+  const spawnArgs = ["-p", buildPrompt(task), "--output-format", "text"];
+  appendTaskFlags(spawnArgs, task);
+  const [cmd, extraArgs] = buildSpawnTarget(spawnArgs);
 
   return new Promise<RunTaskResult>((resolve) => {
-    const child = spawnFn(cmd, extraArgs, opts);
+    const child = spawnFn(cmd, extraArgs, {
+      stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+      env: { ...process.env, MINDER_DISPATCHED: "1" },
+    });
     const pid = child.pid;
-
     if (pid) writePidFile(pid);
 
     let stdout = "";
     let stderr = "";
+    let settled = false;
     const STDOUT_CAP = 50_000;
     const STDERR_CAP = 10_000;
 
@@ -123,6 +124,8 @@ export async function runClassicTask(
     child.stderr?.on("data", (chunk: Buffer) => { if (stderr.length < STDERR_CAP) stderr += chunk.toString(); });
 
     child.on("close", async (code) => {
+      if (settled) return;
+      settled = true;
       if (pid) deletePidFile(pid);
       const durationMs = Date.now() - startMs;
 
@@ -149,6 +152,8 @@ export async function runClassicTask(
     });
 
     child.on("error", async (err) => {
+      if (settled) return;
+      settled = true;
       if (pid) deletePidFile(pid);
       const durationMs = Date.now() - startMs;
       try {
@@ -173,36 +178,24 @@ export async function runStreamTask(
   spawnFn: SpawnFn = spawn
 ): Promise<RunTaskResult> {
   const startMs = Date.now();
-  const prompt = [task.title, task.description].filter(Boolean).join("\n\n");
-
-  const spawnArgs = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
-  if (task.assigned_skill) {
-    spawnArgs.push("--allowedTools", `mcp__skills__${task.assigned_skill}`);
-  }
-  if (task.model) {
-    spawnArgs.push("--model", task.model);
-  }
-
-  const opts = {
-    stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
-    env: { ...process.env, MINDER_DISPATCHED: "1" },
-  };
-
-  const [cmd, extraArgs]: [string, string[]] = isWindows
-    ? ["cmd.exe", ["/c", "claude", ...spawnArgs]]
-    : ["claude", spawnArgs];
+  const spawnArgs = ["-p", buildPrompt(task), "--output-format", "stream-json", "--verbose"];
+  appendTaskFlags(spawnArgs, task);
+  const [cmd, extraArgs] = buildSpawnTarget(spawnArgs);
 
   return new Promise<RunTaskResult>((resolve) => {
-    const child = spawnFn(cmd, extraArgs, opts);
+    const child = spawnFn(cmd, extraArgs, {
+      stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+      env: { ...process.env, MINDER_DISPATCHED: "1" },
+    });
     const pid = child.pid;
-
     if (pid) writePidFile(pid);
 
     let lineBuffer = "";
     let resultText = "";
     let resultCostUsd: number | undefined;
     let stderr = "";
-    const LINE_BUFFER_CAP = 50_000;
+    let settled = false;
+    let sessionIdWritten = false;
     const STDERR_CAP = 10_000;
 
     // UTF-8 encoding prevents chunk boundaries from splitting multi-byte sequences.
@@ -210,8 +203,7 @@ export async function runStreamTask(
       ?.setEncoding?.("utf8");
 
     child.stdout?.on("data", (chunk: string | Buffer) => {
-      if (lineBuffer.length < LINE_BUFFER_CAP)
-        lineBuffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      lineBuffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
       let nl: number;
       while ((nl = lineBuffer.indexOf("\n")) !== -1) {
         const line = lineBuffer.slice(0, nl).trimEnd();
@@ -219,7 +211,8 @@ export async function runStreamTask(
         if (!line) continue;
         try {
           const evt = JSON.parse(line) as Record<string, unknown>;
-          if (evt.type === "system" && evt.subtype === "init" && typeof evt.session_id === "string") {
+          if (!sessionIdWritten && evt.type === "system" && evt.subtype === "init" && typeof evt.session_id === "string") {
+            sessionIdWritten = true;
             setSessionId(task.id, evt.session_id).catch((e) =>
               console.error(`[spawner] setSessionId failed for task ${task.id}:`, e)
             );
@@ -238,6 +231,8 @@ export async function runStreamTask(
     });
 
     child.on("close", async (code) => {
+      if (settled) return;
+      settled = true;
       if (pid) deletePidFile(pid);
       const durationMs = Date.now() - startMs;
 
@@ -265,6 +260,8 @@ export async function runStreamTask(
     });
 
     child.on("error", async (err) => {
+      if (settled) return;
+      settled = true;
       if (pid) deletePidFile(pid);
       const durationMs = Date.now() - startMs;
       try {

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -196,14 +196,22 @@ export async function runStreamTask(
     let stderr = "";
     let settled = false;
     let sessionIdWritten = false;
+    let lineBufOverflow = false;
     const STDERR_CAP = 10_000;
+    const LINEBUF_CAP = 5_000_000; // 5 MB — fail hard on runaway output
 
     // UTF-8 encoding prevents chunk boundaries from splitting multi-byte sequences.
     (child.stdout as NodeJS.ReadableStream & { setEncoding?: (enc: string) => void })
       ?.setEncoding?.("utf8");
 
     child.stdout?.on("data", (chunk: string | Buffer) => {
+      if (lineBufOverflow) return;
       lineBuffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      if (lineBuffer.length > LINEBUF_CAP) {
+        lineBufOverflow = true;
+        lineBuffer = "";
+        return;
+      }
       let nl: number;
       while ((nl = lineBuffer.indexOf("\n")) !== -1) {
         const line = lineBuffer.slice(0, nl).trimEnd();
@@ -235,6 +243,36 @@ export async function runStreamTask(
       settled = true;
       if (pid) deletePidFile(pid);
       const durationMs = Date.now() - startMs;
+
+      // Flush any trailing NDJSON line that wasn't newline-terminated on process exit
+      if (lineBuffer.trim()) {
+        try {
+          const evt = JSON.parse(lineBuffer.trim()) as Record<string, unknown>;
+          if (!sessionIdWritten && evt.type === "system" && evt.subtype === "init" && typeof evt.session_id === "string") {
+            sessionIdWritten = true;
+            // Await here — completeTask below will change status to 'done', blocking the setSessionId guard
+            await setSessionId(task.id, evt.session_id).catch((e) =>
+              console.error(`[spawner] setSessionId failed for task ${task.id}:`, e)
+            );
+          } else if (evt.type === "result") {
+            if (typeof evt.result === "string") resultText = evt.result;
+            if (typeof evt.total_cost_usd === "number") resultCostUsd = evt.total_cost_usd;
+          }
+        } catch {
+          // Not valid JSON — ignore
+        }
+      }
+
+      if (lineBufOverflow) {
+        const errMsg = "Stream output exceeded 5 MB buffer limit";
+        try {
+          await failTask(task.id, { error_message: errMsg, duration_ms: durationMs });
+        } catch (err) {
+          console.error(`[spawner] failTask failed for task ${task.id}:`, err);
+        }
+        resolve({ taskId: task.id, status: "failed", error: errMsg, durationMs });
+        return;
+      }
 
       if (code === 0) {
         const trimmed = resultText.trim();

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -4,7 +4,7 @@ import os from "os";
 import path from "path";
 import fs from "fs";
 import type { Task } from "./types";
-import { completeTask, failTask } from "./store";
+import { completeTask, failTask, setSessionId } from "./store";
 import { isWindows } from "../platform";
 
 const PID_DIR = path.join(os.homedir(), ".minder", "pids");
@@ -132,6 +132,122 @@ export async function runClassicTask(
           await completeTask(task.id, {
             output_summary: trimmed.slice(0, 4000) || undefined,
             duration_ms: durationMs,
+          });
+        } catch (err) {
+          console.error(`[spawner] completeTask failed for task ${task.id}:`, err);
+        }
+        resolve({ taskId: task.id, status: "done", output: trimmed, durationMs });
+      } else {
+        const errMsg = stderr.trim() || `claude exited with code ${code}`;
+        try {
+          await failTask(task.id, { error_message: errMsg.slice(0, 2000), duration_ms: durationMs });
+        } catch (err) {
+          console.error(`[spawner] failTask failed for task ${task.id}:`, err);
+        }
+        resolve({ taskId: task.id, status: "failed", error: errMsg, durationMs });
+      }
+    });
+
+    child.on("error", async (err) => {
+      if (pid) deletePidFile(pid);
+      const durationMs = Date.now() - startMs;
+      try {
+        await failTask(task.id, { error_message: err.message.slice(0, 2000), duration_ms: durationMs });
+      } catch (storeErr) {
+        console.error(`[spawner] failTask failed for task ${task.id}:`, storeErr);
+      }
+      resolve({ taskId: task.id, status: "failed", error: err.message, durationMs });
+    });
+  });
+}
+
+/**
+ * Spawn `claude -p "<prompt>" --output-format stream-json --verbose` (stream mode).
+ * Parses NDJSON events from stdout:
+ *   - {type:"system", subtype:"init"} → write session_id early via setSessionId()
+ *   - {type:"result"} → extract result text + total_cost_usd for completeTask()
+ * Writes a PID marker file while the child is alive.
+ */
+export async function runStreamTask(
+  task: Task,
+  spawnFn: SpawnFn = spawn
+): Promise<RunTaskResult> {
+  const startMs = Date.now();
+  const prompt = [task.title, task.description].filter(Boolean).join("\n\n");
+
+  const spawnArgs = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
+  if (task.assigned_skill) {
+    spawnArgs.push("--allowedTools", `mcp__skills__${task.assigned_skill}`);
+  }
+  if (task.model) {
+    spawnArgs.push("--model", task.model);
+  }
+
+  const opts = {
+    stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+    env: { ...process.env, MINDER_DISPATCHED: "1" },
+  };
+
+  const [cmd, extraArgs]: [string, string[]] = isWindows
+    ? ["cmd.exe", ["/c", "claude", ...spawnArgs]]
+    : ["claude", spawnArgs];
+
+  return new Promise<RunTaskResult>((resolve) => {
+    const child = spawnFn(cmd, extraArgs, opts);
+    const pid = child.pid;
+
+    if (pid) writePidFile(pid);
+
+    let lineBuffer = "";
+    let resultText = "";
+    let resultCostUsd: number | undefined;
+    let stderr = "";
+    const LINE_BUFFER_CAP = 50_000;
+    const STDERR_CAP = 10_000;
+
+    // UTF-8 encoding prevents chunk boundaries from splitting multi-byte sequences.
+    (child.stdout as NodeJS.ReadableStream & { setEncoding?: (enc: string) => void })
+      ?.setEncoding?.("utf8");
+
+    child.stdout?.on("data", (chunk: string | Buffer) => {
+      if (lineBuffer.length < LINE_BUFFER_CAP)
+        lineBuffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      let nl: number;
+      while ((nl = lineBuffer.indexOf("\n")) !== -1) {
+        const line = lineBuffer.slice(0, nl).trimEnd();
+        lineBuffer = lineBuffer.slice(nl + 1);
+        if (!line) continue;
+        try {
+          const evt = JSON.parse(line) as Record<string, unknown>;
+          if (evt.type === "system" && evt.subtype === "init" && typeof evt.session_id === "string") {
+            setSessionId(task.id, evt.session_id).catch((e) =>
+              console.error(`[spawner] setSessionId failed for task ${task.id}:`, e)
+            );
+          } else if (evt.type === "result") {
+            if (typeof evt.result === "string") resultText = evt.result;
+            if (typeof evt.total_cost_usd === "number") resultCostUsd = evt.total_cost_usd;
+          }
+        } catch {
+          // Non-JSON lines (hook output, warnings) — ignore
+        }
+      }
+    });
+
+    child.stderr?.on("data", (chunk: Buffer) => {
+      if (stderr.length < STDERR_CAP) stderr += chunk.toString();
+    });
+
+    child.on("close", async (code) => {
+      if (pid) deletePidFile(pid);
+      const durationMs = Date.now() - startMs;
+
+      if (code === 0) {
+        const trimmed = resultText.trim();
+        try {
+          await completeTask(task.id, {
+            output_summary: trimmed.slice(0, 4000) || undefined,
+            duration_ms: durationMs,
+            cost_usd: resultCostUsd,
           });
         } catch (err) {
           console.error(`[spawner] completeTask failed for task ${task.id}:`, err);

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -297,7 +297,7 @@ export async function rerunTask(id: number): Promise<Task | null> {
 /** Write session_id mid-run (before completeTask is called). Fire-and-forget safe. */
 export async function setSessionId(id: number, sessionId: string): Promise<void> {
   const db = await ensureReady();
-  prepTasksCached(db, "UPDATE ops_tasks SET session_id = ? WHERE id = ?").run(sessionId, id);
+  prepTasksCached(db, "UPDATE ops_tasks SET session_id = ? WHERE id = ? AND status = 'running'").run(sessionId, id);
 }
 
 export interface CompleteTaskInput {

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -294,11 +294,16 @@ export async function rerunTask(id: number): Promise<Task | null> {
   return row ?? null;
 }
 
+/** Write session_id mid-run (before completeTask is called). Fire-and-forget safe. */
+export async function setSessionId(id: number, sessionId: string): Promise<void> {
+  const db = await ensureReady();
+  prepTasksCached(db, "UPDATE ops_tasks SET session_id = ? WHERE id = ?").run(sessionId, id);
+}
+
 export interface CompleteTaskInput {
   output_summary?: string;
   duration_ms?: number;
   cost_usd?: number;
-  session_id?: string;
 }
 
 /** Mark a running task as done with captured output. */
@@ -312,15 +317,13 @@ export async function completeTask(id: number, result: CompleteTaskInput): Promi
          consecutive_failures = 0,
          output_summary = ?,
          duration_ms = ?,
-         cost_usd = ?,
-         session_id = ?
+         cost_usd = ?
      WHERE id = ? AND status = 'running'
      RETURNING *`
   ).get(
     result.output_summary ?? null,
     result.duration_ms ?? null,
     result.cost_usd ?? null,
-    result.session_id ?? null,
     id
   ) as Task | undefined;
   return row ?? null;

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -20,6 +20,10 @@ export const TASK_STATUSES: readonly TaskStatus[] = [
 ];
 export const TASK_QUADRANTS: readonly TaskQuadrant[] = ["do", "schedule", "delegate", "archive"];
 export const EXECUTION_MODES: readonly ExecutionMode[] = ["classic", "stream"];
+export const EXECUTION_MODE_LABELS: Record<ExecutionMode, string> = {
+  classic: "Classic (text)",
+  stream: "Stream (JSON)",
+};
 export const RISK_LEVELS: readonly RiskLevel[] = ["low", "medium", "high"];
 
 /**

--- a/tests/dbMigrations.test.ts
+++ b/tests/dbMigrations.test.ts
@@ -134,7 +134,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
 
     expect(result.available).toBe(true);
     expect(result.quarantined).not.toBeNull();
-    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
     // The schema ran on the rebuilt empty DB.
     const db = await conn.getDb();

--- a/tests/hooksRoute.test.ts
+++ b/tests/hooksRoute.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+import path from "path";
 
 // Mock all server-side dependencies before importing the route
 vi.mock("@/lib/config", () => ({
@@ -122,19 +124,20 @@ describe("POST /api/hooks — slug resolution", () => {
   });
 
   it("resolves subdirectory to parent project slug", async () => {
+    const projectPath = path.join(os.tmpdir(), "dev", "project-minder");
+    const subPath = path.join(projectPath, "src", "lib");
     (getCachedScan as ReturnType<typeof vi.fn>).mockReturnValue({
-      projects: [
-        { slug: "project-minder", path: "C:\\dev\\project-minder", name: "project-minder" },
-      ],
+      projects: [{ slug: "project-minder", path: projectPath, name: "project-minder" }],
     });
-    const res = await POST(makeRequest({ ...baseBody, cwd: "C:\\dev\\project-minder\\src\\lib" }));
+    const res = await POST(makeRequest({ ...baseBody, cwd: subPath }));
     const json = await res.json();
     expect(json.slug).toBe("project-minder");
   });
 
   it("falls back to synthetic slug when no project matches", async () => {
+    const unknownPath = path.join(os.tmpdir(), "dev", "unknown-project");
     (getCachedScan as ReturnType<typeof vi.fn>).mockReturnValue({ projects: [] });
-    const res = await POST(makeRequest({ ...baseBody, cwd: "C:\\dev\\unknown-project" }));
+    const res = await POST(makeRequest({ ...baseBody, cwd: unknownPath }));
     const json = await res.json();
     // toSlug of basename "unknown-project"
     expect(json.slug).toBe("unknown-project");

--- a/tests/tasksSpawner.test.ts
+++ b/tests/tasksSpawner.test.ts
@@ -281,4 +281,22 @@ describe("runStreamTask", () => {
     expect(args).toContain("stream-json");
     expect(args).toContain("--verbose");
   });
+
+  it("flushes trailing result line without newline on close", async () => {
+    const { proc, emitOutput, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 16, execution_mode: "stream" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    // No trailing \n — simulates process flushing stdout on exit without newline
+    emitOutput(JSON.stringify({ type: "result", result: "No newline", total_cost_usd: 0.003 }));
+    emitClose(0);
+
+    const result = await promise;
+    expect(result.status).toBe("done");
+    expect(completeTask).toHaveBeenCalledWith(
+      16,
+      expect.objectContaining({ output_summary: "No newline", cost_usd: 0.003 })
+    );
+  });
 });

--- a/tests/tasksSpawner.test.ts
+++ b/tests/tasksSpawner.test.ts
@@ -19,10 +19,11 @@ vi.mock("../src/lib/platform", () => ({ isWindows: false }));
 vi.mock("../src/lib/tasks/store", () => ({
   completeTask: vi.fn().mockResolvedValue(null),
   failTask: vi.fn().mockResolvedValue(null),
+  setSessionId: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { runClassicTask, sweepStalePids } from "../src/lib/tasks/spawner";
-import { completeTask, failTask } from "../src/lib/tasks/store";
+import { runClassicTask, runStreamTask, sweepStalePids } from "../src/lib/tasks/spawner";
+import { completeTask, failTask, setSessionId } from "../src/lib/tasks/store";
 import type { Task } from "../src/lib/tasks/types";
 
 function makeTask(overrides: Partial<Task> = {}): Task {
@@ -147,8 +148,137 @@ describe("sweepStalePids", () => {
   it("runs without throwing", () => {
     expect(() => sweepStalePids()).not.toThrow();
   });
+});
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// runStreamTask
+// ---------------------------------------------------------------------------
+
+describe("runStreamTask", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function emitLines(emitOutput: (d: string) => void, lines: unknown[]) {
+    emitOutput(lines.map((l) => JSON.stringify(l) + "\n").join(""));
+  }
+
+  it("extracts session_id from init event and calls setSessionId", async () => {
+    const { proc, emitOutput, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 10, execution_mode: "stream" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitLines(emitOutput, [
+      { type: "system", subtype: "init", session_id: "abc-123" },
+      { type: "result", result: "Done", total_cost_usd: 0.001 },
+    ]);
+    emitClose(0);
+
+    await promise;
+    expect(setSessionId).toHaveBeenCalledWith(10, "abc-123");
+  });
+
+  it("calls completeTask with result text and cost_usd on exit 0", async () => {
+    const { proc, emitOutput, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 11, execution_mode: "stream" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitLines(emitOutput, [
+      { type: "system", subtype: "init", session_id: "sess-11" },
+      { type: "result", result: "All done", total_cost_usd: 0.005 },
+    ]);
+    emitClose(0);
+
+    const result = await promise;
+    expect(result.status).toBe("done");
+    expect(result.taskId).toBe(11);
+    expect(completeTask).toHaveBeenCalledWith(
+      11,
+      expect.objectContaining({ output_summary: "All done", cost_usd: 0.005 })
+    );
+  });
+
+  it("handles chunk-boundary split lines correctly", async () => {
+    const { proc, emitOutput, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 12, execution_mode: "stream" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+
+    // Split the result JSON line across two chunks
+    const line = JSON.stringify({ type: "result", result: "Split result", total_cost_usd: 0.002 });
+    emitOutput(line.slice(0, 20));
+    emitOutput(line.slice(20) + "\n");
+    emitClose(0);
+
+    const result = await promise;
+    expect(result.status).toBe("done");
+    expect(completeTask).toHaveBeenCalledWith(
+      12,
+      expect.objectContaining({ output_summary: "Split result", cost_usd: 0.002 })
+    );
+  });
+
+  it("tolerates non-JSON lines without throwing", async () => {
+    const { proc, emitOutput, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 13, execution_mode: "stream" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitOutput("not json\n");
+    emitOutput(JSON.stringify({ type: "result", result: "Fine", total_cost_usd: 0 }) + "\n");
+    emitClose(0);
+
+    const result = await promise;
+    expect(result.status).toBe("done");
+  });
+
+  it("calls failTask on non-zero exit code", async () => {
+    const { proc, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 14, execution_mode: "stream" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitClose(1);
+
+    const result = await promise;
+    expect(result.status).toBe("failed");
+    expect(failTask).toHaveBeenCalledWith(14, expect.objectContaining({ error_message: expect.any(String) }));
+  });
+
+  it("calls failTask on spawn error", async () => {
+    const { proc, emitError } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ id: 15, execution_mode: "stream" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitError(new Error("ENOENT: claude not found"));
+
+    const result = await promise;
+    expect(result.status).toBe("failed");
+    expect(failTask).toHaveBeenCalledWith(15, expect.objectContaining({ error_message: "ENOENT: claude not found" }));
+  });
+
+  it("passes model to spawn args when set", async () => {
+    const { proc, emitClose } = makeChildProcess();
+    const spawnFn = vi.fn().mockReturnValue(proc);
+
+    const task = makeTask({ execution_mode: "stream", model: "claude-haiku-4-5" });
+    const promise = runStreamTask(task, spawnFn as unknown as typeof import("child_process").spawn);
+    emitClose(0);
+    await promise;
+
+    const [, args] = spawnFn.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--model");
+    expect(args).toContain("claude-haiku-4-5");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("stream-json");
+    expect(args).toContain("--verbose");
   });
 });


### PR DESCRIPTION
## Summary

- **`runStreamTask`**: spawns `claude -p --output-format stream-json --verbose`, line-buffers NDJSON stdout (chunk-boundary safe, UTF-8 encoded), extracts `session_id` from the `system/init` event via `setSessionId()` (visible mid-run before completion), and extracts `output_summary` + `cost_usd` from the `result` event
- **`completeTask` fix**: removed `session_id` from the UPDATE — it's now owned exclusively by `setSessionId()`, preventing a race-condition overwrite that was silently nulling the field
- **Dispatcher**: routes `execution_mode="stream"` tasks to `runStreamTask`, classic tasks to `runClassicTask`
- **TaskComposer**: Execution mode selector (Classic / Stream), defaults to Classic
- **7 new tests**: init extraction, chunk-boundary split, non-JSON tolerance, model args, fail paths (exit code + spawn error)

### Simplify pass (second commit)

- Extract `buildPrompt` / `appendTaskFlags` / `buildSpawnTarget`: removes 4 duplicated blocks between the two task runners
- Fix `LINE_BUFFER_CAP` bug: the guard silently dropped result JSON lines > 50k chars; removed it (output is already truncated to 4000 chars in `completeTask`)
- Fix double-`failTask`: `settled` flag prevents both `close` and `error` handlers firing on spawn failure
- Fix `setSessionId` re-fires: `sessionIdWritten` flag guards against multiple DB writes from repeated `system/init` events in `--verbose` mode
- `EXECUTION_MODE_LABELS: Record<ExecutionMode, string>` added to `types.ts`; `TaskComposer` uses it instead of inline ternary

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1546 passing, 1 skipped (142 test files)
- [x] Browser test: stream task created via TaskComposer → `session_id` populated mid-run, `cost_usd` and `output_summary` on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)