### PR TITLE
feat(wave10.1b): task dependency graph — DAG/Gantt views + blocked badge + dispatcher SQL guard (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 10.1b — Cluster W (part 2): Task dependency graph.** TODO #167.
+  - New `task_dependencies(task_id, blocker_id)` table (migration v4) with `CHECK (task_id != blocker_id)`, `UNIQUE (task_id, blocker_id)`, and cascade-delete. Indexed on both columns.
+  - **Dispatcher SQL guard**: `claimPendingTask` and `promoteApprovalTasks` skip tasks whose blockers haven't reached `done` via a single `NOT EXISTS (...)` subquery — atomically safe, no JS-level filter.
+  - **Cycle prevention at insert time**: DFS from `taskId` over downstream edges before each insert; throws `CycleError` (409) if `blockerId` is reachable, preventing cyclic graphs.
+  - `addDependency(taskId, blockerId)` — idempotent (ON CONFLICT DO NOTHING); `removeDependency(taskId, blockerId)` — idempotent 204; `listDependencies(taskId)` — `{ blockedBy, blocks }`; `listAllDependencies()` — full table scan for kanban+DAG+Gantt.
+  - New REST surface: `GET/POST /api/tasks/[id]/dependencies`, `DELETE /api/tasks/[id]/dependencies/[blockerId]`.
+  - `GET /api/kanban` now fetches all dependency edges and builds `blockedByMap`/`blocksMap` passed into `buildBoard`; task cards carry `blockedBy: number[]` and `blocks: number[]`.
+  - **Blocked badge** on Kanban task cards when `blockedBy.length > 0` — gray chip with count.
+  - **Three Kanban view modes** (Board / Dag / Gantt) via toolbar toggle; mode persisted to `localStorage` under `minder:kanban:view-mode`.
+  - **Dag view** — `TaskDependencyGraph.tsx`: manual Sugiyama-style layered layout (`dependencyLayout.ts`), D3 SVG rendering, cubic Bezier edges with arrowhead marker, nodes colored by status, click → `/tasks?focus=<id>`. No new npm dependencies.
+  - **Gantt view** — `TaskGanttChart.tsx`: `d3.scaleTime()` horizontal bars, one row per task ordered by layer, dependency arrows as dashed polylines, placeholder bars for pending/awaiting-approval tasks.
+  - `dependencyLayout.ts` shared pure function (longest-path layer assignment + priority sort) used by both DAG and Gantt.
+  - **Task Composer** gains a "Depends on (optional)" checkbox list of active tasks; creates dependency edges atomically with the task.
+  - Help doc at `/kanban` updated with view modes and dependency semantics.
+  - 32 new tests: `taskDependencies` (store), `dependencyLayout` (pure layout), `apiTaskDependencies` (route), plus extensions to `buildBoard` and `apiKanban`. 1656 tests pass, typecheck clean.
+
 - **Wave 10.1a — Cluster W (part 1): Mission Control Kanban board.** TODO #166.
   - New `/kanban` page with a 5-column board (Working / Waiting / Idle / Done / Error) that unifies Claude Code sessions and dispatcher tasks in a single view.
   - `GET /api/kanban` route: reuses `getLiveStatusPayload()` (6 s cached) for sessions + `listTasks()` for tasks. Optional `?period=last24h|last7d|all` filter controls Done/Error horizon. Returns `{ columns, generatedAt, dispatcherEnabled }`. Graceful no-DB fallback returns sessions-only with `dispatcherEnabled: false`.

--- a/docs/help/kanban.md
+++ b/docs/help/kanban.md
@@ -2,6 +2,28 @@
 
 The Kanban page (`/kanban`) gives you a single-glance view of everything happening across your Claude Code sessions and dispatcher tasks, organized into five columns.
 
+## View modes
+
+Use the **Board / Dag / Gantt** toggle in the toolbar to switch how the Kanban data is displayed.
+
+### Board (default)
+
+Five-column card layout. Dispatcher tasks show a **blocked (N)** chip when they are waiting on one or more blocker tasks that haven't finished yet.
+
+### Dag — dependency graph
+
+A layered SVG graph where each node is a task and each arrow points from a blocker to its dependent ("blocker → dependent" read left to right). Tasks with no dependency edges are excluded. Click any node to jump to `/tasks?focus=<id>`.
+
+Empty state: appears when no tasks have dependency edges yet.
+
+### Gantt — time chart
+
+A horizontal bar chart with one row per task, sorted by dependency layer (blockers above dependents). Bars represent the task's real execution window (`started_at → completed_at`). Tasks still in flight extend to the current time. Pending/awaiting-approval tasks render a hollow placeholder bar (not a real estimate). Dependency arrows connect blocker bar-right to dependent bar-left.
+
+Empty state: appears when no task data exists for the selected period.
+
+View mode is persisted in `localStorage` under `minder:kanban:view-mode`.
+
 ## Columns
 
 | Column | What goes here |
@@ -11,6 +33,32 @@ The Kanban page (`/kanban`) gives you a single-glance view of everything happeni
 | **Idle** | Sessions that have finished a turn and are waiting for your next message; tasks queued as `pending` or `cancelled` |
 | **Done** | Tasks with `done` status |
 | **Error** | Tasks with `failed` status |
+
+## Task dependencies
+
+You can declare that one task must complete before another is dispatched. This is called a **blocking relationship**: task B is *blocked by* task A means B will not be claimed by the dispatcher until A reaches `done` status.
+
+### Creating dependencies
+
+Open the **Task Composer** (`+ New task`), fill in the task details, then check one or more tasks under **Depends on (optional)**. The dependency edges are inserted atomically with the task — if any edge would create a cycle, the whole creation fails with a 409 error.
+
+You can also add edges after creation via the REST API:
+```
+POST /api/tasks/{id}/dependencies     { "blockerId": <number> }
+DELETE /api/tasks/{id}/dependencies/{blockerId}
+```
+
+### Blocker semantics
+
+**Only `done` unblocks a dependent.** A blocker that ends in `failed` or `cancelled` keeps its dependents blocked indefinitely. To clear the hold:
+- **Rerun** the failed/cancelled blocker task (moves it back to `pending` for the dispatcher to retry).
+- **Remove** the dependency edge via `DELETE /api/tasks/{id}/dependencies/{blockerId}`.
+
+This is intentional: a cancelled task usually means "this didn't go the way we planned" — the dependent shouldn't proceed on a potentially half-done state.
+
+### Cycle prevention
+
+The API rejects edges that would create a cycle (direct or transitive) with `409 Conflict`. The graph is always a DAG; the Dag view can safely assume acyclic input.
 
 ## Live / awaiting dots
 

--- a/public/help/kanban.md
+++ b/public/help/kanban.md
@@ -2,6 +2,28 @@
 
 The Kanban page (`/kanban`) gives you a single-glance view of everything happening across your Claude Code sessions and dispatcher tasks, organized into five columns.
 
+## View modes
+
+Use the **Board / Dag / Gantt** toggle in the toolbar to switch how the Kanban data is displayed.
+
+### Board (default)
+
+Five-column card layout. Dispatcher tasks show a **blocked (N)** chip when they are waiting on one or more blocker tasks that haven't finished yet.
+
+### Dag — dependency graph
+
+A layered SVG graph where each node is a task and each arrow points from a blocker to its dependent ("blocker → dependent" read left to right). Tasks with no dependency edges are excluded. Click any node to jump to `/tasks?focus=<id>`.
+
+Empty state: appears when no tasks have dependency edges yet.
+
+### Gantt — time chart
+
+A horizontal bar chart with one row per task, sorted by dependency layer (blockers above dependents). Bars represent the task's real execution window (`started_at → completed_at`). Tasks still in flight extend to the current time. Pending/awaiting-approval tasks render a hollow placeholder bar (not a real estimate). Dependency arrows connect blocker bar-right to dependent bar-left.
+
+Empty state: appears when no task data exists for the selected period.
+
+View mode is persisted in `localStorage` under `minder:kanban:view-mode`.
+
 ## Columns
 
 | Column | What goes here |
@@ -11,6 +33,32 @@ The Kanban page (`/kanban`) gives you a single-glance view of everything happeni
 | **Idle** | Sessions that have finished a turn and are waiting for your next message; tasks queued as `pending` or `cancelled` |
 | **Done** | Tasks with `done` status |
 | **Error** | Tasks with `failed` status |
+
+## Task dependencies
+
+You can declare that one task must complete before another is dispatched. This is called a **blocking relationship**: task B is *blocked by* task A means B will not be claimed by the dispatcher until A reaches `done` status.
+
+### Creating dependencies
+
+Open the **Task Composer** (`+ New task`), fill in the task details, then check one or more tasks under **Depends on (optional)**. The dependency edges are inserted atomically with the task — if any edge would create a cycle, the whole creation fails with a 409 error.
+
+You can also add edges after creation via the REST API:
+```
+POST /api/tasks/{id}/dependencies     { "blockerId": <number> }
+DELETE /api/tasks/{id}/dependencies/{blockerId}
+```
+
+### Blocker semantics
+
+**Only `done` unblocks a dependent.** A blocker that ends in `failed` or `cancelled` keeps its dependents blocked indefinitely. To clear the hold:
+- **Rerun** the failed/cancelled blocker task (moves it back to `pending` for the dispatcher to retry).
+- **Remove** the dependency edge via `DELETE /api/tasks/{id}/dependencies/{blockerId}`.
+
+This is intentional: a cancelled task usually means "this didn't go the way we planned" — the dependent shouldn't proceed on a potentially half-done state.
+
+### Cycle prevention
+
+The API rejects edges that would create a cycle (direct or transitive) with `409 Conflict`. The graph is always a DAG; the Dag view can safely assume acyclic input.
 
 ## Live / awaiting dots
 

--- a/src/app/api/kanban/route.ts
+++ b/src/app/api/kanban/route.ts
@@ -55,10 +55,16 @@ export async function GET(request: Request): Promise<NextResponse> {
     const allTasks = await listTasks();
     tasks = filterTasksByPeriod(allTasks, period);
     decisionCounts = await countOpenDecisionsByTask();
+    const taskStatusMap = new Map(allTasks.map((t) => [t.id, t.status]));
     const deps = await listAllDependencies();
     for (const dep of deps) {
-      if (!blockedByMap.has(dep.task_id)) blockedByMap.set(dep.task_id, []);
-      blockedByMap.get(dep.task_id)!.push(dep.blocker_id);
+      // Only surface the blocked badge while the blocker is still in-flight.
+      // We check allTasks (not period-filtered tasks) so done blockers that
+      // fell outside the time window are still recognized as done.
+      if (taskStatusMap.get(dep.blocker_id) !== "done") {
+        if (!blockedByMap.has(dep.task_id)) blockedByMap.set(dep.task_id, []);
+        blockedByMap.get(dep.task_id)!.push(dep.blocker_id);
+      }
       if (!blocksMap.has(dep.blocker_id)) blocksMap.set(dep.blocker_id, []);
       blocksMap.get(dep.blocker_id)!.push(dep.task_id);
     }

--- a/src/app/api/kanban/route.ts
+++ b/src/app/api/kanban/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getLiveStatusPayload } from "@/lib/liveStatus";
-import { listTasks, countOpenDecisionsByTask } from "@/lib/tasks/store";
+import { listTasks, countOpenDecisionsByTask, listAllDependencies } from "@/lib/tasks/store";
 import { buildBoard } from "@/lib/kanban/buildBoard";
 import { readConfig } from "@/lib/config";
 import { getFlag } from "@/lib/featureFlags";
@@ -47,18 +47,30 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   let tasks: Task[] = [];
   let decisionCounts = new Map<number, number>();
+  let blockedByMap = new Map<number, number[]>();
+  let blocksMap = new Map<number, number[]>();
   let dispatcherEnabled = true;
 
   try {
     const allTasks = await listTasks();
     tasks = filterTasksByPeriod(allTasks, period);
     decisionCounts = await countOpenDecisionsByTask();
+    const deps = await listAllDependencies();
+    for (const dep of deps) {
+      if (!blockedByMap.has(dep.task_id)) blockedByMap.set(dep.task_id, []);
+      blockedByMap.get(dep.task_id)!.push(dep.blocker_id);
+      if (!blocksMap.has(dep.blocker_id)) blocksMap.set(dep.blocker_id, []);
+      blocksMap.get(dep.blocker_id)!.push(dep.task_id);
+    }
   } catch {
     // tasks.db unavailable (driver missing, DB corrupt)
     dispatcherEnabled = false;
   }
 
-  const snapshot = buildBoard({ sessions, tasks, dispatcherEnabled, decisionCounts }, generatedAt);
+  const snapshot = buildBoard(
+    { sessions, tasks, dispatcherEnabled, decisionCounts, blockedByMap, blocksMap },
+    generatedAt
+  );
   return NextResponse.json(snapshot);
 }
 

--- a/src/app/api/tasks/[id]/dependencies/[blockerId]/route.ts
+++ b/src/app/api/tasks/[id]/dependencies/[blockerId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { removeDependency } from "@/lib/tasks/store";
+import { parseId } from "@/lib/tasks/routeUtils";
 
 export const dynamic = "force-dynamic";
 
@@ -8,10 +9,10 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string; blockerId: string }> }
 ): Promise<NextResponse> {
   const { id, blockerId: blockerIdStr } = await params;
-  const taskId = parseInt(id, 10);
-  const blockerId = parseInt(blockerIdStr, 10);
+  const taskId = parseId(id);
+  const blockerId = parseId(blockerIdStr);
 
-  if (!Number.isFinite(taskId) || !Number.isFinite(blockerId)) {
+  if (taskId === null || blockerId === null) {
     return NextResponse.json({ error: "Invalid id" }, { status: 400 });
   }
 

--- a/src/app/api/tasks/[id]/dependencies/[blockerId]/route.ts
+++ b/src/app/api/tasks/[id]/dependencies/[blockerId]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { removeDependency } from "@/lib/tasks/store";
+
+export const dynamic = "force-dynamic";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string; blockerId: string }> }
+): Promise<NextResponse> {
+  const { id, blockerId: blockerIdStr } = await params;
+  const taskId = parseInt(id, 10);
+  const blockerId = parseInt(blockerIdStr, 10);
+
+  if (!Number.isFinite(taskId) || !Number.isFinite(blockerId)) {
+    return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+  }
+
+  await removeDependency(taskId, blockerId);
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/tasks/[id]/dependencies/route.ts
+++ b/src/app/api/tasks/[id]/dependencies/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getTask } from "@/lib/tasks/store";
 import { addDependency, listDependencies, CycleError } from "@/lib/tasks/store";
+import { parseId } from "@/lib/tasks/routeUtils";
 
 export const dynamic = "force-dynamic";
 
@@ -9,8 +10,8 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
   const { id } = await params;
-  const taskId = parseInt(id, 10);
-  if (!Number.isFinite(taskId)) {
+  const taskId = parseId(id);
+  if (taskId === null) {
     return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
   }
 
@@ -26,8 +27,8 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ): Promise<NextResponse> {
   const { id } = await params;
-  const taskId = parseInt(id, 10);
-  if (!Number.isFinite(taskId)) {
+  const taskId = parseId(id);
+  if (taskId === null) {
     return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
   }
 
@@ -38,14 +39,16 @@ export async function POST(
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
+  const rawBlockerId = (body as Record<string, unknown>)?.blockerId;
   if (
     typeof body !== "object" ||
     body === null ||
-    typeof (body as Record<string, unknown>).blockerId !== "number"
+    !Number.isInteger(rawBlockerId) ||
+    (rawBlockerId as number) <= 0
   ) {
-    return NextResponse.json({ error: "body.blockerId must be a number" }, { status: 400 });
+    return NextResponse.json({ error: "body.blockerId must be a positive integer" }, { status: 400 });
   }
-  const blockerId = (body as { blockerId: number }).blockerId;
+  const blockerId = rawBlockerId as number;
 
   if (blockerId === taskId) {
     return NextResponse.json({ error: "A task cannot block itself" }, { status: 400 });

--- a/src/app/api/tasks/[id]/dependencies/route.ts
+++ b/src/app/api/tasks/[id]/dependencies/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { getTask } from "@/lib/tasks/store";
+import { addDependency, listDependencies, CycleError } from "@/lib/tasks/store";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+  const taskId = parseInt(id, 10);
+  if (!Number.isFinite(taskId)) {
+    return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
+  }
+
+  const task = await getTask(taskId).catch(() => null);
+  if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+
+  const deps = await listDependencies(taskId);
+  return NextResponse.json(deps);
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+  const taskId = parseInt(id, 10);
+  if (!Number.isFinite(taskId)) {
+    return NextResponse.json({ error: "Invalid task id" }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    typeof (body as Record<string, unknown>).blockerId !== "number"
+  ) {
+    return NextResponse.json({ error: "body.blockerId must be a number" }, { status: 400 });
+  }
+  const blockerId = (body as { blockerId: number }).blockerId;
+
+  if (blockerId === taskId) {
+    return NextResponse.json({ error: "A task cannot block itself" }, { status: 400 });
+  }
+
+  const task = await getTask(taskId).catch(() => null);
+  if (!task) return NextResponse.json({ error: "Task not found" }, { status: 404 });
+
+  const blocker = await getTask(blockerId).catch(() => null);
+  if (!blocker) return NextResponse.json({ error: "Blocker task not found" }, { status: 404 });
+
+  try {
+    const dep = await addDependency(taskId, blockerId);
+    return NextResponse.json(dep, { status: 201 });
+  } catch (err) {
+    if (err instanceof CycleError) {
+      return NextResponse.json({ error: err.message }, { status: 409 });
+    }
+    throw err;
+  }
+}

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -10,8 +10,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useKanban } from "@/hooks/useKanban";
 import { KanbanCard } from "@/components/KanbanCard";
+import { TaskDependencyGraph } from "@/components/TaskDependencyGraph";
+import { TaskGanttChart } from "@/components/TaskGanttChart";
 import type { KanbanColumn, KanbanCard as KanbanCardType, KanbanKindFilter, KanbanPeriod } from "@/lib/kanban/types";
 import { KANBAN_COLUMNS, KANBAN_COLUMN_LABELS, KANBAN_COLUMN_EMPTY, KANBAN_KIND_FILTERS } from "@/lib/kanban/types";
+
+type ViewMode = "board" | "dag" | "gantt";
+const LS_VIEW_KEY = "minder:kanban:view-mode";
 
 const PAGE_SIZE = 10;
 const LS_KEY = "minder:kanban:hidden-columns";
@@ -229,6 +234,7 @@ export function KanbanBoard() {
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [hiddenCols, setHiddenCols] = useState<Set<KanbanColumn>>(new Set());
+  const [viewMode, setViewMode] = useState<ViewMode>("board");
   const [mounted, setMounted] = useState(false);
 
   const { snapshot, loading, error, refresh } = useKanban(period);
@@ -236,6 +242,8 @@ export function KanbanBoard() {
   // Load localStorage on client only
   useEffect(() => {
     setHiddenCols(loadHiddenColumns());
+    const savedView = localStorage.getItem(LS_VIEW_KEY);
+    if (savedView === "dag" || savedView === "gantt") setViewMode(savedView);
     setMounted(true);
   }, []);
 
@@ -339,6 +347,32 @@ export function KanbanBoard() {
             }}
           >
             {k.charAt(0).toUpperCase() + k.slice(1)}
+          </button>
+        ))}
+
+        {/* View mode toggle */}
+        {(["board", "dag", "gantt"] as ViewMode[]).map((mode) => (
+          <button
+            key={mode}
+            onClick={() => {
+              setViewMode(mode);
+              try { localStorage.setItem(LS_VIEW_KEY, mode); } catch { /* noop */ }
+            }}
+            aria-pressed={viewMode === mode}
+            style={{
+              padding: "5px 10px",
+              fontSize: "0.75rem",
+              fontWeight: 600,
+              borderRadius: "5px",
+              border: "1px solid var(--border)",
+              cursor: "pointer",
+              background: viewMode === mode
+                ? "color-mix(in srgb, var(--info) 15%, transparent)"
+                : "transparent",
+              color: viewMode === mode ? "var(--info)" : "var(--text-muted)",
+            }}
+          >
+            {mode.charAt(0).toUpperCase() + mode.slice(1)}
           </button>
         ))}
 
@@ -448,29 +482,34 @@ export function KanbanBoard() {
         {loading ? "Loading Kanban board…" : `Kanban updated. ${totalCards} card${totalCards !== 1 ? "s" : ""} visible.`}
       </div>
 
-      {/* Columns */}
-      <div
-        style={{
-          display: "flex",
-          gap: "16px",
-          overflowX: "auto",
-          paddingBottom: "8px",
-          alignItems: "flex-start",
-        }}
-      >
-        {KANBAN_COLUMNS.map((col) => (
-          <KanbanColumnSection
-            key={col}
-            col={col}
-            cards={filteredColumns[col]}
-            hidden={hiddenCols.has(col)}
-            onToggleHide={() => toggleHide(col)}
-          />
-        ))}
-      </div>
+      {/* Board / DAG / Gantt */}
+      {viewMode === "board" && (
+        <div
+          style={{
+            display: "flex",
+            gap: "16px",
+            overflowX: "auto",
+            paddingBottom: "8px",
+            alignItems: "flex-start",
+          }}
+        >
+          {KANBAN_COLUMNS.map((col) => (
+            <KanbanColumnSection
+              key={col}
+              col={col}
+              cards={filteredColumns[col]}
+              hidden={hiddenCols.has(col)}
+              onToggleHide={() => toggleHide(col)}
+            />
+          ))}
+        </div>
+      )}
 
-      {/* Whole-board empty state */}
-      {!loading && totalCards === 0 && (
+      {viewMode === "dag" && <TaskDependencyGraph snapshot={snapshot} />}
+      {viewMode === "gantt" && <TaskGanttChart snapshot={snapshot} />}
+
+      {/* Whole-board empty state (board mode only) */}
+      {viewMode === "board" && !loading && totalCards === 0 && (
         <div
           style={{
             textAlign: "center",

--- a/src/components/KanbanCard.tsx
+++ b/src/components/KanbanCard.tsx
@@ -180,6 +180,13 @@ function TaskKanbanCard({ card }: { card: TaskCard }) {
           {card.decisionCount > 0 && (
             <Chip label={`${card.decisionCount} pending`} color="var(--accent)" />
           )}
+          {card.blockedBy.length > 0 && (
+            <Chip
+              label={`blocked (${card.blockedBy.length})`}
+              muted
+              title={`Waiting on task${card.blockedBy.length > 1 ? "s" : ""} #${card.blockedBy.join(", #")}`}
+            />
+          )}
           {card.cancelled && (
             <Chip label="cancelled" muted />
           )}

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -2,8 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { Modal } from "@/components/ui/modal";
-import type { TaskQuadrant, RiskLevel, ExecutionMode, Task } from "@/lib/tasks/types";
+import type { TaskQuadrant, RiskLevel, ExecutionMode, TaskStatus, Task } from "@/lib/tasks/types";
 import { EXECUTION_MODES, EXECUTION_MODE_LABELS } from "@/lib/tasks/types";
+
+const BLOCKER_ELIGIBLE: Set<TaskStatus> = new Set(["pending", "awaiting_approval", "running"]);
 
 interface TaskComposerProps {
   open: boolean;
@@ -72,11 +74,7 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
         if (!Array.isArray(raw)) return;
         const tasks = raw as Task[];
         setBlockerOptions(
-          tasks.filter((t) =>
-            t.status === "pending" ||
-            t.status === "awaiting_approval" ||
-            t.status === "running"
-          )
+          tasks.filter((t) => BLOCKER_ELIGIBLE.has(t.status))
         );
       })
       .catch(() => { /* non-critical */ });

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -73,9 +73,11 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
         const raw = data && typeof data === "object" && "tasks" in data ? (data as { tasks: unknown }).tasks : data;
         if (!Array.isArray(raw)) return;
         const tasks = raw as Task[];
-        setBlockerOptions(
-          tasks.filter((t) => BLOCKER_ELIGIBLE.has(t.status))
-        );
+        const eligible = tasks.filter((t) => BLOCKER_ELIGIBLE.has(t.status));
+        const eligibleIds = new Set(eligible.map((t) => t.id));
+        setBlockerOptions(eligible);
+        // Drop any stale selections that are no longer in the eligible set.
+        setSelectedBlockerIds((prev) => prev.filter((id) => eligibleIds.has(id)));
       })
       .catch(() => { /* non-critical */ });
   }, [open]);

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Modal } from "@/components/ui/modal";
-import type { TaskQuadrant, RiskLevel, ExecutionMode } from "@/lib/tasks/types";
+import type { TaskQuadrant, RiskLevel, ExecutionMode, Task } from "@/lib/tasks/types";
 import { EXECUTION_MODES, EXECUTION_MODE_LABELS } from "@/lib/tasks/types";
 
 interface TaskComposerProps {
@@ -59,6 +59,28 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
   const [scheduledFor, setScheduledFor] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [blockerOptions, setBlockerOptions] = useState<Task[]>([]);
+  const [selectedBlockerIds, setSelectedBlockerIds] = useState<number[]>([]);
+
+  // Fetch active tasks that can serve as blockers.
+  useEffect(() => {
+    if (!open) return;
+    fetch("/api/tasks")
+      .then((r) => r.ok ? r.json() : [])
+      .then((data: unknown) => {
+        const raw = data && typeof data === "object" && "tasks" in data ? (data as { tasks: unknown }).tasks : data;
+        if (!Array.isArray(raw)) return;
+        const tasks = raw as Task[];
+        setBlockerOptions(
+          tasks.filter((t) =>
+            t.status === "pending" ||
+            t.status === "awaiting_approval" ||
+            t.status === "running"
+          )
+        );
+      })
+      .catch(() => { /* non-critical */ });
+  }, [open]);
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
@@ -80,6 +102,7 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
       if (requiresApproval) body.requires_approval = true;
       if (dryRun) body.dry_run = true;
       if (scheduledFor) body.scheduled_for = new Date(scheduledFor).toISOString();
+      if (selectedBlockerIds.length > 0) body.blockedBy = selectedBlockerIds;
 
       const res = await fetch("/api/tasks", {
         method: "POST",
@@ -122,6 +145,56 @@ export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
             style={{ ...inputStyle, resize: "vertical" }}
           />
         </Field>
+
+        {blockerOptions.length > 0 && (
+          <Field label="Depends on (optional)">
+            <div
+              style={{
+                maxHeight: "120px",
+                overflowY: "auto",
+                border: "1px solid var(--border)",
+                borderRadius: "4px",
+                padding: "6px 8px",
+                display: "flex",
+                flexDirection: "column",
+                gap: "4px",
+                fontSize: "0.78rem",
+              }}
+            >
+              {blockerOptions.map((t) => (
+                <label
+                  key={t.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "6px",
+                    cursor: "pointer",
+                    color: "var(--text-secondary)",
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedBlockerIds.includes(t.id)}
+                    onChange={(e) => {
+                      setSelectedBlockerIds((prev) =>
+                        e.target.checked
+                          ? [...prev, t.id]
+                          : prev.filter((id) => id !== t.id)
+                      );
+                    }}
+                  />
+                  <span style={{ fontFamily: "var(--font-mono)", color: "var(--text-muted)", fontSize: "0.68rem" }}>
+                    #{t.id}
+                  </span>
+                  {t.title}
+                </label>
+              ))}
+            </div>
+            <p style={{ fontSize: "0.68rem", color: "var(--text-muted)", marginTop: "3px" }}>
+              This task won&apos;t be dispatched until all selected tasks are done.
+            </p>
+          </Field>
+        )}
 
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
           <Field label="Quadrant">

--- a/src/components/TaskDependencyGraph.tsx
+++ b/src/components/TaskDependencyGraph.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { D3Container } from "@/components/viz/D3Container";
+import { computeLayout } from "@/lib/kanban/dependencyLayout";
+import type { KanbanSnapshot, KanbanCard } from "@/lib/kanban/types";
+
+const NODE_W = 180;
+const NODE_H = 54;
+const GAP_X = 80;
+const GAP_Y = 16;
+const PADDING = 24;
+
+const STATUS_COLOR: Record<string, string> = {
+  working:          "var(--success, #22c55e)",
+  waiting:          "var(--accent)",
+  idle:             "var(--text-muted)",
+  done:             "var(--info)",
+  error:            "var(--error)",
+};
+
+function columnToStatus(col: string) {
+  return col; // column name is the status bucket
+}
+
+interface Props {
+  snapshot: KanbanSnapshot;
+}
+
+export function TaskDependencyGraph({ snapshot }: Props) {
+  const router = useRouter();
+
+  // Collect all task cards that have at least one dependency edge.
+  const taskCards = useMemo(() => {
+    const all: Extract<KanbanCard, { kind: "task" }>[] = [];
+    for (const cards of Object.values(snapshot.columns)) {
+      for (const c of cards) {
+        if (c.kind === "task") all.push(c);
+      }
+    }
+    return all;
+  }, [snapshot]);
+
+  const nodesWithEdges = useMemo(() => {
+    const edged = new Set<number>();
+    for (const c of taskCards) {
+      if (c.blockedBy.length > 0 || c.blocks.length > 0) edged.add(c.taskId);
+    }
+    return taskCards.filter((c) => edged.has(c.taskId));
+  }, [taskCards]);
+
+  const layout = useMemo(() => {
+    const nodes = nodesWithEdges.map((c) => ({
+      id: c.taskId,
+      title: c.title,
+      status: c.column,
+      priority: 3,
+      createdAt: c.createdAt,
+      startedAt: c.startedAt,
+      completedAt: c.completedAt,
+      cancelled: c.cancelled,
+      blockedBy: c.blockedBy,
+      blocks: c.blocks,
+    }));
+    return computeLayout(nodes, NODE_W, NODE_H, GAP_X, GAP_Y);
+  }, [nodesWithEdges]);
+
+  if (nodesWithEdges.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "64px 32px",
+          textAlign: "center",
+          color: "var(--text-muted)",
+          fontSize: "0.85rem",
+        }}
+      >
+        No tasks with dependency edges.
+        <br />
+        Add a <strong>Depends on</strong> link in Task Composer to see the graph.
+      </div>
+    );
+  }
+
+  const maxLayerCount = Math.max(...layout.layerSizes);
+  const svgWidth  = (layout.maxLayer + 1) * (NODE_W + GAP_X) - GAP_X + PADDING * 2;
+  const svgHeight = maxLayerCount * (NODE_H + GAP_Y) - GAP_Y + PADDING * 2;
+
+  // Build edge list: blocker → dependent
+  const edges: { fromId: number; toId: number }[] = [];
+  for (const n of layout.nodes) {
+    for (const bid of n.blockedBy) {
+      if (layout.nodes.find((ln) => ln.id === bid)) {
+        edges.push({ fromId: bid, toId: n.id });
+      }
+    }
+  }
+
+  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
+
+  return (
+    <div style={{ overflowX: "auto", overflowY: "auto", padding: "8px 0" }}>
+      <D3Container
+        height={svgHeight + PADDING * 2}
+        margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+        style={{ minWidth: svgWidth }}
+      >
+        {({ showTooltip, hideTooltip }) => (
+          <g transform={`translate(${PADDING}, ${PADDING})`}>
+            {/* Arrowhead marker */}
+            <defs>
+              <marker
+                id="dep-arrow"
+                viewBox="0 0 10 10"
+                refX="9"
+                refY="5"
+                markerWidth="6"
+                markerHeight="6"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--border-default, #444)" />
+              </marker>
+            </defs>
+
+            {/* Edges (drawn first, behind nodes) */}
+            {edges.map(({ fromId, toId }) => {
+              const from = nodeMap.get(fromId);
+              const to = nodeMap.get(toId);
+              if (!from || !to) return null;
+              const x1 = from.x + NODE_W;
+              const y1 = from.y + NODE_H / 2;
+              const x2 = to.x;
+              const y2 = to.y + NODE_H / 2;
+              const mx = (x1 + x2) / 2;
+              return (
+                <path
+                  key={`${fromId}-${toId}`}
+                  d={`M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}`}
+                  fill="none"
+                  stroke="var(--border-default, #444)"
+                  strokeWidth={1.5}
+                  markerEnd="url(#dep-arrow)"
+                />
+              );
+            })}
+
+            {/* Nodes */}
+            {layout.nodes.map((n) => {
+              const statusColor = STATUS_COLOR[columnToStatus(n.status)] ?? "var(--text-muted)";
+              const truncTitle = n.title.length > 22 ? n.title.slice(0, 21) + "…" : n.title;
+
+              return (
+                <g
+                  key={n.id}
+                  transform={`translate(${n.x}, ${n.y})`}
+                  style={{ cursor: "pointer" }}
+                  onClick={() => router.push(`/tasks?focus=${n.id}`)}
+                  onMouseEnter={(e) => {
+                    showTooltip(
+                      e.clientX,
+                      e.clientY,
+                      `#${n.id} — ${n.title}${n.blockedBy.length > 0 ? `\nBlocked by: ${n.blockedBy.map((b) => `#${b}`).join(", ")}` : ""}`
+                    );
+                  }}
+                  onMouseLeave={hideTooltip}
+                >
+                  <rect
+                    width={NODE_W}
+                    height={NODE_H}
+                    rx={5}
+                    fill={`color-mix(in srgb, ${statusColor} 10%, var(--bg-elevated, #1c1f26))`}
+                    stroke={statusColor}
+                    strokeWidth={1.5}
+                    style={{ transition: "stroke-width 0.15s" }}
+                  />
+                  <text
+                    x={10}
+                    y={20}
+                    fontSize="0.7rem"
+                    fontFamily="var(--font-mono)"
+                    fill="var(--text-muted)"
+                  >
+                    #{n.id}
+                  </text>
+                  <text
+                    x={10}
+                    y={36}
+                    fontSize="0.75rem"
+                    fontFamily="var(--font-body)"
+                    fontWeight={600}
+                    fill="var(--text-primary)"
+                  >
+                    {truncTitle}
+                  </text>
+                  <text
+                    x={10}
+                    y={50}
+                    fontSize="0.62rem"
+                    fontFamily="var(--font-mono)"
+                    fill={statusColor}
+                    style={{ textTransform: "uppercase" }}
+                  >
+                    {n.status}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        )}
+      </D3Container>
+    </div>
+  );
+}

--- a/src/components/TaskDependencyGraph.tsx
+++ b/src/components/TaskDependencyGraph.tsx
@@ -3,26 +3,14 @@
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { D3Container } from "@/components/viz/D3Container";
-import { computeLayout } from "@/lib/kanban/dependencyLayout";
-import type { KanbanSnapshot, KanbanCard } from "@/lib/kanban/types";
+import { computeLayout, extractTaskCards, truncateTitle, STATUS_COLOR } from "@/lib/kanban/dependencyLayout";
+import type { KanbanSnapshot } from "@/lib/kanban/types";
 
 const NODE_W = 180;
 const NODE_H = 54;
 const GAP_X = 80;
 const GAP_Y = 16;
 const PADDING = 24;
-
-const STATUS_COLOR: Record<string, string> = {
-  working:          "var(--success, #22c55e)",
-  waiting:          "var(--accent)",
-  idle:             "var(--text-muted)",
-  done:             "var(--info)",
-  error:            "var(--error)",
-};
-
-function columnToStatus(col: string) {
-  return col; // column name is the status bucket
-}
 
 interface Props {
   snapshot: KanbanSnapshot;
@@ -31,16 +19,7 @@ interface Props {
 export function TaskDependencyGraph({ snapshot }: Props) {
   const router = useRouter();
 
-  // Collect all task cards that have at least one dependency edge.
-  const taskCards = useMemo(() => {
-    const all: Extract<KanbanCard, { kind: "task" }>[] = [];
-    for (const cards of Object.values(snapshot.columns)) {
-      for (const c of cards) {
-        if (c.kind === "task") all.push(c);
-      }
-    }
-    return all;
-  }, [snapshot]);
+  const taskCards = useMemo(() => extractTaskCards(snapshot), [snapshot]);
 
   const nodesWithEdges = useMemo(() => {
     const edged = new Set<number>();
@@ -87,17 +66,15 @@ export function TaskDependencyGraph({ snapshot }: Props) {
   const svgWidth  = (layout.maxLayer + 1) * (NODE_W + GAP_X) - GAP_X + PADDING * 2;
   const svgHeight = maxLayerCount * (NODE_H + GAP_Y) - GAP_Y + PADDING * 2;
 
-  // Build edge list: blocker → dependent
+  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
+
+  // Build edge list: blocker → dependent (only in-graph edges).
   const edges: { fromId: number; toId: number }[] = [];
   for (const n of layout.nodes) {
     for (const bid of n.blockedBy) {
-      if (layout.nodes.find((ln) => ln.id === bid)) {
-        edges.push({ fromId: bid, toId: n.id });
-      }
+      if (nodeMap.has(bid)) edges.push({ fromId: bid, toId: n.id });
     }
   }
-
-  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
 
   return (
     <div style={{ overflowX: "auto", overflowY: "auto", padding: "8px 0" }}>
@@ -147,8 +124,7 @@ export function TaskDependencyGraph({ snapshot }: Props) {
 
             {/* Nodes */}
             {layout.nodes.map((n) => {
-              const statusColor = STATUS_COLOR[columnToStatus(n.status)] ?? "var(--text-muted)";
-              const truncTitle = n.title.length > 22 ? n.title.slice(0, 21) + "…" : n.title;
+              const statusColor = STATUS_COLOR[n.status] ?? "var(--text-muted)";
 
               return (
                 <g
@@ -191,7 +167,7 @@ export function TaskDependencyGraph({ snapshot }: Props) {
                     fontWeight={600}
                     fill="var(--text-primary)"
                   >
-                    {truncTitle}
+                    {truncateTitle(n.title)}
                   </text>
                   <text
                     x={10}

--- a/src/components/TaskGanttChart.tsx
+++ b/src/components/TaskGanttChart.tsx
@@ -3,8 +3,8 @@
 import { useMemo } from "react";
 import * as d3 from "d3";
 import { D3Container } from "@/components/viz/D3Container";
-import { computeLayout } from "@/lib/kanban/dependencyLayout";
-import type { KanbanSnapshot, KanbanCard } from "@/lib/kanban/types";
+import { computeLayout, extractTaskCards, truncateTitle, STATUS_COLOR } from "@/lib/kanban/dependencyLayout";
+import type { KanbanSnapshot } from "@/lib/kanban/types";
 
 const ROW_H = 24;
 const ROW_GAP = 8;
@@ -12,28 +12,12 @@ const LABEL_W = 160;
 const AXIS_H = 28;
 const PLACEHOLDER_MIN = 30 * 60 * 1000; // 30 min in ms (visual only)
 
-const STATUS_COLOR: Record<string, string> = {
-  working:          "var(--success, #22c55e)",
-  waiting:          "var(--accent)",
-  idle:             "var(--text-muted)",
-  done:             "var(--info)",
-  error:            "var(--error)",
-};
-
 interface Props {
   snapshot: KanbanSnapshot;
 }
 
 export function TaskGanttChart({ snapshot }: Props) {
-  const taskCards = useMemo(() => {
-    const all: Extract<KanbanCard, { kind: "task" }>[] = [];
-    for (const cards of Object.values(snapshot.columns)) {
-      for (const c of cards) {
-        if (c.kind === "task") all.push(c);
-      }
-    }
-    return all;
-  }, [snapshot]);
+  const taskCards = useMemo(() => extractTaskCards(snapshot), [snapshot]);
 
   const layout = useMemo(() => {
     const nodes = taskCards.map((c) => ({
@@ -190,7 +174,7 @@ export function TaskGanttChart({ snapshot }: Props) {
                 const barW = Math.max(4, xScale(new Date(endMs)) - barX);
                 const isPlaceholder = !n.startedAt;
 
-                const label = n.title.length > 22 ? n.title.slice(0, 21) + "…" : n.title;
+                const label = truncateTitle(n.title);
 
                 return (
                   <g key={n.id}>

--- a/src/components/TaskGanttChart.tsx
+++ b/src/components/TaskGanttChart.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useMemo } from "react";
+import * as d3 from "d3";
+import { D3Container } from "@/components/viz/D3Container";
+import { computeLayout } from "@/lib/kanban/dependencyLayout";
+import type { KanbanSnapshot, KanbanCard } from "@/lib/kanban/types";
+
+const ROW_H = 24;
+const ROW_GAP = 8;
+const LABEL_W = 160;
+const AXIS_H = 28;
+const PLACEHOLDER_MIN = 30 * 60 * 1000; // 30 min in ms (visual only)
+
+const STATUS_COLOR: Record<string, string> = {
+  working:          "var(--success, #22c55e)",
+  waiting:          "var(--accent)",
+  idle:             "var(--text-muted)",
+  done:             "var(--info)",
+  error:            "var(--error)",
+};
+
+interface Props {
+  snapshot: KanbanSnapshot;
+}
+
+export function TaskGanttChart({ snapshot }: Props) {
+  const taskCards = useMemo(() => {
+    const all: Extract<KanbanCard, { kind: "task" }>[] = [];
+    for (const cards of Object.values(snapshot.columns)) {
+      for (const c of cards) {
+        if (c.kind === "task") all.push(c);
+      }
+    }
+    return all;
+  }, [snapshot]);
+
+  const layout = useMemo(() => {
+    const nodes = taskCards.map((c) => ({
+      id: c.taskId,
+      title: c.title,
+      status: c.column,
+      priority: 3,
+      createdAt: c.createdAt,
+      startedAt: c.startedAt,
+      completedAt: c.completedAt,
+      cancelled: c.cancelled,
+      blockedBy: c.blockedBy,
+      blocks: c.blocks,
+    }));
+    return computeLayout(nodes, 1, ROW_H, 0, ROW_GAP);
+  }, [taskCards]);
+
+  if (layout.nodes.length === 0) {
+    return (
+      <div
+        style={{
+          padding: "64px 32px",
+          textAlign: "center",
+          color: "var(--text-muted)",
+          fontSize: "0.85rem",
+        }}
+      >
+        No task activity yet.
+      </div>
+    );
+  }
+
+  const now = Date.now();
+
+  // Compute time bounds across all tasks.
+  let minTime = now;
+  let maxTime = now;
+  for (const n of layout.nodes) {
+    const start = n.startedAt
+      ? new Date(n.startedAt).getTime()
+      : new Date(n.createdAt).getTime();
+    const end = n.completedAt
+      ? new Date(n.completedAt).getTime()
+      : n.status === "working" || n.status === "waiting"
+        ? now
+        : new Date(n.createdAt).getTime() + PLACEHOLDER_MIN;
+    if (start < minTime) minTime = start;
+    if (end > maxTime) maxTime = end;
+  }
+  // Pad 5% on each side.
+  const span = Math.max(maxTime - minTime, PLACEHOLDER_MIN);
+  minTime = minTime - span * 0.05;
+  maxTime = maxTime + span * 0.05;
+
+  const totalRows = layout.nodes.length;
+  const svgHeight = totalRows * (ROW_H + ROW_GAP) + AXIS_H;
+
+  // Build edge set for dependency arrows.
+  const nodeMap = new Map(layout.nodes.map((n) => [n.id, n]));
+  const edges: { fromId: number; toId: number }[] = [];
+  for (const n of layout.nodes) {
+    for (const bid of n.blockedBy) {
+      if (nodeMap.has(bid)) edges.push({ fromId: bid, toId: n.id });
+    }
+  }
+
+  return (
+    <div style={{ overflowX: "auto", padding: "8px 0" }}>
+      <D3Container
+        height={svgHeight + 16}
+        margin={{ top: 8, right: 16, bottom: AXIS_H, left: LABEL_W }}
+      >
+        {({ width, showTooltip, hideTooltip }) => {
+          const xScale = d3.scaleTime()
+            .domain([new Date(minTime), new Date(maxTime)])
+            .range([0, width]);
+          const tickValues = xScale.ticks(6);
+          const tickFmt = d3.timeFormat(
+            (maxTime - minTime) < 24 * 3600 * 1000 ? "%H:%M" : "%b %d"
+          );
+
+          return (
+            <g>
+              {/* Horizontal grid lines */}
+              {layout.nodes.map((n) => {
+                const rowY = n.order * (ROW_H + ROW_GAP);
+                return (
+                  <line
+                    key={`grid-${n.id}`}
+                    x1={0} y1={rowY + ROW_H / 2}
+                    x2={width} y2={rowY + ROW_H / 2}
+                    stroke="var(--border-default, #333)"
+                    strokeWidth={0.5}
+                    strokeDasharray="3,4"
+                  />
+                );
+              })}
+
+              {/* Dependency arrows (drawn before bars) */}
+              {edges.map(({ fromId, toId }) => {
+                const from = nodeMap.get(fromId);
+                const to   = nodeMap.get(toId);
+                if (!from || !to) return null;
+
+                const fromEnd = from.completedAt
+                  ? new Date(from.completedAt).getTime()
+                  : from.status === "working" ? now
+                  : new Date(from.createdAt).getTime() + PLACEHOLDER_MIN;
+                const toStart = to.startedAt
+                  ? new Date(to.startedAt).getTime()
+                  : new Date(to.createdAt).getTime();
+
+                const x1 = xScale(new Date(fromEnd));
+                const y1 = from.order * (ROW_H + ROW_GAP) + ROW_H / 2;
+                const x2 = xScale(new Date(toStart));
+                const y2 = to.order * (ROW_H + ROW_GAP) + ROW_H / 2;
+
+                return (
+                  <path
+                    key={`dep-${fromId}-${toId}`}
+                    d={`M ${x1} ${y1} Q ${x1 + 20} ${y1}, ${x1 + 20} ${(y1 + y2) / 2} T ${x2} ${y2}`}
+                    fill="none"
+                    stroke="var(--text-muted)"
+                    strokeWidth={1}
+                    strokeDasharray="4,3"
+                    markerEnd="url(#gantt-arrow)"
+                  />
+                );
+              })}
+
+              {/* Arrow marker */}
+              <defs>
+                <marker id="gantt-arrow" viewBox="0 0 8 8" refX="7" refY="4"
+                  markerWidth={5} markerHeight={5} orient="auto-start-reverse">
+                  <path d="M 0 0 L 8 4 L 0 8 z" fill="var(--text-muted)" />
+                </marker>
+              </defs>
+
+              {/* Task bars + labels */}
+              {layout.nodes.map((n) => {
+                const rowY = n.order * (ROW_H + ROW_GAP);
+                const color = STATUS_COLOR[n.status] ?? "var(--text-muted)";
+
+                const startMs = n.startedAt
+                  ? new Date(n.startedAt).getTime()
+                  : new Date(n.createdAt).getTime();
+                const endMs = n.completedAt
+                  ? new Date(n.completedAt).getTime()
+                  : (n.status === "working" || n.status === "waiting")
+                    ? now
+                    : startMs + PLACEHOLDER_MIN;
+
+                const barX = xScale(new Date(startMs));
+                const barW = Math.max(4, xScale(new Date(endMs)) - barX);
+                const isPlaceholder = !n.startedAt;
+
+                const label = n.title.length > 22 ? n.title.slice(0, 21) + "…" : n.title;
+
+                return (
+                  <g key={n.id}>
+                    {/* Row label (left margin area) */}
+                    <text
+                      x={-8}
+                      y={rowY + ROW_H / 2}
+                      textAnchor="end"
+                      dominantBaseline="middle"
+                      fontSize="0.68rem"
+                      fontFamily="var(--font-mono)"
+                      fill="var(--text-secondary)"
+                    >
+                      {label}
+                    </text>
+
+                    {/* Bar */}
+                    <rect
+                      x={barX}
+                      y={rowY + 2}
+                      width={barW}
+                      height={ROW_H - 4}
+                      rx={3}
+                      fill={isPlaceholder
+                        ? "transparent"
+                        : `color-mix(in srgb, ${color} 35%, transparent)`
+                      }
+                      stroke={color}
+                      strokeWidth={isPlaceholder ? 1 : 0}
+                      strokeDasharray={isPlaceholder ? "4,3" : undefined}
+                      style={{ cursor: "pointer" }}
+                      onMouseEnter={(e) => showTooltip(e.clientX, e.clientY,
+                        `#${n.id} ${n.title}\n${n.status}${n.cancelled ? " (cancelled)" : ""}`
+                      )}
+                      onMouseLeave={hideTooltip}
+                    />
+                  </g>
+                );
+              })}
+
+              {/* X axis */}
+              <g transform={`translate(0, ${totalRows * (ROW_H + ROW_GAP)})`}>
+                <line x1={0} y1={0} x2={width} y2={0} stroke="var(--border-default, #333)" />
+                {tickValues.map((t, i) => (
+                  <g key={i} transform={`translate(${xScale(t)}, 0)`}>
+                    <line y1={0} y2={5} stroke="var(--border-default, #333)" />
+                    <text
+                      y={16}
+                      textAnchor="middle"
+                      fontSize="0.62rem"
+                      fontFamily="var(--font-mono)"
+                      fill="var(--text-muted)"
+                    >
+                      {tickFmt(t)}
+                    </text>
+                  </g>
+                ))}
+              </g>
+            </g>
+          );
+        }}
+      </D3Container>
+    </div>
+  );
+}

--- a/src/components/TaskGanttChart.tsx
+++ b/src/components/TaskGanttChart.tsx
@@ -52,6 +52,15 @@ export function TaskGanttChart({ snapshot }: Props) {
 
   const now = Date.now();
 
+  // Build a global row index sorted by (layer, order) so that rows are
+  // sequential across layers. `n.order` is a within-layer index that resets
+  // to 0 for each layer — using it directly as rowY causes nodes in later
+  // layers to overlap earlier-layer rows that share the same within-layer index.
+  const sortedNodes = [...layout.nodes].sort(
+    (a, b) => a.layer - b.layer || a.order - b.order
+  );
+  const rowIndex = new Map(sortedNodes.map((n, i) => [n.id, i]));
+
   // Compute time bounds across all tasks.
   let minTime = now;
   let maxTime = now;
@@ -103,7 +112,7 @@ export function TaskGanttChart({ snapshot }: Props) {
             <g>
               {/* Horizontal grid lines */}
               {layout.nodes.map((n) => {
-                const rowY = n.order * (ROW_H + ROW_GAP);
+                const rowY = rowIndex.get(n.id)! * (ROW_H + ROW_GAP);
                 return (
                   <line
                     key={`grid-${n.id}`}
@@ -131,9 +140,9 @@ export function TaskGanttChart({ snapshot }: Props) {
                   : new Date(to.createdAt).getTime();
 
                 const x1 = xScale(new Date(fromEnd));
-                const y1 = from.order * (ROW_H + ROW_GAP) + ROW_H / 2;
+                const y1 = rowIndex.get(from.id)! * (ROW_H + ROW_GAP) + ROW_H / 2;
                 const x2 = xScale(new Date(toStart));
-                const y2 = to.order * (ROW_H + ROW_GAP) + ROW_H / 2;
+                const y2 = rowIndex.get(to.id)! * (ROW_H + ROW_GAP) + ROW_H / 2;
 
                 return (
                   <path
@@ -158,7 +167,7 @@ export function TaskGanttChart({ snapshot }: Props) {
 
               {/* Task bars + labels */}
               {layout.nodes.map((n) => {
-                const rowY = n.order * (ROW_H + ROW_GAP);
+                const rowY = rowIndex.get(n.id)! * (ROW_H + ROW_GAP);
                 const color = STATUS_COLOR[n.status] ?? "var(--text-muted)";
 
                 const startMs = n.startedAt

--- a/src/components/ui/chip.tsx
+++ b/src/components/ui/chip.tsx
@@ -4,13 +4,16 @@ export function Chip({
   label,
   color = "var(--text-muted)",
   muted = false,
+  title,
 }: {
   label: string;
   color?: string;
   muted?: boolean;
+  title?: string;
 }) {
   return (
     <span
+      title={title}
       style={{
         fontSize: "0.6rem",
         fontFamily: "var(--font-mono)",

--- a/src/lib/kanban/buildBoard.ts
+++ b/src/lib/kanban/buildBoard.ts
@@ -10,10 +10,14 @@ export interface BuildBoardInput {
   dispatcherEnabled: boolean;
   /** Open decision counts per task id. Missing keys default to 0. */
   decisionCounts?: Map<number, number>;
+  /** Blocker ids per task id. Missing keys default to []. */
+  blockedByMap?: Map<number, number[]>;
+  /** Dependent ids per task id. Missing keys default to []. */
+  blocksMap?: Map<number, number[]>;
 }
 
 export function buildBoard(
-  { sessions, tasks, dispatcherEnabled, decisionCounts }: BuildBoardInput,
+  { sessions, tasks, dispatcherEnabled, decisionCounts, blockedByMap, blocksMap }: BuildBoardInput,
   generatedAt: string,
 ): KanbanSnapshot {
   const columns: Record<KanbanColumn, KanbanCard[]> = {
@@ -53,6 +57,8 @@ export function buildBoard(
       costUsd: t.cost_usd,
       sessionId: t.session_id,
       decisionCount: decisionCounts?.get(t.id) ?? 0,
+      blockedBy: blockedByMap?.get(t.id) ?? [],
+      blocks: blocksMap?.get(t.id) ?? [],
       createdAt: t.created_at,
       startedAt: t.started_at,
       completedAt: t.completed_at,

--- a/src/lib/kanban/dependencyLayout.ts
+++ b/src/lib/kanban/dependencyLayout.ts
@@ -7,6 +7,8 @@
  * receive layer 0 and the layout degrades gracefully rather than looping.
  */
 
+import type { KanbanSnapshot, KanbanCard } from "@/lib/kanban/types";
+
 export interface LayoutNode {
   id: number;
   title: string;
@@ -37,6 +39,33 @@ export interface DependencyLayout {
   layerSizes: number[];
 }
 
+/** Column-keyed status colors shared by DAG and Gantt views. */
+export const STATUS_COLOR: Record<string, string> = {
+  working: "var(--success, #22c55e)",
+  waiting: "var(--accent)",
+  idle:    "var(--text-muted)",
+  done:    "var(--info)",
+  error:   "var(--error)",
+};
+
+/** Extract all task cards from a KanbanSnapshot across all columns. */
+export function extractTaskCards(
+  snapshot: KanbanSnapshot
+): Extract<KanbanCard, { kind: "task" }>[] {
+  const result: Extract<KanbanCard, { kind: "task" }>[] = [];
+  for (const cards of Object.values(snapshot.columns)) {
+    for (const c of cards) {
+      if (c.kind === "task") result.push(c);
+    }
+  }
+  return result;
+}
+
+/** Truncate a title to maxLen chars, appending "…" if needed. */
+export function truncateTitle(title: string, maxLen = 22): string {
+  return title.length > maxLen ? title.slice(0, maxLen - 1) + "…" : title;
+}
+
 /**
  * Compute a layered layout for the given nodes.
  *
@@ -58,29 +87,27 @@ export function computeLayout(
   }
 
   const idSet = new Set(nodes.map((n) => n.id));
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
 
   // Longest-path layer assignment. Nodes with no in-graph blockers → layer 0.
   const layerMap = new Map<number, number>();
-  const assigned = new Set<number>();
 
   function assignLayer(id: number, depth: number): number {
     if (depth > nodes.length) return 0; // cycle guard
     if (layerMap.has(id)) return layerMap.get(id)!;
 
-    const node = nodes.find((n) => n.id === id);
+    const node = nodeById.get(id);
     if (!node) { layerMap.set(id, 0); return 0; }
 
     const blockers = node.blockedBy.filter((b) => idSet.has(b));
     if (blockers.length === 0) {
       layerMap.set(id, 0);
-      assigned.add(id);
       return 0;
     }
 
     const maxBlockerLayer = Math.max(...blockers.map((b) => assignLayer(b, depth + 1)));
     const layer = maxBlockerLayer + 1;
     layerMap.set(id, layer);
-    assigned.add(id);
     return layer;
   }
 
@@ -107,19 +134,23 @@ export function computeLayout(
     layerSizes.push(byLayer.get(l)?.length ?? 0);
   }
 
-  const positioned: PositionedNode[] = [];
-  for (const n of nodes) {
+  // Build per-node order index from the sorted layer arrays in O(n).
+  const orderByid = new Map<number, number>();
+  for (const [, layerNodes] of byLayer) {
+    layerNodes.forEach((n, i) => orderByid.set(n.id, i));
+  }
+
+  const positioned: PositionedNode[] = nodes.map((n) => {
     const layer = layerMap.get(n.id) ?? 0;
-    const layerNodes = byLayer.get(layer) ?? [];
-    const order = layerNodes.findIndex((ln) => ln.id === n.id);
-    positioned.push({
+    const order = orderByid.get(n.id) ?? 0;
+    return {
       ...n,
       layer,
       order,
       x: layer * (nodeWidthPx + gapXPx),
       y: order * (nodeHeightPx + gapYPx),
-    });
-  }
+    };
+  });
 
   return { nodes: positioned, maxLayer, layerSizes };
 }

--- a/src/lib/kanban/dependencyLayout.ts
+++ b/src/lib/kanban/dependencyLayout.ts
@@ -3,8 +3,9 @@
  * Shared by TaskDependencyGraph (SVG DAG view) and TaskGanttChart (Gantt rows).
  *
  * Assumes no cycles — enforced at DB insert time by addDependency's DFS check.
- * If a cycle somehow appears in the data (corrupt DB), nodes in the cycle
- * receive layer 0 and the layout degrades gracefully rather than looping.
+ * If a cycle somehow appears in the data (corrupt DB), the visiting-set guard
+ * clamps cycle-involved nodes to layer 0 and the layout degrades gracefully
+ * rather than looping.
  */
 
 import type { KanbanSnapshot, KanbanCard } from "@/lib/kanban/types";
@@ -91,10 +92,11 @@ export function computeLayout(
 
   // Longest-path layer assignment. Nodes with no in-graph blockers → layer 0.
   const layerMap = new Map<number, number>();
+  const visiting = new Set<number>(); // DFS recursion stack for cycle detection
 
-  function assignLayer(id: number, depth: number): number {
-    if (depth > nodes.length) return 0; // cycle guard
+  function assignLayer(id: number): number {
     if (layerMap.has(id)) return layerMap.get(id)!;
+    if (visiting.has(id)) return 0; // back-edge detected — clamp to 0
 
     const node = nodeById.get(id);
     if (!node) { layerMap.set(id, 0); return 0; }
@@ -105,13 +107,16 @@ export function computeLayout(
       return 0;
     }
 
-    const maxBlockerLayer = Math.max(...blockers.map((b) => assignLayer(b, depth + 1)));
+    visiting.add(id);
+    const maxBlockerLayer = Math.max(...blockers.map((b) => assignLayer(b)));
+    visiting.delete(id);
+
     const layer = maxBlockerLayer + 1;
     layerMap.set(id, layer);
     return layer;
   }
 
-  for (const n of nodes) assignLayer(n.id, 0);
+  for (const n of nodes) assignLayer(n.id);
 
   // Group nodes by layer, sort within each layer by (priority ASC, createdAt ASC).
   const byLayer = new Map<number, LayoutNode[]>();

--- a/src/lib/kanban/dependencyLayout.ts
+++ b/src/lib/kanban/dependencyLayout.ts
@@ -1,0 +1,125 @@
+/**
+ * Sugiyama-style layered layout for task dependency DAGs.
+ * Shared by TaskDependencyGraph (SVG DAG view) and TaskGanttChart (Gantt rows).
+ *
+ * Assumes no cycles — enforced at DB insert time by addDependency's DFS check.
+ * If a cycle somehow appears in the data (corrupt DB), nodes in the cycle
+ * receive layer 0 and the layout degrades gracefully rather than looping.
+ */
+
+export interface LayoutNode {
+  id: number;
+  title: string;
+  status: string;
+  priority: number;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  cancelled: boolean;
+  /** Ids that must be 'done' before this task can run. */
+  blockedBy: number[];
+  /** Ids that this task blocks. */
+  blocks: number[];
+}
+
+export interface PositionedNode extends LayoutNode {
+  layer: number;   // 0 = root (no blockers), higher = deeper in the chain
+  order: number;   // within-layer index
+  x: number;      // pixel x (set by caller after knowing layout bounds)
+  y: number;      // pixel y
+}
+
+export interface DependencyLayout {
+  nodes: PositionedNode[];
+  /** Max layer index (0-based). */
+  maxLayer: number;
+  /** Count of nodes per layer. */
+  layerSizes: number[];
+}
+
+/**
+ * Compute a layered layout for the given nodes.
+ *
+ * @param nodes - All task nodes that should appear in the graph.
+ * @param nodeWidthPx - Width of each node rectangle.
+ * @param nodeHeightPx - Height of each node rectangle.
+ * @param gapXPx - Horizontal gap between layers.
+ * @param gapYPx - Vertical gap between nodes in the same layer.
+ */
+export function computeLayout(
+  nodes: LayoutNode[],
+  nodeWidthPx: number,
+  nodeHeightPx: number,
+  gapXPx: number,
+  gapYPx: number,
+): DependencyLayout {
+  if (nodes.length === 0) {
+    return { nodes: [], maxLayer: 0, layerSizes: [] };
+  }
+
+  const idSet = new Set(nodes.map((n) => n.id));
+
+  // Longest-path layer assignment. Nodes with no in-graph blockers → layer 0.
+  const layerMap = new Map<number, number>();
+  const assigned = new Set<number>();
+
+  function assignLayer(id: number, depth: number): number {
+    if (depth > nodes.length) return 0; // cycle guard
+    if (layerMap.has(id)) return layerMap.get(id)!;
+
+    const node = nodes.find((n) => n.id === id);
+    if (!node) { layerMap.set(id, 0); return 0; }
+
+    const blockers = node.blockedBy.filter((b) => idSet.has(b));
+    if (blockers.length === 0) {
+      layerMap.set(id, 0);
+      assigned.add(id);
+      return 0;
+    }
+
+    const maxBlockerLayer = Math.max(...blockers.map((b) => assignLayer(b, depth + 1)));
+    const layer = maxBlockerLayer + 1;
+    layerMap.set(id, layer);
+    assigned.add(id);
+    return layer;
+  }
+
+  for (const n of nodes) assignLayer(n.id, 0);
+
+  // Group nodes by layer, sort within each layer by (priority ASC, createdAt ASC).
+  const byLayer = new Map<number, LayoutNode[]>();
+  for (const n of nodes) {
+    const layer = layerMap.get(n.id) ?? 0;
+    if (!byLayer.has(layer)) byLayer.set(layer, []);
+    byLayer.get(layer)!.push(n);
+  }
+
+  for (const [, layerNodes] of byLayer) {
+    layerNodes.sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority - b.priority;
+      return a.createdAt.localeCompare(b.createdAt);
+    });
+  }
+
+  const maxLayer = Math.max(...layerMap.values());
+  const layerSizes: number[] = [];
+  for (let l = 0; l <= maxLayer; l++) {
+    layerSizes.push(byLayer.get(l)?.length ?? 0);
+  }
+
+  const positioned: PositionedNode[] = [];
+  for (const n of nodes) {
+    const layer = layerMap.get(n.id) ?? 0;
+    const layerNodes = byLayer.get(layer) ?? [];
+    const order = layerNodes.findIndex((ln) => ln.id === n.id);
+    positioned.push({
+      ...n,
+      layer,
+      order,
+      x: layer * (nodeWidthPx + gapXPx),
+      y: order * (nodeHeightPx + gapYPx),
+    });
+  }
+
+  return { nodes: positioned, maxLayer, layerSizes };
+}

--- a/src/lib/kanban/types.ts
+++ b/src/lib/kanban/types.ts
@@ -52,6 +52,10 @@ export type KanbanCard =
       sessionId: string | null;
       /** Number of pending decisions for this task. */
       decisionCount: number;
+      /** Task ids this task is blocked by (blockers not yet 'done'). */
+      blockedBy: number[];
+      /** Task ids that are blocked by this task. */
+      blocks: number[];
       createdAt: string;
       startedAt: string | null;
       completedAt: string | null;

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -6,6 +6,7 @@ import { computeNextRun } from "./cron";
 import type {
   Task,
   TaskDecision,
+  TaskDependency,
   Schedule,
   CreateTaskInput,
   PatchTaskInput,
@@ -74,28 +75,47 @@ export async function getTask(id: number): Promise<Task | null> {
 export async function createTask(input: CreateTaskInput): Promise<Task> {
   const db = await ensureReady();
   const metadataJson = input.metadata !== undefined ? JSON.stringify(input.metadata) : null;
-  const result = prepTasksCached(
-    db,
-    `INSERT INTO ops_tasks
-      (title, description, priority, quadrant, assigned_skill, model,
-       execution_mode, scheduled_for, requires_approval, risk_level, dry_run, metadata)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     RETURNING *`
-  ).get(
-    input.title,
-    input.description ?? "",
-    input.priority ?? 3,
-    input.quadrant ?? "do",
-    input.assigned_skill ?? null,
-    input.model ?? null,
-    input.execution_mode ?? "classic",
-    input.scheduled_for ?? null,
-    input.requires_approval ? 1 : 0,
-    input.risk_level ?? "low",
-    input.dry_run ? 1 : 0,
-    metadataJson
-  ) as Task;
-  return result;
+
+  let createdTask: Task;
+  const txn = db.transaction(() => {
+    createdTask = db
+      .prepare(
+        `INSERT INTO ops_tasks
+          (title, description, priority, quadrant, assigned_skill, model,
+           execution_mode, scheduled_for, requires_approval, risk_level, dry_run, metadata)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         RETURNING *`
+      )
+      .get(
+        input.title,
+        input.description ?? "",
+        input.priority ?? 3,
+        input.quadrant ?? "do",
+        input.assigned_skill ?? null,
+        input.model ?? null,
+        input.execution_mode ?? "classic",
+        input.scheduled_for ?? null,
+        input.requires_approval ? 1 : 0,
+        input.risk_level ?? "low",
+        input.dry_run ? 1 : 0,
+        metadataJson
+      ) as Task;
+
+    // Insert blocker edges synchronously inside the same transaction.
+    // addDependency uses its own ensureReady + transaction, so we inline the
+    // core insert here to stay within the outer transaction.
+    if (input.blockedBy && input.blockedBy.length > 0) {
+      for (const blockerId of input.blockedBy) {
+        if (blockerId === createdTask.id) throw new CycleError(createdTask.id, blockerId);
+        db.prepare(
+          `INSERT INTO task_dependencies (task_id, blocker_id) VALUES (?, ?)
+           ON CONFLICT(task_id, blocker_id) DO NOTHING`
+        ).run(createdTask.id, blockerId);
+      }
+    }
+  });
+  txn();
+  return createdTask!;
 }
 
 export async function patchTask(id: number, input: PatchTaskInput): Promise<Task | null> {
@@ -149,6 +169,12 @@ export async function claimPendingTask(): Promise<Task | null> {
        WHERE status = 'pending'
          AND requires_approval = 0
          AND (scheduled_for IS NULL OR scheduled_for <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+         AND NOT EXISTS (
+           SELECT 1 FROM task_dependencies td
+           JOIN ops_tasks bt ON bt.id = td.blocker_id
+           WHERE td.task_id = ops_tasks.id
+             AND bt.status != 'done'
+         )
        ORDER BY priority ASC, created_at ASC
        LIMIT 1
      )
@@ -171,7 +197,13 @@ export async function promoteApprovalTasks(): Promise<number> {
      WHERE status = 'pending'
        AND requires_approval = 1
        AND approved_at IS NULL
-       AND (scheduled_for IS NULL OR scheduled_for <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`
+       AND (scheduled_for IS NULL OR scheduled_for <= strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+       AND NOT EXISTS (
+         SELECT 1 FROM task_dependencies td
+         JOIN ops_tasks bt ON bt.id = td.blocker_id
+         WHERE td.task_id = ops_tasks.id
+           AND bt.status != 'done'
+       )`
   ).run();
   return result.changes;
 }
@@ -458,6 +490,90 @@ export async function countOpenDecisionsByTask(): Promise<Map<number, number>> {
      GROUP BY task_id`
   ).all() as { task_id: number; n: number }[];
   return new Map(rows.map((r) => [r.task_id, r.n]));
+}
+
+// ---------------------------------------------------------------------------
+// Task dependencies
+// ---------------------------------------------------------------------------
+
+export class CycleError extends Error {
+  constructor(taskId: number, blockerId: number) {
+    super(`Adding dependency ${taskId}→${blockerId} would create a cycle`);
+    this.name = "CycleError";
+  }
+}
+
+/**
+ * Add a blocking relationship: taskId is blocked by blockerId.
+ * Runs cycle-prevention DFS inside a transaction. Idempotent on duplicate.
+ * Throws CycleError if the edge would close a cycle.
+ */
+export async function addDependency(taskId: number, blockerId: number): Promise<TaskDependency> {
+  if (taskId === blockerId) throw new CycleError(taskId, blockerId);
+  const db = await ensureReady();
+
+  let result: TaskDependency | undefined;
+  const txn = db.transaction(() => {
+    // DFS from taskId over "blocks" edges: if we can reach blockerId, the new
+    // edge would close a cycle (blockerId → taskId already has a reverse path).
+    const visited = new Set<number>();
+    const stack = [taskId];
+    while (stack.length > 0) {
+      const cur = stack.pop()!;
+      if (cur === blockerId) throw new CycleError(taskId, blockerId);
+      if (visited.has(cur)) continue;
+      visited.add(cur);
+      const outgoing = db
+        .prepare("SELECT task_id FROM task_dependencies WHERE blocker_id = ?")
+        .all(cur) as { task_id: number }[];
+      for (const row of outgoing) stack.push(row.task_id);
+    }
+
+    result = db
+      .prepare(
+        `INSERT INTO task_dependencies (task_id, blocker_id)
+         VALUES (?, ?)
+         ON CONFLICT(task_id, blocker_id) DO UPDATE SET created_at = created_at
+         RETURNING *`
+      )
+      .get(taskId, blockerId) as TaskDependency;
+  });
+  txn();
+  return result!;
+}
+
+/** Remove a blocking relationship. Returns true if the edge existed, false if not found. */
+export async function removeDependency(taskId: number, blockerId: number): Promise<boolean> {
+  const db = await ensureReady();
+  const result = db
+    .prepare("DELETE FROM task_dependencies WHERE task_id = ? AND blocker_id = ?")
+    .run(taskId, blockerId);
+  return result.changes > 0;
+}
+
+/** Get the direct blockedBy and blocks lists for a single task. */
+export async function listDependencies(
+  taskId: number
+): Promise<{ blockedBy: number[]; blocks: number[] }> {
+  const db = await ensureReady();
+  const blockedByRows = db
+    .prepare("SELECT blocker_id FROM task_dependencies WHERE task_id = ?")
+    .all(taskId) as { blocker_id: number }[];
+  const blocksRows = db
+    .prepare("SELECT task_id FROM task_dependencies WHERE blocker_id = ?")
+    .all(taskId) as { task_id: number }[];
+  return {
+    blockedBy: blockedByRows.map((r) => r.blocker_id),
+    blocks: blocksRows.map((r) => r.task_id),
+  };
+}
+
+/** Return every dependency row. Used by /api/kanban to build per-card blocked state. */
+export async function listAllDependencies(): Promise<TaskDependency[]> {
+  const db = await ensureReady();
+  return db
+    .prepare("SELECT * FROM task_dependencies ORDER BY created_at ASC")
+    .all() as TaskDependency[];
 }
 
 /** Count decisions created after sinceEpoch (Unix seconds). Used by pulse for per-client edge-triggering. */

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -101,16 +101,18 @@ export async function createTask(input: CreateTaskInput): Promise<Task> {
         metadataJson
       ) as Task;
 
-    // Insert blocker edges synchronously inside the same transaction.
-    // addDependency uses its own ensureReady + transaction, so we inline the
-    // core insert here to stay within the outer transaction.
+    // Insert blocker edges inside the same transaction.
+    // Inlined rather than calling addDependency (which owns its own transaction).
+    // Cycle detection is skipped: createdTask.id is brand-new, so no existing
+    // edge can point back to it — a cycle is impossible for fresh tasks.
     if (input.blockedBy && input.blockedBy.length > 0) {
+      const insertDep = prepTasksCached(db,
+        `INSERT INTO task_dependencies (task_id, blocker_id) VALUES (?, ?)
+         ON CONFLICT(task_id, blocker_id) DO NOTHING`
+      );
       for (const blockerId of input.blockedBy) {
         if (blockerId === createdTask.id) throw new CycleError(createdTask.id, blockerId);
-        db.prepare(
-          `INSERT INTO task_dependencies (task_id, blocker_id) VALUES (?, ?)
-           ON CONFLICT(task_id, blocker_id) DO NOTHING`
-        ).run(createdTask.id, blockerId);
+        insertDep.run(createdTask.id, blockerId);
       }
     }
   });
@@ -514,8 +516,15 @@ export async function addDependency(taskId: number, blockerId: number): Promise<
 
   let result: TaskDependency | undefined;
   const txn = db.transaction(() => {
-    // DFS from taskId over "blocks" edges: if we can reach blockerId, the new
-    // edge would close a cycle (blockerId → taskId already has a reverse path).
+    const outgoingStmt = prepTasksCached(db, "SELECT task_id FROM task_dependencies WHERE blocker_id = ?");
+    const insertStmt = prepTasksCached(db,
+      `INSERT INTO task_dependencies (task_id, blocker_id)
+       VALUES (?, ?)
+       ON CONFLICT(task_id, blocker_id) DO UPDATE SET created_at = created_at
+       RETURNING *`
+    );
+
+    // DFS from taskId: if we can reach blockerId, the new edge would close a cycle.
     const visited = new Set<number>();
     const stack = [taskId];
     while (stack.length > 0) {
@@ -523,20 +532,11 @@ export async function addDependency(taskId: number, blockerId: number): Promise<
       if (cur === blockerId) throw new CycleError(taskId, blockerId);
       if (visited.has(cur)) continue;
       visited.add(cur);
-      const outgoing = db
-        .prepare("SELECT task_id FROM task_dependencies WHERE blocker_id = ?")
-        .all(cur) as { task_id: number }[];
+      const outgoing = outgoingStmt.all(cur) as { task_id: number }[];
       for (const row of outgoing) stack.push(row.task_id);
     }
 
-    result = db
-      .prepare(
-        `INSERT INTO task_dependencies (task_id, blocker_id)
-         VALUES (?, ?)
-         ON CONFLICT(task_id, blocker_id) DO UPDATE SET created_at = created_at
-         RETURNING *`
-      )
-      .get(taskId, blockerId) as TaskDependency;
+    result = insertStmt.get(taskId, blockerId) as TaskDependency;
   });
   txn();
   return result!;
@@ -545,9 +545,9 @@ export async function addDependency(taskId: number, blockerId: number): Promise<
 /** Remove a blocking relationship. Returns true if the edge existed, false if not found. */
 export async function removeDependency(taskId: number, blockerId: number): Promise<boolean> {
   const db = await ensureReady();
-  const result = db
-    .prepare("DELETE FROM task_dependencies WHERE task_id = ? AND blocker_id = ?")
-    .run(taskId, blockerId);
+  const result = prepTasksCached(db,
+    "DELETE FROM task_dependencies WHERE task_id = ? AND blocker_id = ?"
+  ).run(taskId, blockerId);
   return result.changes > 0;
 }
 
@@ -556,12 +556,12 @@ export async function listDependencies(
   taskId: number
 ): Promise<{ blockedBy: number[]; blocks: number[] }> {
   const db = await ensureReady();
-  const blockedByRows = db
-    .prepare("SELECT blocker_id FROM task_dependencies WHERE task_id = ?")
-    .all(taskId) as { blocker_id: number }[];
-  const blocksRows = db
-    .prepare("SELECT task_id FROM task_dependencies WHERE blocker_id = ?")
-    .all(taskId) as { task_id: number }[];
+  const blockedByRows = prepTasksCached(db,
+    "SELECT blocker_id FROM task_dependencies WHERE task_id = ?"
+  ).all(taskId) as { blocker_id: number }[];
+  const blocksRows = prepTasksCached(db,
+    "SELECT task_id FROM task_dependencies WHERE blocker_id = ?"
+  ).all(taskId) as { task_id: number }[];
   return {
     blockedBy: blockedByRows.map((r) => r.blocker_id),
     blocks: blocksRows.map((r) => r.task_id),
@@ -571,9 +571,9 @@ export async function listDependencies(
 /** Return every dependency row. Used by /api/kanban to build per-card blocked state. */
 export async function listAllDependencies(): Promise<TaskDependency[]> {
   const db = await ensureReady();
-  return db
-    .prepare("SELECT * FROM task_dependencies ORDER BY created_at ASC")
-    .all() as TaskDependency[];
+  return prepTasksCached(db,
+    "SELECT * FROM task_dependencies ORDER BY created_at ASC"
+  ).all() as TaskDependency[];
 }
 
 /** Count decisions created after sinceEpoch (Unix seconds). Used by pulse for per-client edge-triggering. */

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -80,6 +80,13 @@ export interface Task {
 
 export type DecisionKind = "decision" | "inbox";
 
+export interface TaskDependency {
+  id: number;
+  task_id: number;
+  blocker_id: number;
+  created_at: string;
+}
+
 export interface TaskDecision {
   id: number;
   task_id: number;
@@ -120,6 +127,8 @@ export interface CreateTaskInput {
   dry_run?: boolean;
   /** Arbitrary JSON metadata (e.g. todoDelegation source info). */
   metadata?: unknown;
+  /** Task ids that must reach 'done' before this task can be dispatched. */
+  blockedBy?: number[];
 }
 
 export interface PatchTaskInput {

--- a/src/lib/tasks/validation.ts
+++ b/src/lib/tasks/validation.ts
@@ -74,6 +74,14 @@ export function validateCreateTask(body: unknown): CreateTaskInput | { error: st
   if (b.dry_run !== undefined && typeof b.dry_run !== "boolean") {
     return { error: "dry_run must be a boolean", field: "dry_run" };
   }
+  if (b.blockedBy !== undefined) {
+    if (
+      !Array.isArray(b.blockedBy) ||
+      !(b.blockedBy as unknown[]).every((v) => typeof v === "number" && Number.isInteger(v) && v > 0)
+    ) {
+      return { error: "blockedBy must be an array of positive integers", field: "blockedBy" };
+    }
+  }
 
   return {
     title: (b.title as string).trim(),
@@ -87,6 +95,7 @@ export function validateCreateTask(body: unknown): CreateTaskInput | { error: st
     requires_approval: typeof b.requires_approval === "boolean" ? b.requires_approval : undefined,
     risk_level: b.risk_level as RiskLevel | undefined,
     dry_run: typeof b.dry_run === "boolean" ? b.dry_run : undefined,
+    blockedBy: Array.isArray(b.blockedBy) ? (b.blockedBy as number[]) : undefined,
   };
 }
 

--- a/src/lib/tasksDb/migrations.ts
+++ b/src/lib/tasksDb/migrations.ts
@@ -141,6 +141,26 @@ const MIGRATIONS: Migration[] = [
       );
     },
   },
+  {
+    version: 4,
+    name: "task_dependencies — explicit blocking relationships (Wave 10.1b)",
+    up(db) {
+      runStatements(db, `
+        CREATE TABLE IF NOT EXISTS task_dependencies (
+          id          INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id     INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+          blocker_id  INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+          created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+          CHECK (task_id != blocker_id),
+          UNIQUE (task_id, blocker_id)
+        );
+        CREATE INDEX IF NOT EXISTS ix_task_deps_task
+          ON task_dependencies(task_id);
+        CREATE INDEX IF NOT EXISTS ix_task_deps_blocker
+          ON task_dependencies(blocker_id)
+      `);
+    },
+  },
 ];
 
 function resolveTasksSchemaPath(): string {

--- a/tests/apiKanban.test.ts
+++ b/tests/apiKanban.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/liveStatus", () => ({
 vi.mock("@/lib/tasks/store", () => ({
   listTasks: vi.fn(),
   countOpenDecisionsByTask: vi.fn(),
+  listAllDependencies: vi.fn(),
 }));
 
 vi.mock("@/lib/config", () => ({
@@ -20,13 +21,14 @@ vi.mock("@/lib/featureFlags", () => ({
 }));
 
 import { getLiveStatusPayload } from "@/lib/liveStatus";
-import { listTasks, countOpenDecisionsByTask } from "@/lib/tasks/store";
+import { listTasks, countOpenDecisionsByTask, listAllDependencies } from "@/lib/tasks/store";
 import { readConfig } from "@/lib/config";
 import { getFlag } from "@/lib/featureFlags";
 
 const mockGetLiveStatusPayload = vi.mocked(getLiveStatusPayload);
 const mockListTasks = vi.mocked(listTasks);
 const mockCountOpenDecisionsByTask = vi.mocked(countOpenDecisionsByTask);
+const mockListAllDependencies = vi.mocked(listAllDependencies);
 const mockReadConfig = vi.mocked(readConfig);
 const mockGetFlag = vi.mocked(getFlag);
 
@@ -42,6 +44,7 @@ beforeEach(() => {
   // Default: taskDispatcher flag is enabled
   mockReadConfig.mockResolvedValue({ statuses: {}, hidden: [], portOverrides: {}, devRoot: "C:\\dev", pinnedSlugs: [] } as any);
   mockGetFlag.mockReturnValue(true);
+  mockListAllDependencies.mockResolvedValue([]);
 });
 
 function mkGet(params?: Record<string, string>): NextRequest {
@@ -127,6 +130,28 @@ describe("GET /api/kanban", () => {
     const body = await res.json();
     expect(body.columns.working).toHaveLength(1);
     expect(body.columns.working[0].sessionId).toBe("sess-abc");
+  });
+
+  it("task cards include blockedBy field (defaults to [])", async () => {
+    const liveSession = {
+      sessionId: "s1",
+      projectSlug: "proj",
+      projectName: "Proj",
+      status: "working" as const,
+      mtime: NOW,
+    };
+    mockGetLiveStatusPayload.mockResolvedValue({
+      generatedAt: NOW,
+      sessions: [liveSession],
+    });
+    const res = await getRoute(mkGet());
+    const body = await res.json();
+    // No tasks, so check the structure still has blockedBy on task cards when tasks exist.
+    expect(Array.isArray(body.columns.working)).toBe(true);
+    // Sessions in working column don't have blockedBy — verify session card shape.
+    const card = body.columns.working[0];
+    expect(card.kind).toBe("session");
+    expect(card.blockedBy).toBeUndefined();
   });
 
   it("is read-only (no mutations)", async () => {

--- a/tests/apiKanban.test.ts
+++ b/tests/apiKanban.test.ts
@@ -154,6 +154,31 @@ describe("GET /api/kanban", () => {
     expect(card.blockedBy).toBeUndefined();
   });
 
+  it("excludes done blockers from task card's blockedBy", async () => {
+    const pendingTask = {
+      id: 10, title: "Dependent", status: "pending", quadrant: "do", priority: 3,
+      assigned_skill: null, model: null, risk_level: "low", execution_mode: "classic",
+      requires_approval: false, dry_run: false, scheduled_for: null,
+      created_at: NOW, started_at: null, completed_at: null,
+    };
+    const doneBlocker = {
+      id: 11, title: "Blocker", status: "done", quadrant: "do", priority: 3,
+      assigned_skill: null, model: null, risk_level: "low", execution_mode: "classic",
+      requires_approval: false, dry_run: false, scheduled_for: null,
+      created_at: NOW, started_at: NOW, completed_at: NOW,
+    };
+    mockListTasks.mockResolvedValue([pendingTask, doneBlocker] as any);
+    // dep edge: task 10 is blocked by task 11 (which is done)
+    mockListAllDependencies.mockResolvedValue([{ id: 1, task_id: 10, blocker_id: 11, created_at: NOW }] as any);
+    const res = await getRoute(mkGet());
+    const body = await res.json();
+    const idleCards = body.columns.idle;
+    const depCard = idleCards.find((c: { kind: string; taskId: number }) => c.kind === "task" && c.taskId === 10);
+    expect(depCard).toBeDefined();
+    // Blocker is done — blocked badge should NOT appear
+    expect(depCard.blockedBy).toEqual([]);
+  });
+
   it("is read-only (no mutations)", async () => {
     const routeModule = await import("@/app/api/kanban/route");
     expect((routeModule as Record<string, unknown>).POST).toBeUndefined();

--- a/tests/apiTaskDependencies.test.ts
+++ b/tests/apiTaskDependencies.test.ts
@@ -105,6 +105,54 @@ describe("POST /api/tasks/[id]/dependencies", () => {
   });
 });
 
+describe("GET /api/tasks/[id]/dependencies — malformed id", () => {
+  it("returns 400 for non-numeric task id like '12abc'", async () => {
+    const req = mkRequest("GET");
+    const { GET } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await GET(req, { params: Promise.resolve({ id: "12abc" }) });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/tasks/[id]/dependencies — input validation", () => {
+  it("returns 400 for non-numeric task id like '12abc'", async () => {
+    const req = mkRequest("POST", { blockerId: 2 });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "12abc" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when blockerId is a float", async () => {
+    const req = mkRequest("POST", { blockerId: 2.5 });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when blockerId is negative", async () => {
+    const req = mkRequest("POST", { blockerId: -1 });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/tasks/[id]/dependencies/[blockerId] — malformed ids", () => {
+  it("returns 400 for non-numeric task id", async () => {
+    const req = new NextRequest("http://localhost/api/tasks/abc/dependencies/2", { method: "DELETE" });
+    const { DELETE } = await import("@/app/api/tasks/[id]/dependencies/[blockerId]/route");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "abc", blockerId: "2" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-numeric blockerId", async () => {
+    const req = new NextRequest("http://localhost/api/tasks/1/dependencies/abc", { method: "DELETE" });
+    const { DELETE } = await import("@/app/api/tasks/[id]/dependencies/[blockerId]/route");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "1", blockerId: "abc" }) });
+    expect(res.status).toBe(400);
+  });
+});
+
 describe("DELETE /api/tasks/[id]/dependencies/[blockerId]", () => {
   it("returns 204 when edge existed", async () => {
     mockRemoveDependency.mockResolvedValue(true);

--- a/tests/apiTaskDependencies.test.ts
+++ b/tests/apiTaskDependencies.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/tasks/store", () => ({
+  getTask: vi.fn(),
+  addDependency: vi.fn(),
+  removeDependency: vi.fn(),
+  listDependencies: vi.fn(),
+  CycleError: class CycleError extends Error {
+    constructor(taskId: number, blockerId: number) {
+      super(`Adding dependency ${taskId}→${blockerId} would create a cycle`);
+      this.name = "CycleError";
+    }
+  },
+}));
+
+import { getTask, addDependency, removeDependency, listDependencies, CycleError } from "@/lib/tasks/store";
+
+const mockGetTask = vi.mocked(getTask);
+const mockAddDependency = vi.mocked(addDependency);
+const mockRemoveDependency = vi.mocked(removeDependency);
+const mockListDependencies = vi.mocked(listDependencies);
+
+const TASK_1 = { id: 1, title: "Task 1", status: "pending" } as never;
+const TASK_2 = { id: 2, title: "Task 2", status: "pending" } as never;
+
+function mkRequest(method: string, body?: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/tasks/1/dependencies", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetTask.mockResolvedValue(TASK_1);
+  mockListDependencies.mockResolvedValue({ blockedBy: [], blocks: [] });
+});
+
+describe("GET /api/tasks/[id]/dependencies", () => {
+  it("returns 200 with blockedBy and blocks arrays", async () => {
+    mockListDependencies.mockResolvedValue({ blockedBy: [3], blocks: [4, 5] });
+    const req = mkRequest("GET");
+    const { GET } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await GET(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.blockedBy).toEqual([3]);
+    expect(body.blocks).toEqual([4, 5]);
+  });
+
+  it("returns 404 when task not found", async () => {
+    mockGetTask.mockResolvedValue(null);
+    const req = mkRequest("GET");
+    const { GET } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await GET(req, { params: Promise.resolve({ id: "999" }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/tasks/[id]/dependencies", () => {
+  it("returns 201 with the new dependency row", async () => {
+    mockGetTask.mockImplementation(async (id) => (id === 1 ? TASK_1 : TASK_2));
+    mockAddDependency.mockResolvedValue({ id: 10, task_id: 1, blocker_id: 2, created_at: "" } as never);
+    const req = mkRequest("POST", { blockerId: 2 });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.task_id).toBe(1);
+  });
+
+  it("returns 400 when blockerId equals taskId", async () => {
+    const req = mkRequest("POST", { blockerId: 1 });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when blockerId is missing", async () => {
+    const req = mkRequest("POST", { blockerId: "not-a-number" });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 on cycle", async () => {
+    mockGetTask.mockImplementation(async (id) => (id === 1 ? TASK_1 : TASK_2));
+    mockAddDependency.mockRejectedValue(new CycleError(1, 2));
+    const req = mkRequest("POST", { blockerId: 2 });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/cycle/i);
+  });
+
+  it("returns 404 when blocker task not found", async () => {
+    mockGetTask.mockImplementation(async (id) => (id === 1 ? TASK_1 : null));
+    const req = mkRequest("POST", { blockerId: 2 });
+    const { POST } = await import("@/app/api/tasks/[id]/dependencies/route");
+    const res = await POST(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/tasks/[id]/dependencies/[blockerId]", () => {
+  it("returns 204 when edge existed", async () => {
+    mockRemoveDependency.mockResolvedValue(true);
+    const req = new NextRequest("http://localhost/api/tasks/1/dependencies/2", { method: "DELETE" });
+    const { DELETE } = await import("@/app/api/tasks/[id]/dependencies/[blockerId]/route");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "1", blockerId: "2" }) });
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 204 even when edge did not exist (idempotent)", async () => {
+    mockRemoveDependency.mockResolvedValue(false);
+    const req = new NextRequest("http://localhost/api/tasks/1/dependencies/2", { method: "DELETE" });
+    const { DELETE } = await import("@/app/api/tasks/[id]/dependencies/[blockerId]/route");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "1", blockerId: "2" }) });
+    expect(res.status).toBe(204);
+  });
+});

--- a/tests/buildBoard.test.ts
+++ b/tests/buildBoard.test.ts
@@ -23,7 +23,7 @@ function makeTask(overrides: Partial<Task>): Task {
     title: "Do something",
     description: "",
     status: "pending",
-    priority: 0,
+    priority: 3,
     quadrant: "do",
     assigned_skill: null,
     model: null,
@@ -161,6 +161,33 @@ describe("buildBoard", () => {
     const card = snap.columns.working[0];
     expect(card.kind).toBe("task");
     if (card.kind === "task") expect(card.decisionCount).toBe(3);
+  });
+
+  it("task card has blockedBy=[] and blocks=[] by default", () => {
+    const task = makeTask({ id: 10, status: "pending" });
+    const snap = buildBoard({ sessions: [], tasks: [task], dispatcherEnabled: true }, NOW);
+    const card = snap.columns.idle[0];
+    expect(card.kind).toBe("task");
+    if (card.kind === "task") {
+      expect(card.blockedBy).toEqual([]);
+      expect(card.blocks).toEqual([]);
+    }
+  });
+
+  it("populates blockedBy and blocks from maps", () => {
+    const task = makeTask({ id: 20, status: "pending" });
+    const blockedByMap = new Map([[20, [5, 6]]]);
+    const blocksMap = new Map([[20, [99]]]);
+    const snap = buildBoard(
+      { sessions: [], tasks: [task], dispatcherEnabled: true, blockedByMap, blocksMap },
+      NOW
+    );
+    const card = snap.columns.idle[0];
+    expect(card.kind).toBe("task");
+    if (card.kind === "task") {
+      expect(card.blockedBy).toEqual([5, 6]);
+      expect(card.blocks).toEqual([99]);
+    }
   });
 
   it("sets dispatcherEnabled=false when passed false", () => {

--- a/tests/dependencyLayout.test.ts
+++ b/tests/dependencyLayout.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { computeLayout, type LayoutNode } from "@/lib/kanban/dependencyLayout";
+
+const NOW = "2026-05-08T12:00:00.000Z";
+
+function makeNode(id: number, overrides: Partial<LayoutNode> = {}): LayoutNode {
+  return {
+    id,
+    title: `Task ${id}`,
+    status: "idle",
+    priority: 3,
+    createdAt: NOW,
+    startedAt: null,
+    completedAt: null,
+    cancelled: false,
+    blockedBy: [],
+    blocks: [],
+    ...overrides,
+  };
+}
+
+const W = 180, H = 54, GX = 80, GY = 16;
+
+describe("computeLayout", () => {
+  it("returns empty for no nodes", () => {
+    const result = computeLayout([], W, H, GX, GY);
+    expect(result.nodes).toHaveLength(0);
+    expect(result.maxLayer).toBe(0);
+    expect(result.layerSizes).toHaveLength(0);
+  });
+
+  it("places a single node with no blockers at layer 0", () => {
+    const result = computeLayout([makeNode(1)], W, H, GX, GY);
+    expect(result.nodes[0].layer).toBe(0);
+    expect(result.nodes[0].x).toBe(0);
+    expect(result.maxLayer).toBe(0);
+  });
+
+  it("single chain: A blocks B — B is layer 1", () => {
+    const a = makeNode(1);
+    const b = makeNode(2, { blockedBy: [1], blocks: [] });
+    const result = computeLayout([a, b], W, H, GX, GY);
+    const nodeA = result.nodes.find((n) => n.id === 1)!;
+    const nodeB = result.nodes.find((n) => n.id === 2)!;
+    expect(nodeA.layer).toBe(0);
+    expect(nodeB.layer).toBe(1);
+    expect(nodeB.x).toBe(W + GX);
+  });
+
+  it("diamond: A blocks B and C; B and C both block D — D is layer 2", () => {
+    const a = makeNode(1);
+    const b = makeNode(2, { blockedBy: [1] });
+    const c = makeNode(3, { blockedBy: [1] });
+    const d = makeNode(4, { blockedBy: [2, 3] });
+    const result = computeLayout([a, b, c, d], W, H, GX, GY);
+    const layerOf = (id: number) => result.nodes.find((n) => n.id === id)!.layer;
+    expect(layerOf(1)).toBe(0);
+    expect(layerOf(2)).toBe(1);
+    expect(layerOf(3)).toBe(1);
+    expect(layerOf(4)).toBe(2);
+    expect(result.maxLayer).toBe(2);
+  });
+
+  it("disconnected components: each root starts at layer 0", () => {
+    const a = makeNode(1);
+    const b = makeNode(2);
+    const result = computeLayout([a, b], W, H, GX, GY);
+    expect(result.nodes.every((n) => n.layer === 0)).toBe(true);
+  });
+
+  it("within-layer ordering: lower priority wins", () => {
+    const high = makeNode(1, { priority: 1 });
+    const low  = makeNode(2, { priority: 5 });
+    const result = computeLayout([low, high], W, H, GX, GY); // inserted reversed
+    const n1 = result.nodes.find((n) => n.id === 1)!;
+    const n2 = result.nodes.find((n) => n.id === 2)!;
+    expect(n1.order).toBeLessThan(n2.order);
+  });
+
+  it("layerSizes matches node distribution per layer", () => {
+    const a = makeNode(1);
+    const b = makeNode(2, { blockedBy: [1] });
+    const c = makeNode(3, { blockedBy: [1] });
+    const result = computeLayout([a, b, c], W, H, GX, GY);
+    expect(result.layerSizes[0]).toBe(1); // layer 0: just a
+    expect(result.layerSizes[1]).toBe(2); // layer 1: b and c
+  });
+
+  it("ignores blockers not in the node set (out-of-graph references)", () => {
+    // Node 2 claims to be blocked by node 99, which is not in the input.
+    const b = makeNode(2, { blockedBy: [99] });
+    const result = computeLayout([b], W, H, GX, GY);
+    // Node 2 has no in-graph blocker → layer 0
+    expect(result.nodes[0].layer).toBe(0);
+  });
+});

--- a/tests/taskDependencies.test.ts
+++ b/tests/taskDependencies.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import path from "path";
+import { readFileSync } from "fs";
+import type DatabaseT from "better-sqlite3";
+
+// Store-level tests for task_dependencies: addDependency, removeDependency,
+// listDependencies, listAllDependencies, and claimPendingTask blocker guard.
+// Mirror pattern from tasksStore.test.ts.
+
+let Database: typeof DatabaseT | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  Database = require("better-sqlite3");
+} catch {
+  /* driver not available */
+}
+
+let memDb: DatabaseT.Database | null = null;
+
+vi.mock("@/lib/tasksDb/migrations", () => ({
+  initTasksDb: vi.fn().mockResolvedValue({ available: true }),
+}));
+vi.mock("@/lib/tasksDb/connection", () => ({
+  getTasksDb: vi.fn(async () => memDb),
+  prepTasksCached: (_db: DatabaseT.Database, sql: string) => _db.prepare(sql),
+}));
+
+const SCHEMA_PATH = path.join(__dirname, "..", "src", "lib", "tasksDb", "schema.sql");
+
+function runSql(db: DatabaseT.Database, sql: string) {
+  const stmts = sql
+    .replace(/--[^\n]*/g, "")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const stmt of stmts) db.prepare(stmt).run();
+}
+
+function buildMemDb(): DatabaseT.Database {
+  const db = new Database!(":memory:");
+  db.pragma("foreign_keys = ON");
+  runSql(db, readFileSync(SCHEMA_PATH, "utf-8"));
+  // v2 migration: delegated-todo + metadata + task_decisions
+  runSql(db, `
+    CREATE TABLE ops_tasks_v2 (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      title               TEXT NOT NULL,
+      description         TEXT NOT NULL DEFAULT '',
+      status              TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending','awaiting_approval','running','done','failed','cancelled')),
+      priority            INTEGER NOT NULL DEFAULT 3 CHECK (priority BETWEEN 1 AND 5),
+      quadrant            TEXT NOT NULL DEFAULT 'do'
+        CHECK (quadrant IN ('do','schedule','delegate','archive','delegated-todo')),
+      assigned_skill      TEXT, model TEXT,
+      execution_mode      TEXT NOT NULL DEFAULT 'stream'
+        CHECK (execution_mode IN ('classic','stream')),
+      scheduled_for       TEXT,
+      requires_approval   INTEGER NOT NULL DEFAULT 0 CHECK (requires_approval IN (0, 1)),
+      risk_level          TEXT NOT NULL DEFAULT 'low'
+        CHECK (risk_level IN ('low','medium','high')),
+      dry_run             INTEGER NOT NULL DEFAULT 0 CHECK (dry_run IN (0, 1)),
+      schedule_id         INTEGER REFERENCES ops_schedules(id) ON DELETE SET NULL,
+      approved_at TEXT, session_id TEXT, started_at TEXT, completed_at TEXT,
+      duration_ms INTEGER, cost_usd REAL, output_summary TEXT, error_message TEXT,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      metadata TEXT
+    );
+    INSERT INTO ops_tasks_v2
+      SELECT id,title,description,status,priority,quadrant,assigned_skill,model,
+             execution_mode,scheduled_for,requires_approval,risk_level,dry_run,
+             schedule_id,approved_at,session_id,started_at,completed_at,
+             duration_ms,cost_usd,output_summary,error_message,consecutive_failures,created_at,NULL
+      FROM ops_tasks;
+    DROP TABLE ops_tasks;
+    ALTER TABLE ops_tasks_v2 RENAME TO ops_tasks;
+    CREATE INDEX IF NOT EXISTS ix_tasks_status ON ops_tasks(status);
+    CREATE INDEX IF NOT EXISTS ix_tasks_quadrant ON ops_tasks(quadrant);
+    CREATE INDEX IF NOT EXISTS ix_tasks_scheduled ON ops_tasks(scheduled_for) WHERE scheduled_for IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS ix_tasks_schedule_fk ON ops_tasks(schedule_id) WHERE schedule_id IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS ix_tasks_session ON ops_tasks(session_id) WHERE session_id IS NOT NULL;
+    CREATE TABLE IF NOT EXISTS task_decisions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      session_id TEXT, kind TEXT NOT NULL CHECK (kind IN ('decision','inbox')),
+      prompt TEXT NOT NULL, choices TEXT, decision_text TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()), decided_at INTEGER
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS ux_task_decisions_dedup
+      ON task_decisions(task_id, kind, prompt) WHERE kind = 'decision' AND decided_at IS NULL;
+    CREATE INDEX IF NOT EXISTS ix_task_decisions_task ON task_decisions(task_id);
+    CREATE INDEX IF NOT EXISTS ix_task_decisions_open ON task_decisions(decided_at) WHERE decided_at IS NULL;
+    CREATE TABLE IF NOT EXISTS task_dependencies (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      blocker_id INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      CHECK (task_id != blocker_id),
+      UNIQUE (task_id, blocker_id)
+    );
+    CREATE INDEX IF NOT EXISTS ix_task_deps_task ON task_dependencies(task_id);
+    CREATE INDEX IF NOT EXISTS ix_task_deps_blocker ON task_dependencies(blocker_id);
+  `);
+  return db;
+}
+
+describe.skipIf(!Database)("task_dependencies store", () => {
+  let store: typeof import("@/lib/tasks/store");
+
+  beforeAll(async () => {
+    memDb = buildMemDb();
+    store = await import("@/lib/tasks/store");
+  });
+
+  afterAll(() => {
+    memDb?.close();
+    vi.restoreAllMocks();
+  });
+
+  async function createTask(title: string) {
+    return store.createTask({ title });
+  }
+
+  it("addDependency inserts edge and returns row", async () => {
+    const a = await createTask("A");
+    const b = await createTask("B");
+    const dep = await store.addDependency(b.id, a.id);
+    expect(dep.task_id).toBe(b.id);
+    expect(dep.blocker_id).toBe(a.id);
+    expect(typeof dep.id).toBe("number");
+  });
+
+  it("addDependency is idempotent on duplicate", async () => {
+    const a = await createTask("A2");
+    const b = await createTask("B2");
+    const dep1 = await store.addDependency(b.id, a.id);
+    const dep2 = await store.addDependency(b.id, a.id);
+    expect(dep1.id).toBe(dep2.id);
+  });
+
+  it("addDependency rejects self-loop", async () => {
+    const a = await createTask("Self");
+    await expect(store.addDependency(a.id, a.id)).rejects.toThrow();
+  });
+
+  it("addDependency rejects direct cycle (A→B then B→A)", async () => {
+    const a = await createTask("Cycle-A");
+    const b = await createTask("Cycle-B");
+    await store.addDependency(b.id, a.id); // b is blocked by a
+    // now try a is blocked by b — would close a cycle
+    const { CycleError } = await import("@/lib/tasks/store");
+    await expect(store.addDependency(a.id, b.id)).rejects.toThrow(CycleError);
+  });
+
+  it("addDependency rejects transitive cycle (A→B→C→A)", async () => {
+    const a = await createTask("TC-A");
+    const b = await createTask("TC-B");
+    const c = await createTask("TC-C");
+    await store.addDependency(b.id, a.id); // b blocked by a
+    await store.addDependency(c.id, b.id); // c blocked by b
+    const { CycleError } = await import("@/lib/tasks/store");
+    await expect(store.addDependency(a.id, c.id)).rejects.toThrow(CycleError);
+  });
+
+  it("removeDependency returns true when edge existed", async () => {
+    const a = await createTask("Rm-A");
+    const b = await createTask("Rm-B");
+    await store.addDependency(b.id, a.id);
+    const removed = await store.removeDependency(b.id, a.id);
+    expect(removed).toBe(true);
+  });
+
+  it("removeDependency returns false when edge did not exist", async () => {
+    const a = await createTask("Rm-None-A");
+    const b = await createTask("Rm-None-B");
+    const removed = await store.removeDependency(b.id, a.id);
+    expect(removed).toBe(false);
+  });
+
+  it("listDependencies returns blockedBy and blocks arrays", async () => {
+    const a = await createTask("List-A");
+    const b = await createTask("List-B");
+    const c = await createTask("List-C");
+    await store.addDependency(b.id, a.id); // b blocked by a
+    await store.addDependency(c.id, a.id); // c blocked by a
+
+    const fromA = await store.listDependencies(a.id);
+    expect(fromA.blockedBy).toHaveLength(0);
+    expect(fromA.blocks).toContain(b.id);
+    expect(fromA.blocks).toContain(c.id);
+
+    const fromB = await store.listDependencies(b.id);
+    expect(fromB.blockedBy).toContain(a.id);
+    expect(fromB.blocks).toHaveLength(0);
+  });
+
+  it("listAllDependencies returns all rows", async () => {
+    const before = (await store.listAllDependencies()).length;
+    const a = await createTask("All-A");
+    const b = await createTask("All-B");
+    await store.addDependency(b.id, a.id);
+    const after = await store.listAllDependencies();
+    expect(after.length).toBe(before + 1);
+  });
+
+  it("claimPendingTask skips tasks whose blocker is not done", async () => {
+    const blocker = await createTask("Blocker");
+    const blocked = await createTask("Blocked");
+    await store.addDependency(blocked.id, blocker.id);
+
+    // Only 'blocked' is pending — blocker is also pending, so blocked can't be claimed.
+    // Mark blocker as running so it's out of the pending pool too.
+    await store.patchTask(blocker.id, { status: "running" });
+
+    const claimed = await store.claimPendingTask();
+    // 'blocked' should NOT be claimed while blocker is running (not done).
+    const claimedId = claimed?.id;
+    expect(claimedId).not.toBe(blocked.id);
+  });
+
+  it("claimPendingTask allows task once all blockers are done", async () => {
+    const blocker = await createTask("Done-Blocker");
+    const blocked = await createTask("Unblocked-Dependent");
+    await store.addDependency(blocked.id, blocker.id);
+
+    await store.patchTask(blocker.id, { status: "done" });
+    // Cancel all other pending tasks so only 'blocked' is claimable.
+    memDb!
+      .prepare("UPDATE ops_tasks SET status = 'cancelled' WHERE status = 'pending' AND id != ?")
+      .run(blocked.id);
+
+    const claimed = await store.claimPendingTask();
+    expect(claimed?.id).toBe(blocked.id);
+  });
+
+  it("createTask with blockedBy inserts edges atomically", async () => {
+    const a = await createTask("Atomic-Blocker");
+    const b = await store.createTask({ title: "Atomic-Dependent", blockedBy: [a.id] });
+    const deps = await store.listDependencies(b.id);
+    expect(deps.blockedBy).toContain(a.id);
+  });
+});

--- a/tests/tasksStore.test.ts
+++ b/tests/tasksStore.test.ts
@@ -109,6 +109,16 @@ function buildMemDb(): DatabaseT.Database {
       WHERE decided_at IS NULL;
     CREATE INDEX IF NOT EXISTS ix_task_decisions_task ON task_decisions(task_id);
     CREATE INDEX IF NOT EXISTS ix_task_decisions_open ON task_decisions(decided_at) WHERE decided_at IS NULL;
+    CREATE TABLE IF NOT EXISTS task_dependencies (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id     INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      blocker_id  INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      CHECK (task_id != blocker_id),
+      UNIQUE (task_id, blocker_id)
+    );
+    CREATE INDEX IF NOT EXISTS ix_task_deps_task ON task_dependencies(task_id);
+    CREATE INDEX IF NOT EXISTS ix_task_deps_blocker ON task_dependencies(blocker_id);
   `);
   return db;
 }


### PR DESCRIPTION
## Summary

- **`task_dependencies` table** (migration v4): explicit blocker→dependent edges with cycle CHECK, UNIQUE, CASCADE delete, and indexes
- **Dispatcher SQL guard**: `claimPendingTask` + `promoteApprovalTasks` skip tasks blocked by non-done tasks via `NOT EXISTS` subquery — atomic with the claim transaction, no JS-level filter
- **DFS cycle prevention at insert time**: throws `CycleError` (409) if new edge would close a cycle; idempotent on duplicate
- **REST API**: `GET/POST /api/tasks/[id]/dependencies`, `DELETE /api/tasks/[id]/dependencies/[blockerId]`
- **Three Kanban view modes** (Board/Dag/Gantt) via toolbar toggle, persisted to localStorage
- **Dag view** (`TaskDependencyGraph.tsx`): manual Sugiyama layered layout, D3 SVG, cubic Bezier edges, status-colored nodes — no new npm deps
- **Gantt view** (`TaskGanttChart.tsx`): `d3.scaleTime()` bars, dependency arrows, placeholder bars for pending/approval tasks
- **Blocked badge**: gray "blocked (N)" chip on Kanban task cards
- **Task Composer**: "Depends on" checkbox list creates edges atomically with task creation
- **32 new tests**: store (cycle detection, dispatcher guards, idempotency), pure layout (DAG layers), routes (201/400/404/409/204)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1656 passing (was 1624, +32 new tests)
- [x] Board view renders with real tasks
- [x] Dag view renders empty state ("No tasks with dependency edges")
- [x] Gantt view renders with time bars for existing tasks
- [x] Task Composer "Depends on" field shows eligible tasks (pending/awaiting_approval/running)
- [x] View mode persisted in localStorage across navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)