### PR TITLE
feat(wave10.1c): multi-agent swarm dispatch — TODO #247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 10.1c — Cluster W (part 3): Multi-agent swarm dispatch.** TODO #247.
+  - New `ops_swarms` table (migration v5) with `name`, `mode` (`worktree`|`shared`), `project_path`, `status`, `completed_at`. Two new nullable columns on `ops_tasks`: `swarm_id` (FK → `ops_swarms`) and `swarm_role` (`member`|`coordinator`), added via `ALTER TABLE ADD COLUMN` — zero migration cost for existing rows.
+  - **Swarm creation**: `createSwarm()` — single SQLite transaction creates the swarm row + 2–8 member tasks (with `worktreePath`/`projectPath` in metadata for worktree mode) + optional coordinator task with `task_dependencies` edges to every member.
+  - **Coordinator "all-terminal" SQL guard**: `claimPendingTask` and `promoteApprovalTasks` use a role-aware `NOT EXISTS` subquery — non-coordinator tasks need blockers `= 'done'`; coordinator tasks unblock when all blockers reach any terminal state (`done`|`failed`|`cancelled`).
+  - **Coordinator context injection**: `updateSwarmStatus()` appends member `output_summary` values to the coordinator task's `description` field when all members become terminal — injected exactly once (guarded by `<!-- swarm-summaries-injected -->` marker) so the coordinator runs with full context of what each member produced.
+  - **Worktree spawner**: `runWorktreeTask()` — calls `git worktree add -B <branch> <path> HEAD` via `execFile` (not shell exec), sets `cwd` to the worktree directory via a `spawnFn` closure (no signature change to `runClassicTask`/`runStreamTask`). Worktree paths are siblings of the project dir using `--claude-worktrees-` naming (compatible with the existing worktrees scanner).
+  - **Dispatcher routing**: detects worktree tasks by `worktreePath` in metadata; routes to `runWorktreeTask`; calls `updateSwarmStatus(swarmId)` after every swarm task completes/fails.
+  - **REST surface**: `GET/POST /api/swarms`, `GET /api/swarms/[id]`, `DELETE /api/swarms/[id]/worktrees` (idempotent `git worktree remove --force` cleanup).
+  - **SwarmComposer modal** — name, project path (prefilled from project card or text input on Tasks page), mode radio, 2–8 member definitions, optional coordinator. Navigates to `/swarms/<id>` on success.
+  - **Entry points**: "Launch Swarm" button on Tasks page; "Launch Swarm…" in the project card dropdown (pre-fills project path).
+  - **Swarms nav entry** added to Mission Control group in AppNav.
+  - **`/swarms`** — list page with status dot and mode badges. **`/swarms/[id]`** — detail page polling every 5 s while running; shows per-member status/cost/session link, total cost, "Remove worktrees" action for worktree-mode swarms.
+
 - **Wave 10.1b — Cluster W (part 2): Task dependency graph.** TODO #167.
   - New `task_dependencies(task_id, blocker_id)` table (migration v4) with `CHECK (task_id != blocker_id)`, `UNIQUE (task_id, blocker_id)`, and cascade-delete. Indexed on both columns.
   - **Dispatcher SQL guard**: `claimPendingTask` and `promoteApprovalTasks` skip tasks whose blockers haven't reached `done` via a single `NOT EXISTS (...)` subquery — atomically safe, no JS-level filter.

--- a/docs/help/tasks.md
+++ b/docs/help/tasks.md
@@ -181,6 +181,79 @@ Returns `{ "taskId": 123 }`.
 
 ---
 
-## What's coming
+## Swarms
 
-- **Wave 10** — Kanban board, task dependency graph, multi-agent swarm
+A **swarm** lets you dispatch 2–8 tasks concurrently, with an optional coordinator that fires after all member tasks finish.
+
+### Launching a swarm
+
+Two entry points:
+- **Tasks page** — click **Launch Swarm** (next to "New task") to open the SwarmComposer.
+- **Project card** — open the card's **⋮** dropdown and choose **Launch Swarm…** (pre-fills the project path).
+
+In the SwarmComposer, fill in:
+
+| Field | Description |
+|-------|-------------|
+| **Swarm name** | Display label for the swarm |
+| **Project path** | The git project the swarm operates on |
+| **Execution mode** | `Shared` — all tasks run in the project directory; `Worktree` — each member task gets its own `git worktree` sibling directory |
+| **Member tasks** | 2–8 task definitions, each with title, optional description, skill, and execution mode |
+| **Coordinator** | Optional task that runs after all members complete (blocked via `task_dependencies`) |
+
+### Execution modes
+
+**Shared mode** — members run concurrently in the same project directory. Good for independent tasks that don't conflict on the same files.
+
+**Worktree mode** — the dispatcher calls `git worktree add -B <branch> <path> HEAD` before spawning each member. Each member's `claude` process runs with `cwd` set to its own worktree directory. Worktree paths use the `--claude-worktrees-<slug>-<index>` naming convention compatible with Project Minder's worktrees scanner. After the swarm completes, click **Remove worktrees** on the swarm detail page to clean up.
+
+### Coordinator task
+
+If you add a coordinator:
+- It is blocked by all member tasks via `task_dependencies` rows
+- It becomes claimable when all members reach a **terminal** state — `done`, `failed`, or `cancelled` (unlike regular dependencies which require `done`)
+- Member output summaries are appended to the coordinator's description before it is claimed, so Claude Code has full context of what each member produced
+
+### Swarm status
+
+| Status | Meaning |
+|--------|---------|
+| **Running** | At least one task is still pending or running |
+| **Done** | All tasks completed; coordinator done (if present) |
+| **Failed** | All tasks terminal; coordinator failed (or any member failed with no coordinator) |
+| **Cancelled** | All tasks terminal; coordinator cancelled (or all members cancelled) |
+
+### Viewing swarms
+
+- **`/swarms`** — lists all swarms with status dots and mode badges
+- **`/swarms/<id>`** — detail page showing per-member status, cost, session links, and total cost. Polls every 5 s while the swarm is running.
+
+### REST API
+
+```
+GET    /api/swarms                    — list all swarms
+POST   /api/swarms                    — create a swarm (see body below)
+GET    /api/swarms/<id>               — { swarm, tasks }
+DELETE /api/swarms/<id>/worktrees     — remove all worktree directories (idempotent)
+```
+
+**Create body:**
+```json
+{
+  "name": "Auth refactor",
+  "mode": "worktree",
+  "project_path": "C:\\dev\\my-app",
+  "members": [
+    { "title": "Extract rate limiter", "execution_mode": "stream" },
+    { "title": "Add PKCE support", "execution_mode": "stream" }
+  ],
+  "coordinator": {
+    "title": "Integrate and test",
+    "description": "Review both branches and write integration tests"
+  }
+}
+```
+
+Validation: `members` must have 2–8 items with non-empty titles; `mode` must be `worktree` or `shared`; `project_path` is required.
+
+---

--- a/public/help/tasks.md
+++ b/public/help/tasks.md
@@ -181,6 +181,79 @@ Returns `{ "taskId": 123 }`.
 
 ---
 
-## What's coming
+## Swarms
 
-- **Wave 10** — Kanban board, task dependency graph, multi-agent swarm
+A **swarm** lets you dispatch 2–8 tasks concurrently, with an optional coordinator that fires after all member tasks finish.
+
+### Launching a swarm
+
+Two entry points:
+- **Tasks page** — click **Launch Swarm** (next to "New task") to open the SwarmComposer.
+- **Project card** — open the card's **⋮** dropdown and choose **Launch Swarm…** (pre-fills the project path).
+
+In the SwarmComposer, fill in:
+
+| Field | Description |
+|-------|-------------|
+| **Swarm name** | Display label for the swarm |
+| **Project path** | The git project the swarm operates on |
+| **Execution mode** | `Shared` — all tasks run in the project directory; `Worktree` — each member task gets its own `git worktree` sibling directory |
+| **Member tasks** | 2–8 task definitions, each with title, optional description, skill, and execution mode |
+| **Coordinator** | Optional task that runs after all members complete (blocked via `task_dependencies`) |
+
+### Execution modes
+
+**Shared mode** — members run concurrently in the same project directory. Good for independent tasks that don't conflict on the same files.
+
+**Worktree mode** — the dispatcher calls `git worktree add -B <branch> <path> HEAD` before spawning each member. Each member's `claude` process runs with `cwd` set to its own worktree directory. Worktree paths use the `--claude-worktrees-<slug>-<index>` naming convention compatible with Project Minder's worktrees scanner. After the swarm completes, click **Remove worktrees** on the swarm detail page to clean up.
+
+### Coordinator task
+
+If you add a coordinator:
+- It is blocked by all member tasks via `task_dependencies` rows
+- It becomes claimable when all members reach a **terminal** state — `done`, `failed`, or `cancelled` (unlike regular dependencies which require `done`)
+- Member output summaries are appended to the coordinator's description before it is claimed, so Claude Code has full context of what each member produced
+
+### Swarm status
+
+| Status | Meaning |
+|--------|---------|
+| **Running** | At least one task is still pending or running |
+| **Done** | All tasks completed; coordinator done (if present) |
+| **Failed** | All tasks terminal; coordinator failed (or any member failed with no coordinator) |
+| **Cancelled** | All tasks terminal; coordinator cancelled (or all members cancelled) |
+
+### Viewing swarms
+
+- **`/swarms`** — lists all swarms with status dots and mode badges
+- **`/swarms/<id>`** — detail page showing per-member status, cost, session links, and total cost. Polls every 5 s while the swarm is running.
+
+### REST API
+
+```
+GET    /api/swarms                    — list all swarms
+POST   /api/swarms                    — create a swarm (see body below)
+GET    /api/swarms/<id>               — { swarm, tasks }
+DELETE /api/swarms/<id>/worktrees     — remove all worktree directories (idempotent)
+```
+
+**Create body:**
+```json
+{
+  "name": "Auth refactor",
+  "mode": "worktree",
+  "project_path": "C:\\dev\\my-app",
+  "members": [
+    { "title": "Extract rate limiter", "execution_mode": "stream" },
+    { "title": "Add PKCE support", "execution_mode": "stream" }
+  ],
+  "coordinator": {
+    "title": "Integrate and test",
+    "description": "Review both branches and write integration tests"
+  }
+}
+```
+
+Validation: `members` must have 2–8 items with non-empty titles; `mode` must be `worktree` or `shared`; `project_path` is required.
+
+---

--- a/src/app/api/swarms/[id]/route.ts
+++ b/src/app/api/swarms/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getSwarm, getSwarmTasks } from "@/lib/tasks/store";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (!Number.isInteger(numId) || numId <= 0) {
+    return NextResponse.json({ error: "Invalid swarm id" }, { status: 400 });
+  }
+  try {
+    const [swarm, tasks] = await Promise.all([getSwarm(numId), getSwarmTasks(numId)]);
+    if (!swarm) {
+      return NextResponse.json({ error: "Swarm not found" }, { status: 404 });
+    }
+    return NextResponse.json({ swarm, tasks });
+  } catch (err) {
+    console.error("[api/swarms/[id] GET]", err);
+    return NextResponse.json({ error: "Failed to fetch swarm" }, { status: 500 });
+  }
+}

--- a/src/app/api/swarms/[id]/worktrees/route.ts
+++ b/src/app/api/swarms/[id]/worktrees/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { existsSync } from "fs";
+import { getSwarmTasks } from "@/lib/tasks/store";
+
+export const dynamic = "force-dynamic";
+
+const execFileAsync = promisify(execFile);
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const { id } = await params;
+  const numId = parseInt(id, 10);
+  if (!Number.isInteger(numId) || numId <= 0) {
+    return NextResponse.json({ error: "Invalid swarm id" }, { status: 400 });
+  }
+  try {
+    const tasks = await getSwarmTasks(numId);
+    const errors: string[] = [];
+
+    for (const task of tasks) {
+      if (task.swarm_role !== "member") continue;
+      let meta: { worktreePath?: string; projectPath?: string } = {};
+      try {
+        meta = JSON.parse(task.metadata ?? "{}") as typeof meta;
+      } catch {
+        continue;
+      }
+      const { worktreePath, projectPath } = meta;
+      if (!worktreePath || !projectPath || !existsSync(worktreePath)) continue;
+
+      try {
+        await execFileAsync("git", ["worktree", "remove", "--force", worktreePath], {
+          cwd: projectPath,
+        });
+      } catch (err) {
+        errors.push(`task ${task.id}: ${(err as Error).message}`);
+      }
+    }
+
+    if (errors.length > 0) {
+      console.warn("[api/swarms/[id]/worktrees DELETE] partial failures:", errors);
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    console.error("[api/swarms/[id]/worktrees DELETE]", err);
+    return NextResponse.json({ error: "Failed to remove worktrees" }, { status: 500 });
+  }
+}

--- a/src/app/api/swarms/[id]/worktrees/route.ts
+++ b/src/app/api/swarms/[id]/worktrees/route.ts
@@ -21,25 +21,19 @@ export async function DELETE(
     const tasks = await getSwarmTasks(numId);
     const errors: string[] = [];
 
-    for (const task of tasks) {
-      if (task.swarm_role !== "member") continue;
+    const removals = tasks.flatMap((task) => {
+      if (task.swarm_role !== "member") return [];
       let meta: { worktreePath?: string; projectPath?: string } = {};
-      try {
-        meta = JSON.parse(task.metadata ?? "{}") as typeof meta;
-      } catch {
-        continue;
-      }
+      try { meta = JSON.parse(task.metadata ?? "{}") as typeof meta; } catch { return []; }
       const { worktreePath, projectPath } = meta;
-      if (!worktreePath || !projectPath || !existsSync(worktreePath)) continue;
+      if (!worktreePath || !projectPath || !existsSync(worktreePath)) return [];
+      return [
+        execFileAsync("git", ["worktree", "remove", "--force", worktreePath], { cwd: projectPath })
+          .catch((err: Error) => { errors.push(`task ${task.id}: ${err.message}`); }),
+      ];
+    });
 
-      try {
-        await execFileAsync("git", ["worktree", "remove", "--force", worktreePath], {
-          cwd: projectPath,
-        });
-      } catch (err) {
-        errors.push(`task ${task.id}: ${(err as Error).message}`);
-      }
-    }
+    await Promise.allSettled(removals);
 
     if (errors.length > 0) {
       console.warn("[api/swarms/[id]/worktrees DELETE] partial failures:", errors);

--- a/src/app/api/swarms/route.ts
+++ b/src/app/api/swarms/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { listSwarms, createSwarm } from "@/lib/tasks/store";
 import type { SwarmMode } from "@/lib/tasks/types";
-import { SWARM_MODES } from "@/lib/tasks/types";
+import { SWARM_MODES, EXECUTION_MODES } from "@/lib/tasks/types";
 import { initDispatcher } from "@/lib/tasks/dispatcher";
 
 export const dynamic = "force-dynamic";
@@ -52,6 +52,22 @@ export async function POST(request: Request): Promise<NextResponse> {
       if (!m || typeof m.title !== "string" || !m.title.trim()) {
         return NextResponse.json(
           { error: "each member must have a non-empty title", field: "members" },
+          { status: 400 }
+        );
+      }
+      if (m.execution_mode !== undefined && !(EXECUTION_MODES as readonly string[]).includes(m.execution_mode as string)) {
+        return NextResponse.json(
+          { error: `execution_mode must be one of: ${EXECUTION_MODES.join(", ")}`, field: "members" },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (coordinator !== undefined) {
+      if (!coordinator || typeof (coordinator as Record<string, unknown>).title !== "string" ||
+          !(coordinator as Record<string, unknown>).title) {
+        return NextResponse.json(
+          { error: "coordinator must have a non-empty title", field: "coordinator" },
           { status: 400 }
         );
       }

--- a/src/app/api/swarms/route.ts
+++ b/src/app/api/swarms/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { listSwarms, createSwarm } from "@/lib/tasks/store";
+import type { SwarmMode } from "@/lib/tasks/types";
+import { SWARM_MODES } from "@/lib/tasks/types";
+import { initDispatcher } from "@/lib/tasks/dispatcher";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse> {
+  initDispatcher();
+  try {
+    const swarms = await listSwarms();
+    return NextResponse.json({ swarms });
+  } catch (err) {
+    console.error("[api/swarms GET]", err);
+    return NextResponse.json({ error: "Failed to list swarms" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  initDispatcher();
+  try {
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+    }
+
+    const { name, mode, project_path, members, coordinator } = body as Record<string, unknown>;
+
+    if (!name || typeof name !== "string" || !name.trim()) {
+      return NextResponse.json({ error: "name is required", field: "name" }, { status: 400 });
+    }
+    if (!mode || !SWARM_MODES.includes(mode as SwarmMode)) {
+      return NextResponse.json(
+        { error: `mode must be one of: ${SWARM_MODES.join(", ")}`, field: "mode" },
+        { status: 400 }
+      );
+    }
+    if (!project_path || typeof project_path !== "string" || !project_path.trim()) {
+      return NextResponse.json(
+        { error: "project_path is required", field: "project_path" },
+        { status: 400 }
+      );
+    }
+    if (!Array.isArray(members) || members.length < 2 || members.length > 8) {
+      return NextResponse.json(
+        { error: "members must be an array of 2–8 items", field: "members" },
+        { status: 400 }
+      );
+    }
+    for (const m of members) {
+      if (!m || typeof m.title !== "string" || !m.title.trim()) {
+        return NextResponse.json(
+          { error: "each member must have a non-empty title", field: "members" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const result = await createSwarm({
+      name: (name as string).trim(),
+      mode: mode as SwarmMode,
+      project_path: (project_path as string).trim(),
+      members,
+      coordinator: coordinator as { title: string; description?: string; assigned_skill?: string } | undefined,
+    });
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    console.error("[api/swarms POST]", err);
+    return NextResponse.json({ error: "Failed to create swarm" }, { status: 500 });
+  }
+}

--- a/src/app/swarms/[id]/page.tsx
+++ b/src/app/swarms/[id]/page.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback, use } from "react";
+import { useState, useEffect, useCallback, useRef, use } from "react";
 import Link from "next/link";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import type { Swarm, Task } from "@/lib/tasks/types";
-
-const STATUS_COLORS: Record<string, string> = {
-  running:            "var(--info, #60a5fa)",
-  done:               "var(--success, #22c55e)",
-  failed:             "var(--error)",
-  cancelled:          "var(--text-muted)",
-  pending:            "var(--text-muted)",
-  awaiting_approval:  "var(--accent)",
-};
+import { TASK_STATUS_COLORS } from "@/lib/tasks/types";
 
 export default function SwarmDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -23,6 +15,9 @@ export default function SwarmDetailPage({ params }: { params: Promise<{ id: stri
   const [removing, setRemoving] = useState(false);
 
   useDocumentTitle(swarm ? `Swarm: ${swarm.name}` : "Swarm");
+
+  const swarmRef = useRef<Swarm | null>(null);
+  swarmRef.current = swarm;
 
   const load = useCallback(async () => {
     try {
@@ -45,12 +40,13 @@ export default function SwarmDetailPage({ params }: { params: Promise<{ id: stri
     load();
   }, [load]);
 
-  // Poll while running
+  // Single stable interval; checks status via ref so it doesn't restart on each poll.
   useEffect(() => {
-    if (!swarm || swarm.status !== "running") return;
-    const interval = setInterval(() => { load(); }, 5_000);
+    const interval = setInterval(() => {
+      if (swarmRef.current?.status === "running") load();
+    }, 5_000);
     return () => clearInterval(interval);
-  }, [swarm, load]);
+  }, [load]);
 
   async function handleRemoveWorktrees() {
     setRemoving(true);
@@ -95,7 +91,7 @@ export default function SwarmDetailPage({ params }: { params: Promise<{ id: stri
               fontSize: "0.7rem",
               padding: "2px 8px",
               borderRadius: "3px",
-              background: STATUS_COLORS[swarm.status] ?? "var(--text-muted)",
+              background: TASK_STATUS_COLORS[swarm.status as keyof typeof TASK_STATUS_COLORS] ?? "var(--text-muted)",
               color: "#fff",
               fontWeight: 600,
             }}
@@ -188,7 +184,7 @@ export default function SwarmDetailPage({ params }: { params: Promise<{ id: stri
 }
 
 function TaskRow({ task }: { task: Task }) {
-  const color = STATUS_COLORS[task.status] ?? "var(--text-muted)";
+  const color = TASK_STATUS_COLORS[task.status] ?? "var(--text-muted)";
   return (
     <div
       style={{

--- a/src/app/swarms/[id]/page.tsx
+++ b/src/app/swarms/[id]/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState, useEffect, useCallback, use } from "react";
+import Link from "next/link";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import type { Swarm, Task } from "@/lib/tasks/types";
+
+const STATUS_COLORS: Record<string, string> = {
+  running:            "var(--info, #60a5fa)",
+  done:               "var(--success, #22c55e)",
+  failed:             "var(--error)",
+  cancelled:          "var(--text-muted)",
+  pending:            "var(--text-muted)",
+  awaiting_approval:  "var(--accent)",
+};
+
+export default function SwarmDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [swarm, setSwarm] = useState<Swarm | null>(null);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  useDocumentTitle(swarm ? `Swarm: ${swarm.name}` : "Swarm");
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/swarms/${id}`);
+      if (!res.ok) {
+        setError(res.status === 404 ? "Swarm not found" : `HTTP ${res.status}`);
+        return;
+      }
+      const data = (await res.json()) as { swarm: Swarm; tasks: Task[] };
+      setSwarm(data.swarm);
+      setTasks(data.tasks);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load swarm");
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Poll while running
+  useEffect(() => {
+    if (!swarm || swarm.status !== "running") return;
+    const interval = setInterval(() => { load(); }, 5_000);
+    return () => clearInterval(interval);
+  }, [swarm, load]);
+
+  async function handleRemoveWorktrees() {
+    setRemoving(true);
+    try {
+      await fetch(`/api/swarms/${id}/worktrees`, { method: "DELETE" });
+    } finally {
+      setRemoving(false);
+    }
+  }
+
+  const totalCost = tasks.reduce((sum, t) => sum + (t.cost_usd ?? 0), 0);
+  const members = tasks.filter((t) => t.swarm_role === "member");
+  const coordinator = tasks.find((t) => t.swarm_role === "coordinator");
+
+  if (loading) {
+    return (
+      <div style={{ padding: "48px 0", textAlign: "center", color: "var(--text-muted)", fontSize: "0.85rem" }}>
+        Loading…
+      </div>
+    );
+  }
+
+  if (error || !swarm) {
+    return (
+      <div style={{ padding: "48px 24px", textAlign: "center", color: "var(--error)", fontSize: "0.85rem" }}>
+        {error ?? "Swarm not found"}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "24px", maxWidth: "900px", margin: "0 auto" }}>
+      {/* Header */}
+      <div style={{ marginBottom: "20px" }}>
+        <Link href="/swarms" style={{ fontSize: "0.75rem", color: "var(--text-muted)", textDecoration: "none" }}>
+          ← Swarms
+        </Link>
+        <div style={{ display: "flex", alignItems: "center", gap: "12px", marginTop: "8px" }}>
+          <h1 style={{ margin: 0, fontSize: "1.1rem", fontWeight: 700 }}>{swarm.name}</h1>
+          <span
+            style={{
+              fontSize: "0.7rem",
+              padding: "2px 8px",
+              borderRadius: "3px",
+              background: STATUS_COLORS[swarm.status] ?? "var(--text-muted)",
+              color: "#fff",
+              fontWeight: 600,
+            }}
+          >
+            {swarm.status}
+          </span>
+          <span
+            style={{
+              fontSize: "0.7rem",
+              padding: "2px 6px",
+              borderRadius: "3px",
+              background: "var(--bg-card)",
+              border: "1px solid var(--border)",
+              color: "var(--text-muted)",
+            }}
+          >
+            {swarm.mode}
+          </span>
+        </div>
+        <div style={{ fontSize: "0.75rem", color: "var(--text-muted)", marginTop: "4px", fontFamily: "var(--font-mono)" }}>
+          {swarm.project_path}
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div style={{ display: "flex", gap: "16px", marginBottom: "20px" }}>
+        <div style={{ padding: "10px 14px", background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: "6px" }}>
+          <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>Tasks</div>
+          <div style={{ fontSize: "1.2rem", fontWeight: 700 }}>{tasks.length}</div>
+        </div>
+        <div style={{ padding: "10px 14px", background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: "6px" }}>
+          <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>Total cost</div>
+          <div style={{ fontSize: "1.2rem", fontWeight: 700, fontFamily: "var(--font-mono)" }}>
+            ${totalCost.toFixed(4)}
+          </div>
+        </div>
+        {swarm.completed_at && (
+          <div style={{ padding: "10px 14px", background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: "6px" }}>
+            <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>Completed</div>
+            <div style={{ fontSize: "0.85rem", fontWeight: 600 }}>{new Date(swarm.completed_at).toLocaleString()}</div>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div style={{ display: "flex", gap: "8px", marginBottom: "20px" }}>
+        {swarm.mode === "worktree" && (
+          <button
+            onClick={handleRemoveWorktrees}
+            disabled={removing}
+            style={{
+              padding: "6px 12px",
+              background: "none",
+              border: "1px solid var(--border)",
+              borderRadius: "4px",
+              cursor: removing ? "not-allowed" : "pointer",
+              fontSize: "0.78rem",
+              color: "var(--text-muted)",
+              opacity: removing ? 0.6 : 1,
+            }}
+          >
+            {removing ? "Removing…" : "Remove worktrees"}
+          </button>
+        )}
+      </div>
+
+      {/* Member tasks */}
+      <section style={{ marginBottom: "20px" }}>
+        <h2 style={{ fontSize: "0.85rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-muted)", marginBottom: "10px" }}>
+          Member tasks ({members.length})
+        </h2>
+        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+          {members.map((t) => (
+            <TaskRow key={t.id} task={t} />
+          ))}
+        </div>
+      </section>
+
+      {/* Coordinator task */}
+      {coordinator && (
+        <section>
+          <h2 style={{ fontSize: "0.85rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-muted)", marginBottom: "10px" }}>
+            Coordinator
+          </h2>
+          <TaskRow task={coordinator} />
+        </section>
+      )}
+    </div>
+  );
+}
+
+function TaskRow({ task }: { task: Task }) {
+  const color = STATUS_COLORS[task.status] ?? "var(--text-muted)";
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        padding: "10px 14px",
+        background: "var(--bg-card)",
+        border: "1px solid var(--border)",
+        borderRadius: "6px",
+      }}
+    >
+      <span style={{ display: "inline-block", width: "8px", height: "8px", borderRadius: "50%", background: color, flexShrink: 0 }} />
+      <span style={{ fontWeight: 600, fontSize: "0.85rem", flex: 1 }}>{task.title}</span>
+      <span style={{ fontSize: "0.72rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>{task.status}</span>
+      {task.cost_usd != null && (
+        <span style={{ fontSize: "0.72rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
+          ${task.cost_usd.toFixed(4)}
+        </span>
+      )}
+      {task.session_id && (
+        <Link
+          href={`/sessions/${task.session_id}`}
+          style={{ fontSize: "0.72rem", color: "var(--accent)", textDecoration: "none", fontFamily: "var(--font-mono)" }}
+        >
+          session
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/src/app/swarms/page.tsx
+++ b/src/app/swarms/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import type { Swarm } from "@/lib/tasks/types";
+import { SwarmComposer } from "@/components/SwarmComposer";
+
+const STATUS_COLORS: Record<string, string> = {
+  running:   "var(--info, #60a5fa)",
+  done:      "var(--success, #22c55e)",
+  failed:    "var(--error)",
+  cancelled: "var(--text-muted)",
+};
+
+export default function SwarmsPage() {
+  useDocumentTitle("Swarms");
+  const [swarms, setSwarms] = useState<Swarm[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  async function load() {
+    setError(null);
+    try {
+      const res = await fetch("/api/swarms");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { swarms: Swarm[] };
+      setSwarms(data.swarms);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load swarms");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, []);
+
+  if (loading) {
+    return (
+      <div style={{ padding: "48px 0", textAlign: "center", color: "var(--text-muted)", fontSize: "0.85rem" }}>
+        Loading swarms…
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "24px", maxWidth: "900px", margin: "0 auto" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "20px" }}>
+        <h1 style={{ margin: 0, fontSize: "1.1rem", fontWeight: 700 }}>Swarms</h1>
+        <button
+          onClick={() => setComposerOpen(true)}
+          style={{
+            padding: "6px 14px",
+            background: "var(--accent)",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+            fontSize: "0.82rem",
+            fontWeight: 600,
+            color: "#fff",
+          }}
+        >
+          Launch Swarm
+        </button>
+      </div>
+
+      {error && (
+        <div style={{ color: "var(--error)", fontSize: "0.85rem", marginBottom: "16px" }}>{error}</div>
+      )}
+
+      {swarms.length === 0 ? (
+        <div style={{ textAlign: "center", padding: "48px 0", color: "var(--text-muted)", fontSize: "0.85rem" }}>
+          <div style={{ fontSize: "2rem", marginBottom: "8px" }}>⚡</div>
+          <div style={{ fontWeight: 500, marginBottom: "4px" }}>No swarms yet</div>
+          <div style={{ fontSize: "0.75rem" }}>
+            Launch a swarm to dispatch multiple tasks concurrently with an optional coordinator.
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {swarms.map((s) => (
+            <Link
+              key={s.id}
+              href={`/swarms/${s.id}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "12px",
+                padding: "12px 16px",
+                background: "var(--bg-card)",
+                border: "1px solid var(--border)",
+                borderRadius: "6px",
+                textDecoration: "none",
+                color: "var(--text-primary)",
+              }}
+            >
+              <span
+                style={{
+                  display: "inline-block",
+                  width: "8px",
+                  height: "8px",
+                  borderRadius: "50%",
+                  background: STATUS_COLORS[s.status] ?? "var(--text-muted)",
+                  flexShrink: 0,
+                }}
+              />
+              <span style={{ fontWeight: 600, fontSize: "0.88rem", flex: 1 }}>{s.name}</span>
+              <span
+                style={{
+                  fontSize: "0.7rem",
+                  padding: "2px 6px",
+                  borderRadius: "3px",
+                  background: "var(--bg-elevated, var(--bg-card))",
+                  border: "1px solid var(--border)",
+                  color: "var(--text-muted)",
+                }}
+              >
+                {s.mode}
+              </span>
+              <span style={{ fontSize: "0.72rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
+                {s.status}
+              </span>
+              <span style={{ fontSize: "0.72rem", color: "var(--text-muted)" }}>
+                {new Date(s.created_at).toLocaleString()}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      <SwarmComposer
+        open={composerOpen}
+        onClose={() => { setComposerOpen(false); load(); }}
+      />
+    </div>
+  );
+}

--- a/src/app/swarms/page.tsx
+++ b/src/app/swarms/page.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import type { Swarm } from "@/lib/tasks/types";
+import { TASK_STATUS_COLORS } from "@/lib/tasks/types";
 import { SwarmComposer } from "@/components/SwarmComposer";
-
-const STATUS_COLORS: Record<string, string> = {
-  running:   "var(--info, #60a5fa)",
-  done:      "var(--success, #22c55e)",
-  failed:    "var(--error)",
-  cancelled: "var(--text-muted)",
-};
 
 export default function SwarmsPage() {
   useDocumentTitle("Swarms");
@@ -20,7 +14,7 @@ export default function SwarmsPage() {
   const [error, setError] = useState<string | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
 
-  async function load() {
+  const load = useCallback(async () => {
     setError(null);
     try {
       const res = await fetch("/api/swarms");
@@ -32,9 +26,9 @@ export default function SwarmsPage() {
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); }, [load]);
 
   if (loading) {
     return (
@@ -101,7 +95,7 @@ export default function SwarmsPage() {
                   width: "8px",
                   height: "8px",
                   borderRadius: "50%",
-                  background: STATUS_COLORS[s.status] ?? "var(--text-muted)",
+                  background: TASK_STATUS_COLORS[s.status as keyof typeof TASK_STATUS_COLORS] ?? "var(--text-muted)",
                   flexShrink: 0,
                 }}
               />

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -61,6 +61,7 @@ const GROUPS: Group[] = [
     children: [
       item("/kanban",   "Kanban"),
       item("/tasks",    "Tasks"),
+      item("/swarms",   "Swarms"),
       item("/schedule", "Schedule"),
     ],
   },

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "./ui/dropdown-menu";
-import { Archive, Database, MoreVertical, CheckSquare, ClipboardList, Lightbulb, Pin, PinOff, Layers } from "lucide-react";
+import { Archive, Database, MoreVertical, CheckSquare, ClipboardList, Lightbulb, Pin, PinOff, Layers, Zap } from "lucide-react";
 import { MarkAsTemplateModal } from "./MarkAsTemplateModal";
 import { SwarmComposer } from "./SwarmComposer";
 import { StatusDot } from "./ui/StatusDot";
@@ -341,7 +341,7 @@ export function ProjectCard({ project, onArchive, compact = false, pinned = fals
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
                 >
                   <DropdownMenuItem onClick={() => setSwarmComposerOpen(true)}>
-                    <Layers style={{ width: "12px", height: "12px", marginRight: "6px" }} />
+                    <Zap style={{ width: "12px", height: "12px", marginRight: "6px" }} />
                     Launch Swarm…
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => setShowTemplateModal(true)}>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "./ui/dropdown-menu";
 import { Archive, Database, MoreVertical, CheckSquare, ClipboardList, Lightbulb, Pin, PinOff, Layers } from "lucide-react";
 import { MarkAsTemplateModal } from "./MarkAsTemplateModal";
+import { SwarmComposer } from "./SwarmComposer";
 import { StatusDot } from "./ui/StatusDot";
 import { usePulse } from "./PulseProvider";
 import { ClaudeMdHealthBadge } from "./ClaudeMdAuditPanel";
@@ -67,6 +68,7 @@ const GRADE_STYLE: Record<string, { color: string; bg: string; border: string }>
 export function ProjectCard({ project, onArchive, compact = false, pinned = false, onTogglePin, efficiencyGrade }: ProjectCardProps) {
   const [devPort, setDevPort] = useState(project.devPort);
   const [showTemplateModal, setShowTemplateModal] = useState(false);
+  const [swarmComposerOpen, setSwarmComposerOpen] = useState(false);
   const router = useRouter();
   const { snapshot } = usePulse();
   const isLive = snapshot.liveSlugs.includes(project.slug);
@@ -338,6 +340,10 @@ export function ProjectCard({ project, onArchive, compact = false, pinned = fals
                   align="end"
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
                 >
+                  <DropdownMenuItem onClick={() => setSwarmComposerOpen(true)}>
+                    <Layers style={{ width: "12px", height: "12px", marginRight: "6px" }} />
+                    Launch Swarm…
+                  </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => setShowTemplateModal(true)}>
                     <Layers style={{ width: "12px", height: "12px", marginRight: "6px" }} />
                     Mark as template…
@@ -355,6 +361,11 @@ export function ProjectCard({ project, onArchive, compact = false, pinned = fals
                 onClose={() => setShowTemplateModal(false)}
               />
             )}
+            <SwarmComposer
+              open={swarmComposerOpen}
+              onClose={() => setSwarmComposerOpen(false)}
+              projectPath={project.path}
+            />
           </div>
         </div>
 

--- a/src/components/SwarmComposer.tsx
+++ b/src/components/SwarmComposer.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Modal } from "@/components/ui/modal";
 import type { SwarmMode, ExecutionMode } from "@/lib/tasks/types";
 import { SWARM_MODES } from "@/lib/tasks/types";
+import { inputStyle, labelStyle, Field } from "./composer-fields";
 
 interface MemberDraft {
   title: string;
@@ -18,38 +19,6 @@ interface SwarmComposerProps {
   onClose: () => void;
   /** Pre-fill project path (from project card). If not provided, shows a text input. */
   projectPath?: string;
-}
-
-const inputStyle: React.CSSProperties = {
-  width: "100%",
-  padding: "6px 10px",
-  background: "var(--bg-card)",
-  border: "1px solid var(--border)",
-  borderRadius: "4px",
-  fontSize: "0.82rem",
-  fontFamily: "var(--font-body)",
-  color: "var(--text-primary)",
-  outline: "none",
-  boxSizing: "border-box",
-};
-
-const labelStyle: React.CSSProperties = {
-  display: "block",
-  fontSize: "0.7rem",
-  fontWeight: 600,
-  textTransform: "uppercase",
-  letterSpacing: "0.06em",
-  color: "var(--text-muted)",
-  marginBottom: "4px",
-};
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <label style={labelStyle}>{label}</label>
-      {children}
-    </div>
-  );
 }
 
 function emptyMember(): MemberDraft {

--- a/src/components/SwarmComposer.tsx
+++ b/src/components/SwarmComposer.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Modal } from "@/components/ui/modal";
-import type { SwarmMode, ExecutionMode } from "@/lib/tasks/types";
+import type { SwarmMode } from "@/lib/tasks/types";
 import { SWARM_MODES } from "@/lib/tasks/types";
 import { inputStyle, labelStyle, Field } from "./composer-fields";
 
@@ -11,7 +11,6 @@ interface MemberDraft {
   title: string;
   description: string;
   assigned_skill: string;
-  execution_mode: ExecutionMode;
 }
 
 interface SwarmComposerProps {
@@ -22,7 +21,7 @@ interface SwarmComposerProps {
 }
 
 function emptyMember(): MemberDraft {
-  return { title: "", description: "", assigned_skill: "", execution_mode: "stream" };
+  return { title: "", description: "", assigned_skill: "" };
 }
 
 export function SwarmComposer({ open, onClose, projectPath: propProjectPath }: SwarmComposerProps) {
@@ -88,7 +87,6 @@ export function SwarmComposer({ open, onClose, projectPath: propProjectPath }: S
           title: m.title.trim(),
           description: m.description.trim() || undefined,
           assigned_skill: m.assigned_skill.trim() || undefined,
-          execution_mode: m.execution_mode,
         })),
         coordinator: hasCoordinator
           ? {
@@ -146,12 +144,12 @@ export function SwarmComposer({ open, onClose, projectPath: propProjectPath }: S
               style={inputStyle}
               value={projectPath}
               onChange={(e) => setProjectPath(e.target.value)}
-              placeholder="C:\dev\my-project"
+              placeholder={"C:\\dev\\my-project"}
             />
           </Field>
         )}
 
-        <Field label="Execution mode">
+        <Field label="Swarm mode">
           <div style={{ display: "flex", gap: "16px" }}>
             {SWARM_MODES.map((m) => (
               <label key={m} style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer", fontSize: "0.82rem" }}>

--- a/src/components/SwarmComposer.tsx
+++ b/src/components/SwarmComposer.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Modal } from "@/components/ui/modal";
+import type { SwarmMode, ExecutionMode } from "@/lib/tasks/types";
+import { SWARM_MODES } from "@/lib/tasks/types";
+
+interface MemberDraft {
+  title: string;
+  description: string;
+  assigned_skill: string;
+  execution_mode: ExecutionMode;
+}
+
+interface SwarmComposerProps {
+  open: boolean;
+  onClose: () => void;
+  /** Pre-fill project path (from project card). If not provided, shows a text input. */
+  projectPath?: string;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "6px 10px",
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: "4px",
+  fontSize: "0.82rem",
+  fontFamily: "var(--font-body)",
+  color: "var(--text-primary)",
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "0.7rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "var(--text-muted)",
+  marginBottom: "4px",
+};
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label style={labelStyle}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function emptyMember(): MemberDraft {
+  return { title: "", description: "", assigned_skill: "", execution_mode: "stream" };
+}
+
+export function SwarmComposer({ open, onClose, projectPath: propProjectPath }: SwarmComposerProps) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [mode, setMode] = useState<SwarmMode>("shared");
+  const [projectPath, setProjectPath] = useState(propProjectPath ?? "");
+  const [members, setMembers] = useState<MemberDraft[]>([emptyMember(), emptyMember()]);
+  const [hasCoordinator, setHasCoordinator] = useState(false);
+  const [coordTitle, setCoordTitle] = useState("");
+  const [coordDescription, setCoordDescription] = useState("");
+  const [coordSkill, setCoordSkill] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  function reset() {
+    setName("");
+    setMode("shared");
+    setProjectPath(propProjectPath ?? "");
+    setMembers([emptyMember(), emptyMember()]);
+    setHasCoordinator(false);
+    setCoordTitle("");
+    setCoordDescription("");
+    setCoordSkill("");
+    setError(null);
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  function updateMember(idx: number, patch: Partial<MemberDraft>) {
+    setMembers((prev) => prev.map((m, i) => (i === idx ? { ...m, ...patch } : m)));
+  }
+
+  function addMember() {
+    if (members.length >= 8) return;
+    setMembers((prev) => [...prev, emptyMember()]);
+  }
+
+  function removeMember(idx: number) {
+    if (members.length <= 2) return;
+    setMembers((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+
+    if (!name.trim()) { setError("Name is required"); return; }
+    if (!projectPath.trim()) { setError("Project path is required"); return; }
+    if (members.some((m) => !m.title.trim())) { setError("All member tasks must have a title"); return; }
+    if (hasCoordinator && !coordTitle.trim()) { setError("Coordinator title is required"); return; }
+
+    setSubmitting(true);
+    try {
+      const body = {
+        name: name.trim(),
+        mode,
+        project_path: projectPath.trim(),
+        members: members.map((m) => ({
+          title: m.title.trim(),
+          description: m.description.trim() || undefined,
+          assigned_skill: m.assigned_skill.trim() || undefined,
+          execution_mode: m.execution_mode,
+        })),
+        coordinator: hasCoordinator
+          ? {
+              title: coordTitle.trim(),
+              description: coordDescription.trim() || undefined,
+              assigned_skill: coordSkill.trim() || undefined,
+            }
+          : undefined,
+      };
+
+      const res = await fetch("/api/swarms", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error ?? `Server error (${res.status})`);
+        return;
+      }
+
+      const data = (await res.json()) as { swarm: { id: number } };
+      handleClose();
+      router.push(`/swarms/${data.swarm.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unexpected error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Launch Swarm">
+      <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: "14px" }}>
+        <Field label="Swarm name">
+          <input
+            style={inputStyle}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Auth refactor"
+            autoFocus
+          />
+        </Field>
+
+        {propProjectPath ? (
+          <Field label="Project">
+            <div style={{ ...inputStyle, color: "var(--text-muted)", cursor: "default" }}>
+              {propProjectPath}
+            </div>
+          </Field>
+        ) : (
+          <Field label="Project path">
+            <input
+              style={inputStyle}
+              value={projectPath}
+              onChange={(e) => setProjectPath(e.target.value)}
+              placeholder="C:\dev\my-project"
+            />
+          </Field>
+        )}
+
+        <Field label="Execution mode">
+          <div style={{ display: "flex", gap: "16px" }}>
+            {SWARM_MODES.map((m) => (
+              <label key={m} style={{ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer", fontSize: "0.82rem" }}>
+                <input type="radio" name="mode" value={m} checked={mode === m} onChange={() => setMode(m)} />
+                {m === "worktree" ? "Worktree (isolated branch per task)" : "Shared (same working directory)"}
+              </label>
+            ))}
+          </div>
+        </Field>
+
+        <div>
+          <label style={{ ...labelStyle, marginBottom: "8px" }}>
+            Member tasks ({members.length}/8)
+          </label>
+          <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+            {members.map((m, i) => (
+              <div
+                key={i}
+                style={{
+                  padding: "10px",
+                  background: "var(--bg-elevated, var(--bg-card))",
+                  borderRadius: "6px",
+                  border: "1px solid var(--border)",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "8px",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                  <span style={{ fontSize: "0.72rem", color: "var(--text-muted)", fontWeight: 600 }}>
+                    TASK {i + 1}
+                  </span>
+                  {members.length > 2 && (
+                    <button
+                      type="button"
+                      onClick={() => removeMember(i)}
+                      style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-muted)", fontSize: "0.75rem" }}
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+                <input
+                  style={inputStyle}
+                  value={m.title}
+                  onChange={(e) => updateMember(i, { title: e.target.value })}
+                  placeholder="Task title (required)"
+                />
+                <input
+                  style={inputStyle}
+                  value={m.description}
+                  onChange={(e) => updateMember(i, { description: e.target.value })}
+                  placeholder="Description (optional)"
+                />
+                <input
+                  style={inputStyle}
+                  value={m.assigned_skill}
+                  onChange={(e) => updateMember(i, { assigned_skill: e.target.value })}
+                  placeholder="Skill (optional)"
+                />
+              </div>
+            ))}
+          </div>
+          {members.length < 8 && (
+            <button
+              type="button"
+              onClick={addMember}
+              style={{
+                marginTop: "8px",
+                padding: "6px 12px",
+                background: "none",
+                border: "1px dashed var(--border)",
+                borderRadius: "4px",
+                cursor: "pointer",
+                color: "var(--text-muted)",
+                fontSize: "0.78rem",
+                width: "100%",
+              }}
+            >
+              + Add member task
+            </button>
+          )}
+        </div>
+
+        <div>
+          <label style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer", fontSize: "0.82rem" }}>
+            <input type="checkbox" checked={hasCoordinator} onChange={(e) => setHasCoordinator(e.target.checked)} />
+            Add coordinator task (runs after all members complete)
+          </label>
+          {hasCoordinator && (
+            <div
+              style={{
+                marginTop: "10px",
+                padding: "10px",
+                background: "var(--bg-elevated, var(--bg-card))",
+                borderRadius: "6px",
+                border: "1px solid var(--border)",
+                display: "flex",
+                flexDirection: "column",
+                gap: "8px",
+              }}
+            >
+              <input
+                style={inputStyle}
+                value={coordTitle}
+                onChange={(e) => setCoordTitle(e.target.value)}
+                placeholder="Coordinator task title (required)"
+              />
+              <input
+                style={inputStyle}
+                value={coordDescription}
+                onChange={(e) => setCoordDescription(e.target.value)}
+                placeholder="Description — member outputs will be appended (optional)"
+              />
+              <input
+                style={inputStyle}
+                value={coordSkill}
+                onChange={(e) => setCoordSkill(e.target.value)}
+                placeholder="Skill (optional)"
+              />
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <div style={{ color: "var(--error)", fontSize: "0.78rem", padding: "6px 0" }}>{error}</div>
+        )}
+
+        <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            onClick={handleClose}
+            style={{
+              padding: "7px 14px",
+              background: "none",
+              border: "1px solid var(--border)",
+              borderRadius: "4px",
+              cursor: "pointer",
+              fontSize: "0.82rem",
+              color: "var(--text-primary)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            style={{
+              padding: "7px 16px",
+              background: "var(--accent)",
+              border: "none",
+              borderRadius: "4px",
+              cursor: submitting ? "not-allowed" : "pointer",
+              fontSize: "0.82rem",
+              color: "#fff",
+              fontWeight: 600,
+              opacity: submitting ? 0.7 : 1,
+            }}
+          >
+            {submitting ? "Launching…" : "Launch Swarm"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/TaskComposer.tsx
+++ b/src/components/TaskComposer.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { Modal } from "@/components/ui/modal";
 import type { TaskQuadrant, RiskLevel, ExecutionMode, TaskStatus, Task } from "@/lib/tasks/types";
 import { EXECUTION_MODES, EXECUTION_MODE_LABELS } from "@/lib/tasks/types";
+import { inputStyle, selectStyle, Field } from "./composer-fields";
 
 const BLOCKER_ELIGIBLE: Set<TaskStatus> = new Set(["pending", "awaiting_approval", "running"]);
 
@@ -13,39 +14,6 @@ interface TaskComposerProps {
   onSuccess: () => void;
 }
 
-const inputStyle: React.CSSProperties = {
-  width: "100%",
-  padding: "6px 10px",
-  background: "var(--bg-card)",
-  border: "1px solid var(--border)",
-  borderRadius: "4px",
-  fontSize: "0.82rem",
-  fontFamily: "var(--font-body)",
-  color: "var(--text-primary)",
-  outline: "none",
-  boxSizing: "border-box",
-};
-
-const selectStyle: React.CSSProperties = { ...inputStyle, cursor: "pointer" };
-
-const labelStyle: React.CSSProperties = {
-  display: "block",
-  fontSize: "0.7rem",
-  fontWeight: 600,
-  textTransform: "uppercase",
-  letterSpacing: "0.06em",
-  color: "var(--text-muted)",
-  marginBottom: "4px",
-};
-
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div>
-      <label style={labelStyle}>{label}</label>
-      {children}
-    </div>
-  );
-}
 
 export function TaskComposer({ open, onClose, onSuccess }: TaskComposerProps) {
   const [title, setTitle] = useState("");

--- a/src/components/TasksBrowser.tsx
+++ b/src/components/TasksBrowser.tsx
@@ -17,6 +17,7 @@ import {
 import type { Task, Schedule, TaskStatus, TaskQuadrant } from "@/lib/tasks/types";
 import { TASK_STATUSES, TASK_QUADRANTS } from "@/lib/tasks/types";
 import { TaskComposer } from "./TaskComposer";
+import { SwarmComposer } from "./SwarmComposer";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -317,6 +318,7 @@ export function TasksBrowser({ tasks, schedules, decisionCounts, onRefresh }: Pr
   const [sortKey, setSortKey] = useState<SortKey>("created_at");
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const [composerOpen, setComposerOpen] = useState(false);
+  const [swarmComposerOpen, setSwarmComposerOpen] = useState(false);
 
   const filtered = useMemo(() => {
     let result = tasks;
@@ -419,24 +421,41 @@ export function TasksBrowser({ tasks, schedules, decisionCounts, onRefresh }: Pr
           {filtered.length} / {tasks.length}
         </span>
 
-        <button
-          onClick={() => setComposerOpen(true)}
-          style={{
-            display: "flex", alignItems: "center", gap: "5px",
-            padding: "5px 12px",
-            background: "var(--accent)",
-            border: "none",
-            borderRadius: "4px",
-            fontSize: "0.78rem",
-            fontWeight: 600,
-            color: "white",
-            cursor: "pointer",
-            marginLeft: "auto",
-          }}
-        >
-          <Plus style={{ width: "12px", height: "12px" }} />
-          New task
-        </button>
+        <div style={{ display: "flex", gap: "6px", marginLeft: "auto" }}>
+          <button
+            onClick={() => setSwarmComposerOpen(true)}
+            style={{
+              display: "flex", alignItems: "center", gap: "5px",
+              padding: "5px 12px",
+              background: "none",
+              border: "1px solid var(--border)",
+              borderRadius: "4px",
+              fontSize: "0.78rem",
+              fontWeight: 600,
+              color: "var(--text-primary)",
+              cursor: "pointer",
+            }}
+          >
+            Launch Swarm
+          </button>
+          <button
+            onClick={() => setComposerOpen(true)}
+            style={{
+              display: "flex", alignItems: "center", gap: "5px",
+              padding: "5px 12px",
+              background: "var(--accent)",
+              border: "none",
+              borderRadius: "4px",
+              fontSize: "0.78rem",
+              fontWeight: 600,
+              color: "white",
+              cursor: "pointer",
+            }}
+          >
+            <Plus style={{ width: "12px", height: "12px" }} />
+            New task
+          </button>
+        </div>
       </div>
 
       <TaskComposer
@@ -446,6 +465,10 @@ export function TasksBrowser({ tasks, schedules, decisionCounts, onRefresh }: Pr
           setComposerOpen(false);
           onRefresh?.();
         }}
+      />
+      <SwarmComposer
+        open={swarmComposerOpen}
+        onClose={() => setSwarmComposerOpen(false)}
       />
 
       {/* Tasks list */}

--- a/src/components/TasksBrowser.tsx
+++ b/src/components/TasksBrowser.tsx
@@ -15,7 +15,7 @@ import {
   Plus,
 } from "lucide-react";
 import type { Task, Schedule, TaskStatus, TaskQuadrant } from "@/lib/tasks/types";
-import { TASK_STATUSES, TASK_QUADRANTS } from "@/lib/tasks/types";
+import { TASK_STATUSES, TASK_QUADRANTS, TASK_STATUS_COLORS } from "@/lib/tasks/types";
 import { TaskComposer } from "./TaskComposer";
 import { SwarmComposer } from "./SwarmComposer";
 
@@ -32,20 +32,12 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
   cancelled:          "Cancelled",
 };
 
-const STATUS_COLORS: Record<TaskStatus, string> = {
-  pending:            "var(--text-muted)",
-  awaiting_approval:  "var(--accent)",
-  running:            "var(--info)",
-  done:               "var(--success, #22c55e)",
-  failed:             "var(--error)",
-  cancelled:          "var(--text-muted)",
-};
 
 const REDUCED_MOTION =
   typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 function StatusIcon({ status }: { status: TaskStatus }) {
-  const style = { width: "12px", height: "12px", color: STATUS_COLORS[status] };
+  const style = { width: "12px", height: "12px", color: TASK_STATUS_COLORS[status] };
   switch (status) {
     case "pending":           return <Circle style={style} />;
     case "awaiting_approval": return <HelpCircle style={style} />;
@@ -67,8 +59,8 @@ function StatusBadge({ status }: { status: TaskStatus }) {
         textTransform: "uppercase",
         padding: "1px 5px",
         borderRadius: "3px",
-        background: `color-mix(in srgb, ${STATUS_COLORS[status]} 12%, transparent)`,
-        color: STATUS_COLORS[status],
+        background: `color-mix(in srgb, ${TASK_STATUS_COLORS[status]} 12%, transparent)`,
+        color: TASK_STATUS_COLORS[status],
         display: "inline-flex",
         alignItems: "center",
         gap: "3px",

--- a/src/components/composer-fields.tsx
+++ b/src/components/composer-fields.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+/** Shared form primitives for Task/Swarm composer modals. */
+
+export const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "6px 10px",
+  background: "var(--bg-card)",
+  border: "1px solid var(--border)",
+  borderRadius: "4px",
+  fontSize: "0.82rem",
+  fontFamily: "var(--font-body)",
+  color: "var(--text-primary)",
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+export const selectStyle: React.CSSProperties = { ...inputStyle, cursor: "pointer" };
+
+export const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "0.7rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  color: "var(--text-muted)",
+  marginBottom: "4px",
+};
+
+export function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label style={labelStyle}>{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/src/lib/tasks/dispatcher.ts
+++ b/src/lib/tasks/dispatcher.ts
@@ -2,8 +2,8 @@ import "server-only";
 import os from "os";
 import path from "path";
 import fs from "fs";
-import { claimPendingTask, materializeSchedules, promoteApprovalTasks, completeTask, recordDecision, getTask } from "./store";
-import { runClassicTask, runStreamTask, sweepStalePids, type SpawnFn } from "./spawner";
+import { claimPendingTask, materializeSchedules, promoteApprovalTasks, completeTask, recordDecision, getTask, updateSwarmStatus } from "./store";
+import { runClassicTask, runStreamTask, runWorktreeTask, sweepStalePids, type SpawnFn } from "./spawner";
 import type { Task } from "./types";
 import type { DecisionEvent } from "./decisionParser";
 import { readConfig } from "../config";
@@ -108,15 +108,50 @@ export function initDispatcher(spawnFn?: SpawnFn): void {
           continue;
         }
 
+        const swarmId = task.swarm_id;
+
+        async function afterStreamComplete(completedTask: Task): Promise<void> {
+          await onTaskCompleteToggleTodo(completedTask);
+          if (swarmId != null) {
+            await updateSwarmStatus(swarmId).catch((err) =>
+              console.error(`[dispatcher] updateSwarmStatus failed for swarm ${swarmId}:`, err)
+            );
+          }
+        }
+
+        async function afterClassicSwarmComplete(): Promise<void> {
+          if (swarmId != null) {
+            await updateSwarmStatus(swarmId).catch((err) =>
+              console.error(`[dispatcher] updateSwarmStatus failed for swarm ${swarmId}:`, err)
+            );
+          }
+        }
+
         let promise: Promise<void>;
-        if (task.execution_mode === "stream") {
-          promise = runStreamTask(task, spawnFn, handleDecision, onTaskCompleteToggleTodo)
+        const isWorktree =
+          task.swarm_id != null &&
+          (() => {
+            try {
+              return !!(JSON.parse(task.metadata ?? "{}") as { worktreePath?: string })
+                .worktreePath;
+            } catch {
+              return false;
+            }
+          })();
+
+        if (isWorktree) {
+          promise = runWorktreeTask(task, spawnFn, handleDecision, afterStreamComplete)
+            .then(() => {})
+            .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
+            .finally(() => inFlight.delete(task!.id));
+        } else if (task.execution_mode === "stream") {
+          promise = runStreamTask(task, spawnFn, handleDecision, afterStreamComplete)
             .then(() => {})
             .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
             .finally(() => inFlight.delete(task!.id));
         } else {
           promise = runClassicTask(task, spawnFn)
-            .then(() => {})
+            .then(() => afterClassicSwarmComplete())
             .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
             .finally(() => inFlight.delete(task!.id));
         }

--- a/src/lib/tasks/dispatcher.ts
+++ b/src/lib/tasks/dispatcher.ts
@@ -110,8 +110,8 @@ export function initDispatcher(spawnFn?: SpawnFn): void {
 
         const swarmId = task.swarm_id;
 
-        async function afterStreamComplete(completedTask: Task): Promise<void> {
-          await onTaskCompleteToggleTodo(completedTask);
+        async function afterComplete(completedTask?: Task): Promise<void> {
+          if (completedTask) await onTaskCompleteToggleTodo(completedTask);
           if (swarmId != null) {
             await updateSwarmStatus(swarmId).catch((err) =>
               console.error(`[dispatcher] updateSwarmStatus failed for swarm ${swarmId}:`, err)
@@ -119,39 +119,26 @@ export function initDispatcher(spawnFn?: SpawnFn): void {
           }
         }
 
-        async function afterClassicSwarmComplete(): Promise<void> {
-          if (swarmId != null) {
-            await updateSwarmStatus(swarmId).catch((err) =>
-              console.error(`[dispatcher] updateSwarmStatus failed for swarm ${swarmId}:`, err)
-            );
-          }
-        }
+        let worktreePath: string | undefined;
+        try {
+          worktreePath = (JSON.parse(task.metadata ?? "{}") as { worktreePath?: string }).worktreePath;
+        } catch { /* metadata not JSON */ }
+        const isWorktree = task.swarm_id != null && !!worktreePath;
 
         let promise: Promise<void>;
-        const isWorktree =
-          task.swarm_id != null &&
-          (() => {
-            try {
-              return !!(JSON.parse(task.metadata ?? "{}") as { worktreePath?: string })
-                .worktreePath;
-            } catch {
-              return false;
-            }
-          })();
-
         if (isWorktree) {
-          promise = runWorktreeTask(task, spawnFn, handleDecision, afterStreamComplete)
+          promise = runWorktreeTask(task, spawnFn, handleDecision, afterComplete)
             .then(() => {})
             .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
             .finally(() => inFlight.delete(task!.id));
         } else if (task.execution_mode === "stream") {
-          promise = runStreamTask(task, spawnFn, handleDecision, afterStreamComplete)
+          promise = runStreamTask(task, spawnFn, handleDecision, afterComplete)
             .then(() => {})
             .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
             .finally(() => inFlight.delete(task!.id));
         } else {
           promise = runClassicTask(task, spawnFn)
-            .then(() => afterClassicSwarmComplete())
+            .then(() => afterComplete())
             .catch((err) => console.error(`[dispatcher] task ${task!.id} spawn error:`, err))
             .finally(() => inFlight.delete(task!.id));
         }

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -5,7 +5,7 @@ import os from "os";
 import path from "path";
 import fs from "fs";
 import type { Task } from "./types";
-import { completeTask, failTask, setSessionId } from "./store";
+import { completeTask, failTask, setSessionId, getTask } from "./store";
 import { isWindows } from "../platform";
 import { createDecisionParser, type DecisionEvent } from "./decisionParser";
 
@@ -388,10 +388,28 @@ export async function runWorktreeTask(
 
   const { worktreePath, projectPath } = meta;
 
-  if (!worktreePath || !projectPath) {
-    return task.execution_mode === "stream"
-      ? runStreamTask(task, spawnFn, onDecision, onComplete)
-      : runClassicTask(task, spawnFn);
+  if (!projectPath) {
+    // No project context at all — dispatch with default cwd and inherited spawnFn.
+    if (task.execution_mode === "stream") return runStreamTask(task, spawnFn, onDecision, onComplete);
+    const result = await runClassicTask(task, spawnFn);
+    if (onComplete) {
+      const updated = await getTask(task.id).catch(() => null);
+      if (updated) onComplete(updated).catch((e) => console.error(`[spawner] onComplete failed for task ${task.id}:`, e));
+    }
+    return result;
+  }
+
+  // Shared mode: no worktree, but cwd should be the project root.
+  if (!worktreePath) {
+    const sharedSpawnFn = ((cmd: string, args: readonly string[], opts: object) =>
+      spawnFn(cmd as string, args as readonly string[], { ...opts, cwd: projectPath } as never)) as unknown as SpawnFn;
+    if (task.execution_mode === "stream") return runStreamTask(task, sharedSpawnFn, onDecision, onComplete);
+    const result = await runClassicTask(task, sharedSpawnFn);
+    if (onComplete) {
+      const updated = await getTask(task.id).catch(() => null);
+      if (updated) onComplete(updated).catch((e) => console.error(`[spawner] onComplete failed for task ${task.id}:`, e));
+    }
+    return result;
   }
 
   // Create the worktree if it doesn't already exist.
@@ -409,12 +427,19 @@ export async function runWorktreeTask(
     }
   }
 
-  // Wrap spawnFn so child processes inherit the worktree's cwd.
+  // Wrap spawnFn so child processes inherit the target cwd.
   // Cast required because SpawnFn has many overloads; we only use the (cmd, args, opts) form.
+  const effectiveCwd = worktreePath;
   const cwdSpawnFn = ((cmd: string, args: readonly string[], opts: object) =>
-    spawnFn(cmd as string, args as readonly string[], { ...opts, cwd: worktreePath } as never)) as unknown as SpawnFn;
+    spawnFn(cmd as string, args as readonly string[], { ...opts, cwd: effectiveCwd } as never)) as unknown as SpawnFn;
 
-  return task.execution_mode === "stream"
-    ? runStreamTask(task, cwdSpawnFn, onDecision, onComplete)
-    : runClassicTask(task, cwdSpawnFn);
+  if (task.execution_mode === "stream") {
+    return runStreamTask(task, cwdSpawnFn, onDecision, onComplete);
+  }
+  const result = await runClassicTask(task, cwdSpawnFn);
+  if (onComplete) {
+    const updated = await getTask(task.id).catch(() => null);
+    if (updated) onComplete(updated).catch((e) => console.error(`[spawner] onComplete failed for task ${task.id}:`, e));
+  }
+  return result;
 }

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -372,12 +372,7 @@ export async function runStreamTask(
 
 const execFileAsync = promisify(execFile);
 
-/**
- * Spawn a task inside a git worktree directory.
- * Reads worktreePath and projectPath from task metadata JSON.
- * Creates the worktree via `git worktree add` if the directory doesn't exist yet.
- * Injects cwd via a spawnFn closure so runClassicTask/runStreamTask need no signature changes.
- */
+/** Injects cwd via spawnFn closure — avoids signature changes to runClassicTask/runStreamTask. */
 export async function runWorktreeTask(
   task: Task,
   spawnFn: SpawnFn = spawn,

--- a/src/lib/tasks/spawner.ts
+++ b/src/lib/tasks/spawner.ts
@@ -1,5 +1,6 @@
 import "server-only";
-import { spawn, type ChildProcess } from "child_process";
+import { spawn, execFile, type ChildProcess } from "child_process";
+import { promisify } from "util";
 import os from "os";
 import path from "path";
 import fs from "fs";
@@ -367,4 +368,58 @@ export async function runStreamTask(
       resolve({ taskId: task.id, status: "failed", error: err.message, durationMs });
     });
   });
+}
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Spawn a task inside a git worktree directory.
+ * Reads worktreePath and projectPath from task metadata JSON.
+ * Creates the worktree via `git worktree add` if the directory doesn't exist yet.
+ * Injects cwd via a spawnFn closure so runClassicTask/runStreamTask need no signature changes.
+ */
+export async function runWorktreeTask(
+  task: Task,
+  spawnFn: SpawnFn = spawn,
+  onDecision?: OnDecisionFn,
+  onComplete?: OnCompleteFn
+): Promise<RunTaskResult> {
+  let meta: { worktreePath?: string; projectPath?: string } = {};
+  try {
+    meta = JSON.parse(task.metadata ?? "{}") as typeof meta;
+  } catch {
+    // malformed metadata — fall through to normal dispatch
+  }
+
+  const { worktreePath, projectPath } = meta;
+
+  if (!worktreePath || !projectPath) {
+    return task.execution_mode === "stream"
+      ? runStreamTask(task, spawnFn, onDecision, onComplete)
+      : runClassicTask(task, spawnFn);
+  }
+
+  // Create the worktree if it doesn't already exist.
+  if (!fs.existsSync(worktreePath)) {
+    const branchName = `swarm-${task.swarm_id ?? "x"}-${task.id}-${Date.now()}`;
+    try {
+      await execFileAsync("git", ["worktree", "add", "-B", branchName, worktreePath, "HEAD"], {
+        cwd: projectPath,
+      });
+    } catch (err) {
+      const errMsg = `git worktree add failed: ${(err as Error).message}`.slice(0, 2000);
+      console.error(`[spawner] ${errMsg}`);
+      await failTask(task.id, { error_message: errMsg }).catch(() => {});
+      return { taskId: task.id, status: "failed", error: errMsg, durationMs: 0 };
+    }
+  }
+
+  // Wrap spawnFn so child processes inherit the worktree's cwd.
+  // Cast required because SpawnFn has many overloads; we only use the (cmd, args, opts) form.
+  const cwdSpawnFn = ((cmd: string, args: readonly string[], opts: object) =>
+    spawnFn(cmd as string, args as readonly string[], { ...opts, cwd: worktreePath } as never)) as unknown as SpawnFn;
+
+  return task.execution_mode === "stream"
+    ? runStreamTask(task, cwdSpawnFn, onDecision, onComplete)
+    : runClassicTask(task, cwdSpawnFn);
 }

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import path from "path";
 import type DatabaseT from "better-sqlite3";
 import { initTasksDb } from "../tasksDb/migrations";
 import { getTasksDb, prepTasksCached } from "../tasksDb/connection";
@@ -8,7 +9,10 @@ import type {
   TaskDecision,
   TaskDependency,
   Schedule,
+  Swarm,
+  SwarmStatus,
   CreateTaskInput,
+  CreateSwarmInput,
   PatchTaskInput,
   CreateScheduleInput,
   PatchScheduleInput,
@@ -174,8 +178,13 @@ export async function claimPendingTask(): Promise<Task | null> {
          AND NOT EXISTS (
            SELECT 1 FROM task_dependencies td
            JOIN ops_tasks bt ON bt.id = td.blocker_id
-           WHERE td.task_id = ops_tasks.id
-             AND bt.status != 'done'
+           WHERE td.task_id = ops_tasks.id AND (
+             (ops_tasks.swarm_role IS NULL OR ops_tasks.swarm_role != 'coordinator')
+               AND bt.status != 'done'
+             OR
+             ops_tasks.swarm_role = 'coordinator'
+               AND bt.status NOT IN ('done','failed','cancelled')
+           )
          )
        ORDER BY priority ASC, created_at ASC
        LIMIT 1
@@ -203,8 +212,13 @@ export async function promoteApprovalTasks(): Promise<number> {
        AND NOT EXISTS (
          SELECT 1 FROM task_dependencies td
          JOIN ops_tasks bt ON bt.id = td.blocker_id
-         WHERE td.task_id = ops_tasks.id
-           AND bt.status != 'done'
+         WHERE td.task_id = ops_tasks.id AND (
+           (ops_tasks.swarm_role IS NULL OR ops_tasks.swarm_role != 'coordinator')
+             AND bt.status != 'done'
+           OR
+           ops_tasks.swarm_role = 'coordinator'
+             AND bt.status NOT IN ('done','failed','cancelled')
+         )
        )`
   ).run();
   return result.changes;
@@ -574,6 +588,199 @@ export async function listAllDependencies(): Promise<TaskDependency[]> {
   return prepTasksCached(db,
     "SELECT * FROM task_dependencies ORDER BY created_at ASC"
   ).all() as TaskDependency[];
+}
+
+// ---------------------------------------------------------------------------
+// Swarms
+// ---------------------------------------------------------------------------
+
+const WORKTREE_SEP = "--claude-worktrees-";
+
+/** Create a swarm with its member tasks (and optional coordinator) in one transaction. */
+export async function createSwarm(
+  input: CreateSwarmInput
+): Promise<{ swarm: Swarm; tasks: Task[] }> {
+  const db = await ensureReady();
+
+  const slug = input.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 30);
+
+  let swarm!: Swarm;
+  const allTasks: Task[] = [];
+
+  const txn = db.transaction(() => {
+    swarm = db
+      .prepare(
+        `INSERT INTO ops_swarms (name, mode, project_path) VALUES (?, ?, ?) RETURNING *`
+      )
+      .get(input.name, input.mode, input.project_path) as Swarm;
+
+    const insertTask = db.prepare(
+      `INSERT INTO ops_tasks
+        (title, description, priority, quadrant, assigned_skill, model,
+         execution_mode, requires_approval, risk_level, dry_run, metadata,
+         swarm_id, swarm_role)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 0, 'low', 0, ?, ?, ?)
+       RETURNING *`
+    );
+
+    const memberIds: number[] = [];
+
+    for (let i = 0; i < input.members.length; i++) {
+      const member = input.members[i];
+      let meta: Record<string, unknown> | null = null;
+      if (input.mode === "worktree") {
+        const worktreePath = path.join(
+          path.dirname(input.project_path),
+          path.basename(input.project_path) + WORKTREE_SEP + slug + "-" + i
+        );
+        meta = { worktreePath, projectPath: input.project_path };
+      }
+      const task = insertTask.get(
+        member.title,
+        member.description ?? "",
+        3,
+        "do",
+        member.assigned_skill ?? null,
+        member.model ?? null,
+        member.execution_mode ?? "stream",
+        meta ? JSON.stringify(meta) : null,
+        swarm.id,
+        "member"
+      ) as Task;
+      allTasks.push(task);
+      memberIds.push(task.id);
+    }
+
+    if (input.coordinator) {
+      const coordTask = insertTask.get(
+        input.coordinator.title,
+        input.coordinator.description ?? "",
+        3,
+        "do",
+        input.coordinator.assigned_skill ?? null,
+        null,
+        "stream",
+        null,
+        swarm.id,
+        "coordinator"
+      ) as Task;
+      allTasks.push(coordTask);
+
+      const insertDep = db.prepare(
+        `INSERT INTO task_dependencies (task_id, blocker_id) VALUES (?, ?)
+         ON CONFLICT(task_id, blocker_id) DO NOTHING`
+      );
+      for (const memberId of memberIds) {
+        insertDep.run(coordTask.id, memberId);
+      }
+    }
+  });
+
+  txn();
+  return { swarm, tasks: allTasks };
+}
+
+export async function getSwarm(id: number): Promise<Swarm | null> {
+  const db = await ensureReady();
+  const row = db
+    .prepare("SELECT * FROM ops_swarms WHERE id = ?")
+    .get(id) as Swarm | undefined;
+  return row ?? null;
+}
+
+export async function listSwarms(): Promise<Swarm[]> {
+  const db = await ensureReady();
+  return db
+    .prepare("SELECT * FROM ops_swarms ORDER BY created_at DESC")
+    .all() as Swarm[];
+}
+
+export async function getSwarmTasks(swarmId: number): Promise<Task[]> {
+  const db = await ensureReady();
+  return db
+    .prepare("SELECT * FROM ops_tasks WHERE swarm_id = ? ORDER BY created_at ASC")
+    .all(swarmId) as Task[];
+}
+
+/**
+ * Recompute and write the aggregate status for a swarm after any member/coordinator changes.
+ * When all members become terminal, injects their output summaries into the coordinator description
+ * (exactly once, guarded by a marker string in the description).
+ */
+export async function updateSwarmStatus(swarmId: number): Promise<void> {
+  const db = await ensureReady();
+
+  const swarm = db
+    .prepare("SELECT * FROM ops_swarms WHERE id = ?")
+    .get(swarmId) as Swarm | undefined;
+  if (!swarm) return;
+
+  type TaskRow = {
+    id: number;
+    status: string;
+    output_summary: string | null;
+    title: string;
+    swarm_role: string;
+    description: string;
+  };
+
+  const tasks = db
+    .prepare(
+      "SELECT id, status, output_summary, title, swarm_role, description FROM ops_tasks WHERE swarm_id = ?"
+    )
+    .all(swarmId) as TaskRow[];
+  if (tasks.length === 0) return;
+
+  const TERMINAL = new Set(["done", "failed", "cancelled"]);
+  const members = tasks.filter((t) => t.swarm_role === "member");
+  const coordinator = tasks.find((t) => t.swarm_role === "coordinator");
+
+  // Inject member summaries into coordinator description once, right before it becomes claimable.
+  if (
+    coordinator &&
+    coordinator.status === "pending" &&
+    members.every((t) => TERMINAL.has(t.status))
+  ) {
+    const withOutput = members.filter((t) => t.output_summary);
+    if (
+      withOutput.length > 0 &&
+      !coordinator.description.includes("<!-- swarm-summaries-injected -->")
+    ) {
+      const block = [
+        "<!-- swarm-summaries-injected -->",
+        "## Member Task Outputs",
+        ...withOutput.map((m) => `\n### ${m.title} (${m.status})\n${m.output_summary}`),
+      ].join("\n\n");
+      db.prepare(
+        `UPDATE ops_tasks SET description = description || ?
+         WHERE id = ? AND status = 'pending'`
+      ).run("\n\n" + block, coordinator.id);
+    }
+  }
+
+  const allTerminal = tasks.every((t) => TERMINAL.has(t.status));
+  if (!allTerminal) return;
+
+  let newStatus: SwarmStatus;
+  if (coordinator) {
+    const cs = coordinator.status;
+    newStatus = cs === "done" ? "done" : cs === "failed" ? "failed" : "cancelled";
+  } else {
+    if (members.every((t) => t.status === "done")) newStatus = "done";
+    else if (members.some((t) => t.status === "failed")) newStatus = "failed";
+    else newStatus = "cancelled";
+  }
+
+  db.prepare(
+    `UPDATE ops_swarms
+     SET status = ?, completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+     WHERE id = ? AND status = 'running'`
+  ).run(newStatus, swarmId);
 }
 
 /** Count decisions created after sinceEpoch (Unix seconds). Used by pulse for per-client edge-triggering. */

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import path from "path";
 import type DatabaseT from "better-sqlite3";
+import { WORKTREE_SEP } from "../scanner/worktreeCheck";
 import { initTasksDb } from "../tasksDb/migrations";
 import { getTasksDb, prepTasksCached } from "../tasksDb/connection";
 import { computeNextRun } from "./cron";
@@ -595,7 +596,6 @@ export async function listAllDependencies(): Promise<TaskDependency[]> {
 // Swarms
 // ---------------------------------------------------------------------------
 
-const WORKTREE_SEP = "--claude-worktrees-";
 const TERMINAL_STATUSES = new Set<TaskStatus>(["done", "failed", "cancelled"]);
 
 type SwarmTaskRow = Pick<Task, "id" | "status" | "output_summary" | "title" | "swarm_role" | "description">;
@@ -636,13 +636,15 @@ export async function createSwarm(
 
     for (let i = 0; i < input.members.length; i++) {
       const member = input.members[i];
-      let meta: Record<string, unknown> | null = null;
+      let meta: Record<string, unknown>;
       if (input.mode === "worktree") {
         const worktreePath = path.join(
           path.dirname(input.project_path),
-          path.basename(input.project_path) + WORKTREE_SEP + slug + "-" + i
+          path.basename(input.project_path) + WORKTREE_SEP + slug + "-" + swarm.id + "-" + i
         );
         meta = { worktreePath, projectPath: input.project_path };
+      } else {
+        meta = { projectPath: input.project_path };
       }
       const task = insertTask.get(
         member.title,
@@ -652,7 +654,7 @@ export async function createSwarm(
         member.assigned_skill ?? null,
         member.model ?? null,
         member.execution_mode ?? "stream",
-        meta ? JSON.stringify(meta) : null,
+        JSON.stringify(meta),
         swarm.id,
         "member"
       ) as Task;

--- a/src/lib/tasks/store.ts
+++ b/src/lib/tasks/store.ts
@@ -6,6 +6,7 @@ import { getTasksDb, prepTasksCached } from "../tasksDb/connection";
 import { computeNextRun } from "./cron";
 import type {
   Task,
+  TaskStatus,
   TaskDecision,
   TaskDependency,
   Schedule,
@@ -595,6 +596,9 @@ export async function listAllDependencies(): Promise<TaskDependency[]> {
 // ---------------------------------------------------------------------------
 
 const WORKTREE_SEP = "--claude-worktrees-";
+const TERMINAL_STATUSES = new Set<TaskStatus>(["done", "failed", "cancelled"]);
+
+type SwarmTaskRow = Pick<Task, "id" | "status" | "output_summary" | "title" | "swarm_role" | "description">;
 
 /** Create a swarm with its member tasks (and optional coordinator) in one transaction. */
 export async function createSwarm(
@@ -715,28 +719,13 @@ export async function getSwarmTasks(swarmId: number): Promise<Task[]> {
 export async function updateSwarmStatus(swarmId: number): Promise<void> {
   const db = await ensureReady();
 
-  const swarm = db
-    .prepare("SELECT * FROM ops_swarms WHERE id = ?")
-    .get(swarmId) as Swarm | undefined;
-  if (!swarm) return;
-
-  type TaskRow = {
-    id: number;
-    status: string;
-    output_summary: string | null;
-    title: string;
-    swarm_role: string;
-    description: string;
-  };
-
   const tasks = db
     .prepare(
       "SELECT id, status, output_summary, title, swarm_role, description FROM ops_tasks WHERE swarm_id = ?"
     )
-    .all(swarmId) as TaskRow[];
+    .all(swarmId) as SwarmTaskRow[];
   if (tasks.length === 0) return;
 
-  const TERMINAL = new Set(["done", "failed", "cancelled"]);
   const members = tasks.filter((t) => t.swarm_role === "member");
   const coordinator = tasks.find((t) => t.swarm_role === "coordinator");
 
@@ -744,7 +733,7 @@ export async function updateSwarmStatus(swarmId: number): Promise<void> {
   if (
     coordinator &&
     coordinator.status === "pending" &&
-    members.every((t) => TERMINAL.has(t.status))
+    members.every((t) => TERMINAL_STATUSES.has(t.status))
   ) {
     const withOutput = members.filter((t) => t.output_summary);
     if (
@@ -763,7 +752,7 @@ export async function updateSwarmStatus(swarmId: number): Promise<void> {
     }
   }
 
-  const allTerminal = tasks.every((t) => TERMINAL.has(t.status));
+  const allTerminal = tasks.every((t) => TERMINAL_STATUSES.has(t.status));
   if (!allTerminal) return;
 
   let newStatus: SwarmStatus;

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -51,6 +51,15 @@ export const TASK_STATUSES: readonly TaskStatus[] = [
   "failed",
   "cancelled",
 ];
+
+export const TASK_STATUS_COLORS: Record<TaskStatus, string> = {
+  pending:           "var(--text-muted)",
+  awaiting_approval: "var(--accent)",
+  running:           "var(--info, #60a5fa)",
+  done:              "var(--success, #22c55e)",
+  failed:            "var(--error)",
+  cancelled:         "var(--text-muted)",
+};
 export const TASK_QUADRANTS: readonly TaskQuadrant[] = ["do", "schedule", "delegate", "archive", "delegated-todo"];
 export const EXECUTION_MODES: readonly ExecutionMode[] = ["classic", "stream"];
 export const EXECUTION_MODE_LABELS: Record<ExecutionMode, string> = {

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -1,3 +1,36 @@
+export type SwarmMode = "worktree" | "shared";
+export type SwarmStatus = "running" | "done" | "failed" | "cancelled";
+export type SwarmRole = "member" | "coordinator";
+export const SWARM_MODES: readonly SwarmMode[] = ["worktree", "shared"];
+
+export interface Swarm {
+  id: number;
+  name: string;
+  mode: SwarmMode;
+  project_path: string;
+  status: SwarmStatus;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface CreateSwarmInput {
+  name: string;
+  mode: SwarmMode;
+  project_path: string;
+  members: {
+    title: string;
+    description?: string;
+    assigned_skill?: string;
+    model?: string;
+    execution_mode?: ExecutionMode;
+  }[];
+  coordinator?: {
+    title: string;
+    description?: string;
+    assigned_skill?: string;
+  };
+}
+
 export type TaskStatus =
   | "pending"
   | "awaiting_approval"
@@ -76,6 +109,8 @@ export interface Task {
   created_at: string;
   /** JSON blob set by todoDelegation for auto-toggle on completion. */
   metadata: string | null;
+  swarm_id: number | null;
+  swarm_role: SwarmRole | null;
 }
 
 export type DecisionKind = "decision" | "inbox";

--- a/src/lib/tasksDb/migrations.ts
+++ b/src/lib/tasksDb/migrations.ts
@@ -161,6 +161,27 @@ const MIGRATIONS: Migration[] = [
       `);
     },
   },
+  {
+    version: 5,
+    name: "ops_swarms + swarm_id/swarm_role on ops_tasks (Wave 10.1c)",
+    up(db) {
+      runStatements(db, `
+        CREATE TABLE IF NOT EXISTS ops_swarms (
+          id           INTEGER PRIMARY KEY AUTOINCREMENT,
+          name         TEXT    NOT NULL,
+          mode         TEXT    NOT NULL CHECK (mode IN ('worktree','shared')),
+          project_path TEXT    NOT NULL,
+          status       TEXT    NOT NULL DEFAULT 'running'
+                       CHECK (status IN ('running','done','failed','cancelled')),
+          created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+          completed_at TEXT
+        );
+        ALTER TABLE ops_tasks ADD COLUMN swarm_id INTEGER REFERENCES ops_swarms(id) ON DELETE SET NULL;
+        ALTER TABLE ops_tasks ADD COLUMN swarm_role TEXT CHECK (swarm_role IN ('member','coordinator') OR swarm_role IS NULL);
+        CREATE INDEX IF NOT EXISTS ix_tasks_swarm ON ops_tasks(swarm_id) WHERE swarm_id IS NOT NULL
+      `);
+    },
+  },
 ];
 
 function resolveTasksSchemaPath(): string {

--- a/tests/apiSwarms.test.ts
+++ b/tests/apiSwarms.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/tasks/store", () => ({
+  listSwarms: vi.fn(),
+  createSwarm: vi.fn(),
+  getSwarm: vi.fn(),
+  getSwarmTasks: vi.fn(),
+}));
+
+vi.mock("@/lib/tasks/dispatcher", () => ({
+  initDispatcher: vi.fn(),
+}));
+
+import { listSwarms, createSwarm, getSwarm, getSwarmTasks } from "@/lib/tasks/store";
+
+const mockListSwarms = vi.mocked(listSwarms);
+const mockCreateSwarm = vi.mocked(createSwarm);
+const mockGetSwarm = vi.mocked(getSwarm);
+const mockGetSwarmTasks = vi.mocked(getSwarmTasks);
+
+const NOW = "2026-05-09T10:00:00.000Z";
+
+const SWARM_1 = {
+  id: 1,
+  name: "Test swarm",
+  mode: "shared" as const,
+  project_path: "C:\\dev\\test",
+  status: "running" as const,
+  created_at: NOW,
+  completed_at: null,
+};
+
+const TASK_1 = {
+  id: 10,
+  title: "Member A",
+  status: "pending" as const,
+  swarm_id: 1,
+  swarm_role: "member" as const,
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListSwarms.mockResolvedValue([]);
+  mockCreateSwarm.mockResolvedValue({ swarm: SWARM_1, tasks: [TASK_1] });
+  mockGetSwarm.mockResolvedValue(SWARM_1);
+  mockGetSwarmTasks.mockResolvedValue([TASK_1]);
+});
+
+function mkRequest(method: string, url: string, body?: unknown): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+const VALID_BODY = {
+  name: "My swarm",
+  mode: "shared",
+  project_path: "C:\\dev\\my-project",
+  members: [{ title: "Task A" }, { title: "Task B" }],
+};
+
+describe("GET /api/swarms", () => {
+  it("returns 200 with swarms array", async () => {
+    mockListSwarms.mockResolvedValue([SWARM_1]);
+    const { GET } = await import("@/app/api/swarms/route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.swarms)).toBe(true);
+    expect(body.swarms).toHaveLength(1);
+  });
+});
+
+describe("POST /api/swarms", () => {
+  it("returns 201 with swarm and tasks on happy path", async () => {
+    const req = mkRequest("POST", "http://localhost/api/swarms", VALID_BODY);
+    const { POST } = await import("@/app/api/swarms/route");
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.swarm.id).toBe(1);
+    expect(Array.isArray(body.tasks)).toBe(true);
+  });
+
+  it("returns 400 when members < 2", async () => {
+    const req = mkRequest("POST", "http://localhost/api/swarms", {
+      ...VALID_BODY,
+      members: [{ title: "Only one" }],
+    });
+    const { POST } = await import("@/app/api/swarms/route");
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/2/);
+  });
+
+  it("returns 400 when members > 8", async () => {
+    const req = mkRequest("POST", "http://localhost/api/swarms", {
+      ...VALID_BODY,
+      members: Array.from({ length: 9 }, (_, i) => ({ title: `Task ${i}` })),
+    });
+    const { POST } = await import("@/app/api/swarms/route");
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/8/);
+  });
+
+  it("returns 400 when project_path is missing", async () => {
+    const req = mkRequest("POST", "http://localhost/api/swarms", {
+      ...VALID_BODY,
+      project_path: "",
+    });
+    const { POST } = await import("@/app/api/swarms/route");
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.field).toBe("project_path");
+  });
+
+  it("returns 400 when mode is invalid", async () => {
+    const req = mkRequest("POST", "http://localhost/api/swarms", {
+      ...VALID_BODY,
+      mode: "parallel",
+    });
+    const { POST } = await import("@/app/api/swarms/route");
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when a member title is empty", async () => {
+    const req = mkRequest("POST", "http://localhost/api/swarms", {
+      ...VALID_BODY,
+      members: [{ title: "Valid" }, { title: "" }],
+    });
+    const { POST } = await import("@/app/api/swarms/route");
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/swarms/[id]", () => {
+  it("returns 200 with swarm and tasks", async () => {
+    const req = mkRequest("GET", "http://localhost/api/swarms/1");
+    const { GET } = await import("@/app/api/swarms/[id]/route");
+    const res = await GET(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.swarm.id).toBe(1);
+    expect(Array.isArray(body.tasks)).toBe(true);
+  });
+
+  it("returns 404 when swarm not found", async () => {
+    mockGetSwarm.mockResolvedValue(null);
+    const req = mkRequest("GET", "http://localhost/api/swarms/999");
+    const { GET } = await import("@/app/api/swarms/[id]/route");
+    const res = await GET(req, { params: Promise.resolve({ id: "999" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for non-numeric id", async () => {
+    const req = mkRequest("GET", "http://localhost/api/swarms/abc");
+    const { GET } = await import("@/app/api/swarms/[id]/route");
+    const res = await GET(req, { params: Promise.resolve({ id: "abc" }) });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/swarms/[id]/worktrees", () => {
+  it("returns 204", async () => {
+    const req = mkRequest("DELETE", "http://localhost/api/swarms/1/worktrees");
+    const { DELETE } = await import("@/app/api/swarms/[id]/worktrees/route");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "1" }) });
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 400 for non-numeric id", async () => {
+    const req = mkRequest("DELETE", "http://localhost/api/swarms/abc/worktrees");
+    const { DELETE } = await import("@/app/api/swarms/[id]/worktrees/route");
+    const res = await DELETE(req, { params: Promise.resolve({ id: "abc" }) });
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/buildBoard.test.ts
+++ b/tests/buildBoard.test.ts
@@ -44,6 +44,8 @@ function makeTask(overrides: Partial<Task>): Task {
     consecutive_failures: 0,
     created_at: NOW,
     metadata: null,
+    swarm_id: null,
+    swarm_role: null,
     ...overrides,
   };
 }

--- a/tests/spawnerStdin.test.ts
+++ b/tests/spawnerStdin.test.ts
@@ -76,6 +76,8 @@ const BASE_TASK: Task = {
   consecutive_failures: 0,
   created_at: new Date().toISOString(),
   metadata: null,
+  swarm_id: null,
+  swarm_role: null,
 };
 
 const mockCompleteTask = vi.mocked(completeTask);

--- a/tests/swarm.test.ts
+++ b/tests/swarm.test.ts
@@ -332,7 +332,10 @@ describe.skipIf(!Database)("swarm store", () => {
 
     // Call again — should not duplicate the block
     await store.updateSwarmStatus(swarm.id);
-    const count = (updatedCoord.description.match(/## Member Task Outputs/g) ?? []).length;
+    const afterSecond = memDb!
+      .prepare("SELECT description FROM ops_tasks WHERE id = ?")
+      .get(coord.id) as { description: string };
+    const count = (afterSecond.description.match(/## Member Task Outputs/g) ?? []).length;
     expect(count).toBe(1);
 
     void swarm;

--- a/tests/swarm.test.ts
+++ b/tests/swarm.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import path from "path";
+import { readFileSync } from "fs";
+import type DatabaseT from "better-sqlite3";
+
+let Database: typeof DatabaseT | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  Database = require("better-sqlite3");
+} catch {
+  /* driver not available */
+}
+
+let memDb: DatabaseT.Database | null = null;
+
+vi.mock("@/lib/tasksDb/migrations", () => ({
+  initTasksDb: vi.fn().mockResolvedValue({ available: true }),
+}));
+vi.mock("@/lib/tasksDb/connection", () => ({
+  getTasksDb: vi.fn(async () => memDb),
+  prepTasksCached: (_db: DatabaseT.Database, sql: string) => _db.prepare(sql),
+}));
+
+const SCHEMA_PATH = path.join(__dirname, "..", "src", "lib", "tasksDb", "schema.sql");
+
+function runSql(db: DatabaseT.Database, sql: string) {
+  const stmts = sql
+    .replace(/--[^\n]*/g, "")
+    .split(";")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const stmt of stmts) db.prepare(stmt).run();
+}
+
+function buildMemDb(): DatabaseT.Database {
+  const db = new Database!(":memory:");
+  db.pragma("foreign_keys = ON");
+  runSql(db, readFileSync(SCHEMA_PATH, "utf-8"));
+
+  // v2: delegated-todo quadrant + metadata column
+  runSql(db, `
+    CREATE TABLE ops_tasks_v2 (
+      id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+      title               TEXT    NOT NULL,
+      description         TEXT    NOT NULL DEFAULT '',
+      status              TEXT    NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending','awaiting_approval','running','done','failed','cancelled')),
+      priority            INTEGER NOT NULL DEFAULT 3 CHECK (priority BETWEEN 1 AND 5),
+      quadrant            TEXT    NOT NULL DEFAULT 'do'
+        CHECK (quadrant IN ('do','schedule','delegate','archive','delegated-todo')),
+      assigned_skill      TEXT,
+      model               TEXT,
+      execution_mode      TEXT    NOT NULL DEFAULT 'stream'
+        CHECK (execution_mode IN ('classic','stream')),
+      scheduled_for       TEXT,
+      requires_approval   INTEGER NOT NULL DEFAULT 0 CHECK (requires_approval IN (0, 1)),
+      risk_level          TEXT    NOT NULL DEFAULT 'low'
+        CHECK (risk_level IN ('low','medium','high')),
+      dry_run             INTEGER NOT NULL DEFAULT 0 CHECK (dry_run IN (0, 1)),
+      schedule_id         INTEGER REFERENCES ops_schedules(id) ON DELETE SET NULL,
+      approved_at         TEXT,
+      session_id          TEXT,
+      started_at          TEXT,
+      completed_at        TEXT,
+      duration_ms         INTEGER,
+      cost_usd            REAL,
+      output_summary      TEXT,
+      error_message       TEXT,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      created_at          TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      metadata            TEXT
+    );
+    INSERT INTO ops_tasks_v2
+      SELECT id,title,description,status,priority,quadrant,assigned_skill,model,
+             execution_mode,scheduled_for,requires_approval,risk_level,dry_run,
+             schedule_id,approved_at,session_id,started_at,completed_at,
+             duration_ms,cost_usd,output_summary,error_message,
+             consecutive_failures,created_at,NULL
+      FROM ops_tasks;
+    DROP TABLE ops_tasks;
+    ALTER TABLE ops_tasks_v2 RENAME TO ops_tasks;
+    CREATE INDEX IF NOT EXISTS ix_tasks_status ON ops_tasks(status);
+    CREATE INDEX IF NOT EXISTS ix_tasks_session ON ops_tasks(session_id) WHERE session_id IS NOT NULL;
+    CREATE TABLE IF NOT EXISTS task_decisions (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id     INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      session_id  TEXT,
+      kind        TEXT NOT NULL CHECK (kind IN ('decision','inbox')),
+      prompt      TEXT NOT NULL,
+      choices     TEXT,
+      decision_text TEXT,
+      created_at  INTEGER NOT NULL DEFAULT (unixepoch()),
+      decided_at  INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS ix_task_decisions_task ON task_decisions(task_id);
+    CREATE TABLE IF NOT EXISTS task_dependencies (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id     INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      blocker_id  INTEGER NOT NULL REFERENCES ops_tasks(id) ON DELETE CASCADE,
+      created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      CHECK (task_id != blocker_id),
+      UNIQUE (task_id, blocker_id)
+    );
+    CREATE INDEX IF NOT EXISTS ix_task_deps_task ON task_dependencies(task_id);
+    CREATE INDEX IF NOT EXISTS ix_task_deps_blocker ON task_dependencies(blocker_id)
+  `);
+
+  // v5: ops_swarms + swarm columns on ops_tasks
+  runSql(db, `
+    CREATE TABLE IF NOT EXISTS ops_swarms (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      name         TEXT    NOT NULL,
+      mode         TEXT    NOT NULL CHECK (mode IN ('worktree','shared')),
+      project_path TEXT    NOT NULL,
+      status       TEXT    NOT NULL DEFAULT 'running'
+                   CHECK (status IN ('running','done','failed','cancelled')),
+      created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      completed_at TEXT
+    );
+    ALTER TABLE ops_tasks ADD COLUMN swarm_id INTEGER REFERENCES ops_swarms(id) ON DELETE SET NULL;
+    ALTER TABLE ops_tasks ADD COLUMN swarm_role TEXT CHECK (swarm_role IN ('member','coordinator') OR swarm_role IS NULL);
+    CREATE INDEX IF NOT EXISTS ix_tasks_swarm ON ops_tasks(swarm_id) WHERE swarm_id IS NOT NULL
+  `);
+
+  return db;
+}
+
+describe.skipIf(!Database)("swarm store", () => {
+  let store: typeof import("@/lib/tasks/store");
+
+  beforeAll(async () => {
+    memDb = buildMemDb();
+    store = await import("@/lib/tasks/store");
+  });
+
+  afterAll(() => {
+    memDb?.close();
+    vi.restoreAllMocks();
+  });
+
+  it("createSwarm (shared) creates swarm + member tasks", async () => {
+    const { swarm, tasks } = await store.createSwarm({
+      name: "Test swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test-project",
+      members: [
+        { title: "Member A" },
+        { title: "Member B" },
+      ],
+    });
+    expect(swarm.id).toBeGreaterThan(0);
+    expect(swarm.name).toBe("Test swarm");
+    expect(swarm.mode).toBe("shared");
+    expect(swarm.status).toBe("running");
+    expect(tasks).toHaveLength(2);
+    expect(tasks.every((t) => t.swarm_id === swarm.id)).toBe(true);
+    expect(tasks.every((t) => t.swarm_role === "member")).toBe(true);
+    // Shared mode: no worktreePath in metadata
+    for (const t of tasks) {
+      const meta = t.metadata ? JSON.parse(t.metadata) : null;
+      expect(meta?.worktreePath).toBeUndefined();
+    }
+  });
+
+  it("createSwarm (worktree) stores worktreePath in member metadata", async () => {
+    const { swarm, tasks } = await store.createSwarm({
+      name: "Worktree swarm",
+      mode: "worktree",
+      project_path: "C:\\dev\\my-project",
+      members: [
+        { title: "Wt member 1" },
+        { title: "Wt member 2" },
+      ],
+    });
+    expect(swarm.mode).toBe("worktree");
+    for (let i = 0; i < tasks.length; i++) {
+      const meta = JSON.parse(tasks[i].metadata!) as { worktreePath?: string; projectPath?: string };
+      expect(meta.worktreePath).toContain("--claude-worktrees-");
+      expect(meta.projectPath).toBe("C:\\dev\\my-project");
+    }
+  });
+
+  it("createSwarm with coordinator creates dep edges and coordinator task", async () => {
+    const { swarm, tasks } = await store.createSwarm({
+      name: "Coord swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test",
+      members: [{ title: "M1" }, { title: "M2" }],
+      coordinator: { title: "Coord" },
+    });
+    const members = tasks.filter((t) => t.swarm_role === "member");
+    const coord = tasks.find((t) => t.swarm_role === "coordinator");
+    expect(coord).toBeDefined();
+    expect(members).toHaveLength(2);
+
+    // Verify dependency rows exist
+    const deps = memDb!
+      .prepare("SELECT * FROM task_dependencies WHERE task_id = ?")
+      .all(coord!.id) as { blocker_id: number }[];
+    expect(deps).toHaveLength(2);
+    const memberIds = members.map((m) => m.id);
+    expect(deps.map((d) => d.blocker_id).sort()).toEqual(memberIds.sort());
+
+    // Cancel all other pending tasks so only coord + members remain
+    memDb!.prepare(
+      `UPDATE ops_tasks SET status = 'cancelled'
+       WHERE status = 'pending' AND id NOT IN (${members.map(() => "?").join(",")}, ${coord!.id})`
+    ).run(...members.map((m) => m.id));
+
+    // Coordinator not claimable while members pending
+    const claimedBefore = await store.claimPendingTask();
+    // Only members (pending, unblocked) or null should be returned — not the coordinator
+    if (claimedBefore) {
+      expect(claimedBefore.swarm_role).not.toBe("coordinator");
+      // Reset it back
+      memDb!.prepare(`UPDATE ops_tasks SET status = 'pending', started_at = NULL WHERE id = ?`).run(claimedBefore.id);
+    }
+
+    // Mark all members done → coordinator should become claimable
+    for (const m of members) {
+      memDb!.prepare(`UPDATE ops_tasks SET status = 'cancelled' WHERE id = ?`).run(m.id);
+    }
+    const claimedAfterDone = await store.claimPendingTask();
+    expect(claimedAfterDone?.id).toBe(coord!.id);
+    // Clean up: reset coordinator
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'pending', started_at = NULL WHERE id = ?`).run(coord!.id);
+
+    void swarm;
+  });
+
+  it("coordinator claimable when members failed (all-terminal guard)", async () => {
+    const { tasks } = await store.createSwarm({
+      name: "Failed members swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test",
+      members: [{ title: "FM1" }, { title: "FM2" }],
+      coordinator: { title: "FC" },
+    });
+    const members = tasks.filter((t) => t.swarm_role === "member");
+    const coord = tasks.find((t) => t.swarm_role === "coordinator")!;
+
+    // Mark one member failed, one cancelled
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'running' WHERE id = ?`).run(members[0].id);
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'failed' WHERE id = ?`).run(members[0].id);
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'cancelled' WHERE id = ?`).run(members[1].id);
+
+    // Cancel all other pending tasks so only coord remains
+    memDb!.prepare(
+      `UPDATE ops_tasks SET status = 'cancelled' WHERE status = 'pending' AND id != ?`
+    ).run(coord.id);
+
+    // All members terminal (failed/cancelled) → coordinator should be claimable
+    const claimed = await store.claimPendingTask();
+    expect(claimed?.id).toBe(coord.id);
+    // Clean up
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'pending', started_at = NULL WHERE id = ?`).run(coord.id);
+  });
+
+  it("getSwarmTasks returns tasks for the swarm", async () => {
+    const { swarm, tasks } = await store.createSwarm({
+      name: "Get tasks swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test",
+      members: [{ title: "GT1" }, { title: "GT2" }],
+    });
+    const fetched = await store.getSwarmTasks(swarm.id);
+    expect(fetched).toHaveLength(tasks.length);
+    expect(fetched.every((t) => t.swarm_id === swarm.id)).toBe(true);
+  });
+
+  it("updateSwarmStatus sets done when all members done (no coordinator)", async () => {
+    const { swarm, tasks } = await store.createSwarm({
+      name: "Status update swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test",
+      members: [{ title: "S1" }, { title: "S2" }],
+    });
+    for (const t of tasks) {
+      memDb!.prepare(`UPDATE ops_tasks SET status = 'running' WHERE id = ?`).run(t.id);
+      memDb!.prepare(`UPDATE ops_tasks SET status = 'done', output_summary = ? WHERE id = ?`).run("OK", t.id);
+    }
+    await store.updateSwarmStatus(swarm.id);
+    const updated = await store.getSwarm(swarm.id);
+    expect(updated?.status).toBe("done");
+    expect(updated?.completed_at).toBeTruthy();
+  });
+
+  it("updateSwarmStatus sets failed when any member failed (no coordinator)", async () => {
+    const { swarm, tasks } = await store.createSwarm({
+      name: "Failed swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test",
+      members: [{ title: "F1" }, { title: "F2" }],
+    });
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'running' WHERE id = ?`).run(tasks[0].id);
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'failed' WHERE id = ?`).run(tasks[0].id);
+    memDb!.prepare(`UPDATE ops_tasks SET status = 'cancelled' WHERE id = ?`).run(tasks[1].id);
+    await store.updateSwarmStatus(swarm.id);
+    const updated = await store.getSwarm(swarm.id);
+    expect(updated?.status).toBe("failed");
+  });
+
+  it("updateSwarmStatus injects member summaries into coordinator description once", async () => {
+    const { swarm, tasks } = await store.createSwarm({
+      name: "Inject swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test",
+      members: [{ title: "IM1" }, { title: "IM2" }],
+      coordinator: { title: "IC", description: "Coordinate" },
+    });
+    const members = tasks.filter((t) => t.swarm_role === "member");
+    const coord = tasks.find((t) => t.swarm_role === "coordinator")!;
+
+    for (const m of members) {
+      memDb!
+        .prepare(`UPDATE ops_tasks SET status = 'running' WHERE id = ?`)
+        .run(m.id);
+      memDb!
+        .prepare(`UPDATE ops_tasks SET status = 'done', output_summary = ? WHERE id = ?`)
+        .run(`Output of ${m.title}`, m.id);
+    }
+
+    await store.updateSwarmStatus(swarm.id);
+
+    const updatedCoord = memDb!
+      .prepare("SELECT description FROM ops_tasks WHERE id = ?")
+      .get(coord.id) as { description: string };
+
+    expect(updatedCoord.description).toContain("## Member Task Outputs");
+    expect(updatedCoord.description).toContain("IM1");
+    expect(updatedCoord.description).toContain("IM2");
+
+    // Call again — should not duplicate the block
+    await store.updateSwarmStatus(swarm.id);
+    const count = (updatedCoord.description.match(/## Member Task Outputs/g) ?? []).length;
+    expect(count).toBe(1);
+
+    void swarm;
+  });
+
+  it("listSwarms returns all swarms", async () => {
+    const before = await store.listSwarms();
+    await store.createSwarm({
+      name: "List test swarm",
+      mode: "shared",
+      project_path: "C:\\dev\\test",
+      members: [{ title: "L1" }, { title: "L2" }],
+    });
+    const after = await store.listSwarms();
+    expect(after.length).toBe(before.length + 1);
+  });
+});

--- a/tests/taskDependencies.test.ts
+++ b/tests/taskDependencies.test.ts
@@ -99,7 +99,23 @@ function buildMemDb(): DatabaseT.Database {
       UNIQUE (task_id, blocker_id)
     );
     CREATE INDEX IF NOT EXISTS ix_task_deps_task ON task_dependencies(task_id);
-    CREATE INDEX IF NOT EXISTS ix_task_deps_blocker ON task_dependencies(blocker_id);
+    CREATE INDEX IF NOT EXISTS ix_task_deps_blocker ON task_dependencies(blocker_id)
+  `);
+  // v5: ops_swarms + swarm columns
+  runSql(db, `
+    CREATE TABLE IF NOT EXISTS ops_swarms (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      mode TEXT NOT NULL CHECK (mode IN ('worktree','shared')),
+      project_path TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running'
+             CHECK (status IN ('running','done','failed','cancelled')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      completed_at TEXT
+    );
+    ALTER TABLE ops_tasks ADD COLUMN swarm_id INTEGER REFERENCES ops_swarms(id) ON DELETE SET NULL;
+    ALTER TABLE ops_tasks ADD COLUMN swarm_role TEXT CHECK (swarm_role IN ('member','coordinator') OR swarm_role IS NULL);
+    CREATE INDEX IF NOT EXISTS ix_tasks_swarm ON ops_tasks(swarm_id) WHERE swarm_id IS NOT NULL
   `);
   return db;
 }

--- a/tests/tasksSpawner.test.ts
+++ b/tests/tasksSpawner.test.ts
@@ -53,6 +53,8 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     consecutive_failures: 0,
     created_at: new Date().toISOString(),
     metadata: null,
+    swarm_id: null,
+    swarm_role: null,
     ...overrides,
   };
 }

--- a/tests/tasksStore.test.ts
+++ b/tests/tasksStore.test.ts
@@ -118,7 +118,23 @@ function buildMemDb(): DatabaseT.Database {
       UNIQUE (task_id, blocker_id)
     );
     CREATE INDEX IF NOT EXISTS ix_task_deps_task ON task_dependencies(task_id);
-    CREATE INDEX IF NOT EXISTS ix_task_deps_blocker ON task_dependencies(blocker_id);
+    CREATE INDEX IF NOT EXISTS ix_task_deps_blocker ON task_dependencies(blocker_id)
+  `);
+  // v5: ops_swarms + swarm columns
+  runSql(db, `
+    CREATE TABLE IF NOT EXISTS ops_swarms (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      mode TEXT NOT NULL CHECK (mode IN ('worktree','shared')),
+      project_path TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running'
+             CHECK (status IN ('running','done','failed','cancelled')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      completed_at TEXT
+    );
+    ALTER TABLE ops_tasks ADD COLUMN swarm_id INTEGER REFERENCES ops_swarms(id) ON DELETE SET NULL;
+    ALTER TABLE ops_tasks ADD COLUMN swarm_role TEXT CHECK (swarm_role IN ('member','coordinator') OR swarm_role IS NULL);
+    CREATE INDEX IF NOT EXISTS ix_tasks_swarm ON ops_tasks(swarm_id) WHERE swarm_id IS NOT NULL
   `);
   return db;
 }

--- a/tests/todoDelegation.test.ts
+++ b/tests/todoDelegation.test.ts
@@ -63,6 +63,8 @@ function makeTask(overrides: Partial<Task> = {}): Task {
       projectSlug: "my-project",
       projectPath: "/mock/roots/my-project",
     }),
+    swarm_id: null,
+    swarm_role: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- **Migration v5** — `ops_swarms` table + `swarm_id`/`swarm_role` nullable columns on `ops_tasks` (zero-cost for existing rows)
- **Store** — `createSwarm`, `getSwarm`, `listSwarms`, `getSwarmTasks`, `updateSwarmStatus`; role-aware SQL guard in `claimPendingTask`/`promoteApprovalTasks` so coordinator tasks unblock when all members reach any terminal state (`done`/`failed`/`cancelled`), not just `done`
- **Worktree spawner** — `runWorktreeTask` in `spawner.ts`: calls `git worktree add -B <branch> <path> HEAD` via `execFile` (not shell exec), injects `cwd` via a `spawnFn` closure so `runClassicTask`/`runStreamTask` need no signature changes
- **API** — `GET/POST /api/swarms`, `GET /api/swarms/[id]`, `DELETE /api/swarms/[id]/worktrees` (parallel removal, idempotent)
- **SwarmComposer** — modal with swarm name, project path, worktree/shared mode picker, 2–8 member task definitions, optional coordinator task
- **Entry points** — "Launch Swarm" button on Tasks page + "Launch Swarm…" action (Zap icon) on project card dropdown
- **Views** — `/swarms` list page, `/swarms/[id]` detail page with 5 s polling, per-member status/cost/session links, total cost, "Remove worktrees" button
- **AppNav** — "Swarms" added to Mission Control group
- **Tests** — `tests/swarm.test.ts` (8 cases: shared/worktree creation, coordinator dep edges, all-terminal SQL guard, `getSwarmTasks`, status rollup, summary injection idempotency, `listSwarms`) + `tests/apiSwarms.test.ts` (9 cases: happy-path POST 201, validation 400s, GET list/detail, 404, DELETE 204)
- **Docs** — full "Swarms" section in `docs/help/tasks.md` + `public/help/tasks.md`
- **Simplify pass** — shared `composer-fields.tsx` (eliminates verbatim copy between TaskComposer/SwarmComposer), `TASK_STATUS_COLORS` moved to `types.ts`, unified `afterComplete` callback in dispatcher, `TERMINAL_STATUSES` at module scope, dropped redundant `SELECT *` existence check in `updateSwarmStatus`, parallel worktree removal, stable polling interval via `useRef`

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1684 passing (1 skipped); was ~1660 before this wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)