### PR TITLE
feat(wave10.2a): multi-platform adapter architecture — SessionAdapter + claude adapter + source threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 10.2a — Cluster X (part 1): Multi-platform adapter architecture.** TODO #223.
+  - New `SessionAdapter` interface + registry (`src/lib/adapters/`) with `discover()`, `parseFile()`, `parseFileWithMeta?()`. `claude` adapter wraps existing parser/ingest paths — no behavior change, only formalization.
+  - `enabledAdapters?: string[]` on `MinderConfig` (default `["claude"]`). `PATCH /api/config` validates adapter IDs against the registry; rejects unknown IDs with 400.
+  - `source` field threaded through `UsageTurn`, `SessionSummary`, `SessionDetail`, `SessionRow`. All existing sessions coerce to `"claude"`.
+  - **By Source** breakdown on `/usage` — always visible when data exists (proves the pipeline end-to-end with one "Claude Code" row today). `bySource: SourceBreakdown[]` on `UsageReport`, computed by both file-parse and DB aggregation paths.
+  - **Source badge** (`SourceBadge`) in session row and session header — always visible; shows "Claude Code" for all current sessions.
+  - **Source filter** dropdown in Sessions browser toolbar — always visible when sessions exist.
+  - **Adapters** section in Settings — lists all registered adapters with enable/disable toggle and status badge.
+  - `?source=` query param on `/api/sessions` and `/api/usage` (cache key + ETag). `/api/sessions` also gates results by `enabledAdapters` config — disabling an adapter produces an empty list.
+  - Help doc at `/settings#adapters`.
+
+### Changed
+- **DB schema v11**: `sessions.source TEXT NOT NULL DEFAULT 'claude'` + `idx_sessions_source` index. Existing rows migrated to `'claude'` automatically — no re-parse required.
+
+### Internal
+- Claude session reading wrapped as the `claude` adapter; existing `parser.ts` / `ingest.ts` functions stay public and are called by the adapter wrapper.
+- `claudeConversations.scanAllSessions` stamps `source: "claude"` directly (adapter-registry routing deferred to Wave 10.2b when Codex lands).
+
 - **Wave 10.1c — Cluster W (part 3): Multi-agent swarm dispatch.** TODO #247.
   - New `ops_swarms` table (migration v5) with `name`, `mode` (`worktree`|`shared`), `project_path`, `status`, `completed_at`. Two new nullable columns on `ops_tasks`: `swarm_id` (FK → `ops_swarms`) and `swarm_role` (`member`|`coordinator`), added via `ALTER TABLE ADD COLUMN` — zero migration cost for existing rows.
   - **Swarm creation**: `createSwarm()` — single SQLite transaction creates the swarm row + 2–8 member tasks (with `worktreePath`/`projectPath` in metadata for worktree mode) + optional coordinator task with `task_dependencies` edges to every member.

--- a/docs/help/adapters.md
+++ b/docs/help/adapters.md
@@ -6,23 +6,21 @@ Project Minder reads AI coding-agent sessions through **adapters** — thin modu
 
 | Adapter | ID | Status |
 |---|---|---|
-| Claude Code | `claude` | Active (always enabled) |
+| Claude Code | `claude` | Active |
 | Codex | `codex` | Coming in Wave 10.2b |
 | Gemini | `gemini` | Coming in Wave 10.2c |
 
 ## Managing adapters
 
-Go to **Settings → Adapters** to see which adapters are enabled. Disabling an adapter hides its sessions from the session browser and excludes them from analytics.
-
-> **Note:** The Claude Code adapter is always enabled and cannot be disabled — it is the core data source.
+Go to **Settings → Adapters** to see which adapters are enabled. Disabling an adapter hides its sessions from the session browser and excludes them from analytics. All adapters, including Claude Code, can be toggled.
 
 ## Source badges
 
-When multiple adapters are active, a small source badge appears in the session row and session header to indicate which adapter produced the session. When only Claude Code is active, the badge is hidden.
+A small source badge appears in the session row and session header to indicate which adapter produced the session, making it easy to distinguish sessions at a glance.
 
 ## By Source breakdown
 
-The `/usage` page shows a **By Source** section when multiple adapters have data. This lets you compare cost and usage across different coding assistants.
+The `/usage` page shows a **By Source** section whenever source data is available. This lets you compare cost and usage across different coding assistants.
 
 ## API
 
@@ -30,6 +28,7 @@ The following endpoints accept an optional `?source=` query parameter to filter 
 
 - `GET /api/sessions?source=claude` — session list for a specific source
 - `GET /api/usage?source=claude` — usage report for a specific source
+- `GET /api/adapters` — list all registered adapters
 
 ## Configuration
 

--- a/docs/help/adapters.md
+++ b/docs/help/adapters.md
@@ -1,0 +1,42 @@
+# Adapters
+
+Project Minder reads AI coding-agent sessions through **adapters** — thin modules that know how to discover session files and parse them into a common format. This architecture makes it straightforward to support multiple coding assistants from one dashboard.
+
+## Available adapters
+
+| Adapter | ID | Status |
+|---|---|---|
+| Claude Code | `claude` | Active (always enabled) |
+| Codex | `codex` | Coming in Wave 10.2b |
+| Gemini | `gemini` | Coming in Wave 10.2c |
+
+## Managing adapters
+
+Go to **Settings → Adapters** to see which adapters are enabled. Disabling an adapter hides its sessions from the session browser and excludes them from analytics.
+
+> **Note:** The Claude Code adapter is always enabled and cannot be disabled — it is the core data source.
+
+## Source badges
+
+When multiple adapters are active, a small source badge appears in the session row and session header to indicate which adapter produced the session. When only Claude Code is active, the badge is hidden.
+
+## By Source breakdown
+
+The `/usage` page shows a **By Source** section when multiple adapters have data. This lets you compare cost and usage across different coding assistants.
+
+## API
+
+The following endpoints accept an optional `?source=` query parameter to filter results by adapter:
+
+- `GET /api/sessions?source=claude` — session list for a specific source
+- `GET /api/usage?source=claude` — usage report for a specific source
+
+## Configuration
+
+`enabledAdapters` in `.minder.json` controls which adapters are active. You can also set this via `PATCH /api/config`:
+
+```json
+{ "enabledAdapters": ["claude"] }
+```
+
+Unknown adapter IDs in this list are rejected with a 400 error naming the known adapters.

--- a/public/help/adapters.md
+++ b/public/help/adapters.md
@@ -6,23 +6,21 @@ Project Minder reads AI coding-agent sessions through **adapters** — thin modu
 
 | Adapter | ID | Status |
 |---|---|---|
-| Claude Code | `claude` | Active (always enabled) |
+| Claude Code | `claude` | Active |
 | Codex | `codex` | Coming in Wave 10.2b |
 | Gemini | `gemini` | Coming in Wave 10.2c |
 
 ## Managing adapters
 
-Go to **Settings → Adapters** to see which adapters are enabled. Disabling an adapter hides its sessions from the session browser and excludes them from analytics.
-
-> **Note:** The Claude Code adapter is always enabled and cannot be disabled — it is the core data source.
+Go to **Settings → Adapters** to see which adapters are enabled. Disabling an adapter hides its sessions from the session browser and excludes them from analytics. All adapters, including Claude Code, can be toggled.
 
 ## Source badges
 
-When multiple adapters are active, a small source badge appears in the session row and session header to indicate which adapter produced the session. When only Claude Code is active, the badge is hidden.
+A small source badge appears in the session row and session header to indicate which adapter produced the session, making it easy to distinguish sessions at a glance.
 
 ## By Source breakdown
 
-The `/usage` page shows a **By Source** section when multiple adapters have data. This lets you compare cost and usage across different coding assistants.
+The `/usage` page shows a **By Source** section whenever source data is available. This lets you compare cost and usage across different coding assistants.
 
 ## API
 
@@ -30,6 +28,7 @@ The following endpoints accept an optional `?source=` query parameter to filter 
 
 - `GET /api/sessions?source=claude` — session list for a specific source
 - `GET /api/usage?source=claude` — usage report for a specific source
+- `GET /api/adapters` — list all registered adapters
 
 ## Configuration
 

--- a/public/help/adapters.md
+++ b/public/help/adapters.md
@@ -1,0 +1,42 @@
+# Adapters
+
+Project Minder reads AI coding-agent sessions through **adapters** — thin modules that know how to discover session files and parse them into a common format. This architecture makes it straightforward to support multiple coding assistants from one dashboard.
+
+## Available adapters
+
+| Adapter | ID | Status |
+|---|---|---|
+| Claude Code | `claude` | Active (always enabled) |
+| Codex | `codex` | Coming in Wave 10.2b |
+| Gemini | `gemini` | Coming in Wave 10.2c |
+
+## Managing adapters
+
+Go to **Settings → Adapters** to see which adapters are enabled. Disabling an adapter hides its sessions from the session browser and excludes them from analytics.
+
+> **Note:** The Claude Code adapter is always enabled and cannot be disabled — it is the core data source.
+
+## Source badges
+
+When multiple adapters are active, a small source badge appears in the session row and session header to indicate which adapter produced the session. When only Claude Code is active, the badge is hidden.
+
+## By Source breakdown
+
+The `/usage` page shows a **By Source** section when multiple adapters have data. This lets you compare cost and usage across different coding assistants.
+
+## API
+
+The following endpoints accept an optional `?source=` query parameter to filter results by adapter:
+
+- `GET /api/sessions?source=claude` — session list for a specific source
+- `GET /api/usage?source=claude` — usage report for a specific source
+
+## Configuration
+
+`enabledAdapters` in `.minder.json` controls which adapters are active. You can also set this via `PATCH /api/config`:
+
+```json
+{ "enabledAdapters": ["claude"] }
+```
+
+Unknown adapter IDs in this list are rejected with a 400 error naming the known adapters.

--- a/src/app/api/adapters/route.ts
+++ b/src/app/api/adapters/route.ts
@@ -1,0 +1,9 @@
+import { listAdapters } from "@/lib/adapters";
+
+export async function GET() {
+  const adapters = listAdapters().map((a) => ({
+    id: a.id,
+    displayName: a.displayName,
+  }));
+  return Response.json(adapters);
+}

--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -6,6 +6,7 @@ import { ProjectStatus, MinderConfig, FeatureFlagKey, PricingRule, ScheduleMode,
 import { isFeatureFlagKey } from "@/lib/featureFlags";
 import { setPricingRules } from "@/lib/usage/costCalculator";
 import { VALID_CURRENCIES } from "@/lib/currencies";
+import { listAdapters } from "@/lib/adapters";
 
 // Derived from the MinderConfig union types — update both together if options change
 const VALID_DEFAULT_SORTS: MinderConfig["defaultSort"][] = ["activity", "name", "claude"];
@@ -287,6 +288,21 @@ export async function PATCH(request: NextRequest) {
       );
     }
     patches.push((c) => { c.scheduleMode = body.scheduleMode as ScheduleMode; });
+  }
+
+  if (body.enabledAdapters !== undefined) {
+    if (!Array.isArray(body.enabledAdapters) || body.enabledAdapters.some((id: unknown) => typeof id !== "string")) {
+      return NextResponse.json({ error: "enabledAdapters must be an array of strings" }, { status: 400 });
+    }
+    const knownIds = new Set(listAdapters().map((a) => a.id));
+    const ids = body.enabledAdapters as string[];
+    const unknown = ids.filter((id) => !knownIds.has(id));
+    if (unknown.length > 0) {
+      return NextResponse.json({
+        error: `Unknown adapter id(s): ${unknown.join(", ")}. Known adapters: ${[...knownIds].join(", ")}`,
+      }, { status: 400 });
+    }
+    patches.push((c) => { c.enabledAdapters = ids; });
   }
 
   if (patches.length === 0) {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { getSessionsList, type SessionsListResult } from "@/lib/data";
 import { SessionSummary } from "@/lib/types";
 import { computeETag, ifNoneMatch, jsonWithETag } from "@/lib/httpCache";
+import { readConfig } from "@/lib/config";
 
 const CACHE_TTL = 30_000; // 30s — kept short so live status badges on the dashboard are timely
 
@@ -35,6 +36,7 @@ function deriveMaxSessionMs(sessions: SessionSummary[]): number {
 
 export async function GET(request: NextRequest) {
   const project = request.nextUrl.searchParams.get("project");
+  const source = request.nextUrl.searchParams.get("source");
 
   // Refresh the in-route cache when stale. The façade itself layers DB and
   // file-parse caches under it, so a refresh that finds no JSONL changes is
@@ -64,18 +66,25 @@ export async function GET(request: NextRequest) {
   // Combining both means the ETag is stable WITHIN a 30 s window (304s work
   // for back-to-back navigations) but rotates ACROSS windows so any
   // time-driven status flip surfaces on the next refresh.
+  const config = await readConfig();
+  const enabledAdapters = new Set(config.enabledAdapters ?? ["claude"]);
+
   const etag = computeETag({
     salt: "sessions-v1",
     maxMtimeMs: Math.max(cache.maxSessionMs, cache.cachedAt),
-    parts: [project ?? "", cache.result.sessions.length],
+    parts: [project ?? "", source ?? "", cache.result.sessions.length, [...enabledAdapters].sort().join(",")],
   });
 
   const notModified = ifNoneMatch(request, etag);
   if (notModified) return notModified;
 
   let results = cache.result.sessions;
+  results = results.filter((s) => enabledAdapters.has(s.source ?? "claude"));
   if (project) {
     results = results.filter((s) => s.projectSlug === project || s.projectName.includes(project));
+  }
+  if (source) {
+    results = results.filter((s) => (s.source ?? "claude") === source);
   }
 
   // jsonWithETag returns a NextResponse; layer the backend header on top so

--- a/src/app/api/sessions/search/route.ts
+++ b/src/app/api/sessions/search/route.ts
@@ -11,6 +11,7 @@ import { SessionSearchError } from "@/lib/data/sessionSearch";
 //   q      — search text (required, non-empty after trim)
 //   scope  — 'titles' | 'prompts' | 'both' (default: 'both')
 //   limit  — clamp to 1..200 (default: 50)
+//   source — adapter source id (e.g. 'claude'). Client-side filtered in SessionsBrowser.
 //
 // Response shape:
 //   { hits: Array<{ sessionId, score, source }>, backend: 'db' | 'file' }

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -31,13 +31,14 @@ export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const safePeriod = validatePeriod(params.get("period") || "month");
   const project = params.get("project") || undefined;
+  const source = params.get("source") || undefined;
 
   // Include the requested backend in the cache key so a flag flip
   // (MINDER_USE_DB toggled at runtime) invalidates the slot immediately
   // — without this, a cached file-backend report could be served to a
   // db-backend caller for the rest of the 2-min TTL window.
   const requestedBackend = dbModeRequested() ? "db" : "file";
-  const cacheKey = `${requestedBackend}:${safePeriod}:${project || "all"}`;
+  const cacheKey = `${requestedBackend}:${safePeriod}:${project || "all"}:${source || "all"}`;
   const cache = globalForUsage.__usageCache!;
   const cached = cache.get(cacheKey);
   const fresh = cached && Date.now() - cached.cachedAt < CACHE_TTL;
@@ -62,7 +63,7 @@ export async function GET(request: NextRequest) {
   const etag = computeETag({
     salt: `usage-v3-${slot.backend}`,
     maxMtimeMs: slot.maxMtime,
-    parts: [safePeriod, project ?? ""],
+    parts: [safePeriod, project ?? "", source ?? ""],
   });
 
   const notModified = ifNoneMatch(request, etag);

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest) {
   if (fresh) {
     slot = cached!;
   } else {
-    const { report, meta } = await getUsage(safePeriod, project);
+    const { report, meta } = await getUsage(safePeriod, project, source);
     slot = {
       report,
       cachedAt: Date.now(),

--- a/src/components/SessionDetailView.tsx
+++ b/src/components/SessionDetailView.tsx
@@ -49,6 +49,7 @@ import { Modal } from "@/components/ui/modal";
 import { downloadBlob } from "@/lib/downloadBlob";
 import { formatCost } from "@/lib/format";
 import { useCurrency } from "@/hooks/useCurrency";
+import { SourceBadge } from "@/components/SourceBadge";
 
 const checkboxRowStyle: React.CSSProperties = {
   display: "flex", alignItems: "center", gap: "8px",
@@ -720,6 +721,7 @@ export function SessionDetailView({ sessionId }: { sessionId: string }) {
               {data.gitBranch}
             </span>
           )}
+          <SourceBadge source={data.source} />
           {data.modelsUsed.map((m) => (
             <span key={m} style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "var(--text-muted)", background: "var(--bg-elevated)", border: "1px solid var(--border-subtle)", borderRadius: "3px", padding: "2px 6px" }}>
               {m}

--- a/src/components/SessionsBrowser.tsx
+++ b/src/components/SessionsBrowser.tsx
@@ -28,6 +28,7 @@ import { formatCost, formatTokens } from "@/lib/format";
 import { useCurrency } from "@/hooks/useCurrency";
 import { StackedStrip } from "@/components/stats/StackedStrip";
 import { WORK_MODE_SEGMENTS } from "@/lib/usage/workMode";
+import { SourceBadge } from "@/components/SourceBadge";
 
 type SortOption = "recent" | "longest" | "tokens" | "oneshot";
 
@@ -456,6 +457,7 @@ function SessionRow({
           {session.oneShotRate !== undefined && (
             <OneShotBadge rate={session.oneShotRate} />
           )}
+          <SourceBadge source={session.source} />
           {session.modelsUsed.slice(0, 1).map((m) => (
             <span
               key={m}
@@ -645,6 +647,7 @@ export function SessionsBrowser() {
   const [sortBy, setSortBy] = useState<SortOption>("recent");
   const [groupByProject, setGroupByProject] = useState(true);
   const [starredOnly, setStarredOnly] = useState(false);
+  const [sourceFilter, setSourceFilter] = useState<string>("all");
   const [collapsedSlugs, setCollapsedSlugs] = useState<Set<string>>(new Set());
   const [searchState, setSearchState] = useState<SearchState>({ kind: "idle" });
 
@@ -685,10 +688,18 @@ export function SessionsBrowser() {
     };
   }, [search]);
 
+  const availableSources = useMemo(() => {
+    const srcs = new Set(data.map((s) => s.source ?? "claude"));
+    return [...srcs].sort();
+  }, [data]);
+
   const filtered = useMemo(() => {
     let result = data;
     if (starredOnly) {
       result = result.filter((s) => !!s.starredAt);
+    }
+    if (sourceFilter !== "all") {
+      result = result.filter((s) => (s.source ?? "claude") === sourceFilter);
     }
     const trimmed = search.trim();
     if (trimmed) {
@@ -718,7 +729,7 @@ export function SessionsBrowser() {
         }
       }
     });
-  }, [data, search, sortBy, searchState, starredOnly]);
+  }, [data, search, sortBy, searchState, starredOnly, sourceFilter]);
 
   const projectGroups = useMemo(
     () => groupByProject ? buildProjectGroups(filtered) : [],
@@ -855,6 +866,20 @@ export function SessionsBrowser() {
           <Star style={{ width: "10px", height: "10px", fill: starredOnly ? "currentColor" : "none" }} />
           Starred
         </button>
+
+        {/* Source filter */}
+        {availableSources.length > 0 && (
+          <select
+            value={sourceFilter}
+            onChange={(e) => setSourceFilter(e.target.value)}
+            style={{ padding: "5px 8px", fontSize: "0.72rem", fontFamily: "var(--font-body)", color: sourceFilter !== "all" ? "var(--accent)" : "var(--text-secondary)", background: "var(--bg-surface)", border: `1px solid ${sourceFilter !== "all" ? "var(--accent-border)" : "var(--border-subtle)"}`, borderRadius: "var(--radius)", cursor: "pointer", lineHeight: 1, flexShrink: 0 }}
+          >
+            <option value="all">All sources</option>
+            {availableSources.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        )}
 
         {/* Group by project toggle */}
         <button

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { TerminalSection } from "@/components/settings/TerminalSection";
 import { AutoTitleSection } from "@/components/settings/AutoTitleSection";
 import { LiveActivitySection } from "@/components/settings/LiveActivitySection";
 import { CostSection } from "@/components/settings/CostSection";
+import { AdaptersSection } from "@/components/settings/AdaptersSection";
 import { Toggle } from "@/components/settings/Toggle";
 
 // Hoisted so each Settings render doesn't re-filter the static metadata.
@@ -28,7 +29,8 @@ type SectionKey =
   | "data"
   | "terminal"
   | "auto-title"
-  | "live-activity";
+  | "live-activity"
+  | "adapters";
 
 interface SectionDef {
   key: SectionKey;
@@ -50,6 +52,7 @@ const SECTIONS: SectionDef[] = [
   { key: "terminal",       label: "Terminal",       shipsInWave: 7,  description: "Preferred terminal application for resume." },
   { key: "auto-title",    label: "Auto-title",     shipsInWave: 7,  description: "LLM endpoint for session-title generation." },
   { key: "live-activity", label: "Live Activity",  shipsInWave: 7,  description: "Hook server install/remove + awaiting-permission alerts." },
+  { key: "adapters",      label: "Adapters",       shipsInWave: 10, description: "Platform adapters: enable/disable session sources (Claude Code, Codex, Gemini)." },
 ];
 
 export function SettingsPage() {
@@ -231,7 +234,10 @@ export function SettingsPage() {
         {active === "cost" && (
           <CostSection config={config} onConfigChange={patchConfig} />
         )}
-        {active !== "features" && active !== "notifications" && active !== "integrations" && active !== "terminal" && active !== "auto-title" && active !== "live-activity" && active !== "cost" && activeSection && (
+        {active === "adapters" && (
+          <AdaptersSection config={config} onConfigChange={patchConfig} />
+        )}
+        {active !== "features" && active !== "notifications" && active !== "integrations" && active !== "terminal" && active !== "auto-title" && active !== "live-activity" && active !== "cost" && active !== "adapters" && activeSection && (
           <PlaceholderSection
             label={activeSection.label}
             wave={activeSection.shipsInWave}

--- a/src/components/SourceBadge.tsx
+++ b/src/components/SourceBadge.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+const SOURCE_LABELS: Record<string, string> = {
+  claude: "Claude Code",
+  codex: "Codex",
+  gemini: "Gemini",
+};
+
+function formatSourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source;
+}
+
+export function SourceBadge({ source }: { source?: string }) {
+  const src = source ?? "claude";
+  const label = formatSourceLabel(src);
+  return (
+    <span
+      title={`Session source: ${label}`}
+      style={{
+        fontFamily: "var(--font-mono)",
+        fontSize: "0.65rem",
+        color: "var(--text-secondary)",
+        background: "var(--bg-elevated)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "3px",
+        padding: "1px 5px",
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/UsageDashboard.tsx
+++ b/src/components/UsageDashboard.tsx
@@ -840,6 +840,28 @@ export function UsageDashboard() {
           {/* ── Aggregate mode ──────────────────────────────────────────── */}
           {(breakdownMode === "aggregate" || !!project) && (
             <>
+              {/* By source */}
+              {data.bySource && data.bySource.length > 0 && (
+                <div style={{ marginBottom: "24px" }}>
+                  <SectionHeader label="By Source" />
+                  <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                    {(() => {
+                      const max = Math.max(...data.bySource.map((s) => s.cost));
+                      return data.bySource.map((s) => (
+                        <CostRow
+                          key={s.source}
+                          label={s.displayName}
+                          cost={s.cost}
+                          maxCost={max}
+                          color="var(--accent)"
+                          detail={`${s.sessionCount} sessions`}
+                        />
+                      ));
+                    })()}
+                  </div>
+                </div>
+              )}
+
               {/* By model + by category */}
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "32px" }}>
                 <div>

--- a/src/components/settings/AdaptersSection.tsx
+++ b/src/components/settings/AdaptersSection.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { MinderConfig } from "@/lib/types";
 import { S } from "./styles";
 
-const ALL_ADAPTERS = [
-  { id: "claude", displayName: "Claude Code", description: "Reads sessions from ~/.claude/projects/." },
-];
+interface AdapterEntry {
+  id: string;
+  displayName: string;
+}
+
+const ADAPTER_DESCRIPTIONS: Record<string, string> = {
+  claude: "Reads sessions from ~/.claude/projects/.",
+  codex: "Reads sessions from Codex CLI.",
+  gemini: "Reads sessions from Gemini CLI.",
+};
 
 export function AdaptersSection({
   config,
@@ -15,8 +22,16 @@ export function AdaptersSection({
   config: MinderConfig | null;
   onConfigChange: (patch: Partial<MinderConfig>) => Promise<void>;
 }) {
+  const [adapters, setAdapters] = useState<AdapterEntry[]>([]);
   const [saving, setSaving] = useState(false);
   const enabled = new Set(config?.enabledAdapters ?? ["claude"]);
+
+  useEffect(() => {
+    fetch("/api/adapters")
+      .then((r) => r.json())
+      .then((data: AdapterEntry[]) => setAdapters(data))
+      .catch(() => {});
+  }, []);
 
   async function toggleAdapter(id: string, on: boolean) {
     const next = new Set(enabled);
@@ -38,7 +53,7 @@ export function AdaptersSection({
       </p>
 
       <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-        {ALL_ADAPTERS.map((adapter) => {
+        {adapters.map((adapter) => {
           const isEnabled = enabled.has(adapter.id);
           return (
             <div key={adapter.id} style={S.row}>
@@ -49,7 +64,9 @@ export function AdaptersSection({
                     {isEnabled ? "Active" : "Disabled"}
                   </span>
                 </div>
-                <div style={{ ...S.muted, marginTop: "2px" }}>{adapter.description}</div>
+                <div style={{ ...S.muted, marginTop: "2px" }}>
+                  {ADAPTER_DESCRIPTIONS[adapter.id] ?? `${adapter.displayName} adapter.`}
+                </div>
               </div>
               <button
                 style={{ ...S.btn, cursor: "pointer" }}
@@ -61,6 +78,9 @@ export function AdaptersSection({
             </div>
           );
         })}
+        {adapters.length === 0 && (
+          <div style={S.muted}>Loading adapters…</div>
+        )}
       </div>
     </section>
   );

--- a/src/components/settings/AdaptersSection.tsx
+++ b/src/components/settings/AdaptersSection.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import type { MinderConfig } from "@/lib/types";
+import { S } from "./styles";
+
+const ALL_ADAPTERS = [
+  { id: "claude", displayName: "Claude Code", description: "Reads sessions from ~/.claude/projects/." },
+];
+
+export function AdaptersSection({
+  config,
+  onConfigChange,
+}: {
+  config: MinderConfig | null;
+  onConfigChange: (patch: Partial<MinderConfig>) => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+  const enabled = new Set(config?.enabledAdapters ?? ["claude"]);
+
+  async function toggleAdapter(id: string, on: boolean) {
+    const next = new Set(enabled);
+    if (on) next.add(id); else next.delete(id);
+    setSaving(true);
+    try {
+      await onConfigChange({ enabledAdapters: [...next] });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section>
+      <h2 style={S.sectionTitle}>Adapters</h2>
+      <p style={S.desc}>
+        Enable or disable session sources. Disabling an adapter hides its sessions from the browser
+        and excludes them from analytics.
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+        {ALL_ADAPTERS.map((adapter) => {
+          const isEnabled = enabled.has(adapter.id);
+          return (
+            <div key={adapter.id} style={S.row}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                  <span style={S.label}>{adapter.displayName}</span>
+                  <span style={{ ...S.badge, color: isEnabled ? "var(--status-active-text)" : "var(--text-muted)", borderColor: isEnabled ? "var(--status-active-border)" : "var(--border-subtle)", background: isEnabled ? "var(--status-active-bg)" : "transparent" }}>
+                    {isEnabled ? "Active" : "Disabled"}
+                  </span>
+                </div>
+                <div style={{ ...S.muted, marginTop: "2px" }}>{adapter.description}</div>
+              </div>
+              <button
+                style={{ ...S.btn, cursor: "pointer" }}
+                disabled={saving}
+                onClick={() => toggleAdapter(adapter.id, !isEnabled)}
+              >
+                {isEnabled ? "Disable" : "Enable"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/adapters/claude.ts
+++ b/src/lib/adapters/claude.ts
@@ -15,7 +15,6 @@ const claudeAdapter: SessionAdapter = {
 
   async discover(): Promise<SessionFile[]> {
     const projectsDir = path.join(os.homedir(), ".claude", "projects");
-    const files: SessionFile[] = [];
 
     let subdirs: string[];
     try {
@@ -25,26 +24,25 @@ const claudeAdapter: SessionAdapter = {
       return [];
     }
 
-    for (const dirName of subdirs) {
-      const dirPath = path.join(projectsDir, dirName);
-      let jsonlFiles: string[];
-      try {
-        const entries = await fs.readdir(dirPath);
-        jsonlFiles = entries.filter((f) => f.endsWith(".jsonl"));
-      } catch {
-        continue;
-      }
+    const perDir = await Promise.all(
+      subdirs.map(async (dirName) => {
+        const dirPath = path.join(projectsDir, dirName);
+        try {
+          const entries = await fs.readdir(dirPath);
+          return entries
+            .filter((f) => f.endsWith(".jsonl"))
+            .map((file) => ({
+              source: "claude",
+              filePath: path.join(dirPath, file),
+              projectDirName: dirName,
+            }));
+        } catch {
+          return [];
+        }
+      })
+    );
 
-      for (const file of jsonlFiles) {
-        files.push({
-          source: "claude",
-          filePath: path.join(dirPath, file),
-          projectDirName: dirName,
-        });
-      }
-    }
-
-    return files;
+    return perDir.flat();
   },
 
   async parseFile(file: SessionFile): Promise<UsageTurn[]> {

--- a/src/lib/adapters/claude.ts
+++ b/src/lib/adapters/claude.ts
@@ -1,0 +1,69 @@
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
+import type { SessionAdapter, SessionFile } from "./types";
+import type { UsageTurn } from "@/lib/usage/types";
+import {
+  parseSessionTurns,
+  parseSessionTurnsWithMeta,
+  type SessionTurnsMeta,
+} from "@/lib/usage/parser";
+
+const claudeAdapter: SessionAdapter = {
+  id: "claude",
+  displayName: "Claude Code",
+
+  async discover(): Promise<SessionFile[]> {
+    const projectsDir = path.join(os.homedir(), ".claude", "projects");
+    const files: SessionFile[] = [];
+
+    let subdirs: string[];
+    try {
+      const entries = await fs.readdir(projectsDir, { withFileTypes: true });
+      subdirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+    } catch {
+      return [];
+    }
+
+    for (const dirName of subdirs) {
+      const dirPath = path.join(projectsDir, dirName);
+      let jsonlFiles: string[];
+      try {
+        const entries = await fs.readdir(dirPath);
+        jsonlFiles = entries.filter((f) => f.endsWith(".jsonl"));
+      } catch {
+        continue;
+      }
+
+      for (const file of jsonlFiles) {
+        files.push({
+          source: "claude",
+          filePath: path.join(dirPath, file),
+          projectDirName: dirName,
+        });
+      }
+    }
+
+    return files;
+  },
+
+  async parseFile(file: SessionFile): Promise<UsageTurn[]> {
+    const turns = await parseSessionTurns(file.filePath, file.projectDirName);
+    return turns.map((t) => ({ ...t, source: "claude" }));
+  },
+
+  async parseFileWithMeta(
+    file: SessionFile
+  ): Promise<{ turns: UsageTurn[]; meta: SessionTurnsMeta }> {
+    const { turns, meta } = await parseSessionTurnsWithMeta(
+      file.filePath,
+      file.projectDirName
+    );
+    return {
+      turns: turns.map((t) => ({ ...t, source: "claude" })),
+      meta,
+    };
+  },
+};
+
+export default claudeAdapter;

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -1,0 +1,52 @@
+import type { SessionAdapter, SessionFile } from "./types";
+import type { MinderConfig } from "@/lib/types";
+import claudeAdapter from "./claude";
+
+const REGISTRY = new Map<string, SessionAdapter>();
+
+function register(adapter: SessionAdapter): void {
+  REGISTRY.set(adapter.id, adapter);
+}
+
+register(claudeAdapter);
+
+export function listAdapters(): SessionAdapter[] {
+  return [...REGISTRY.values()];
+}
+
+export function getAdapter(id: string): SessionAdapter | undefined {
+  return REGISTRY.get(id);
+}
+
+export function getEnabledAdapters(config: MinderConfig): SessionAdapter[] {
+  const ids = config.enabledAdapters ?? ["claude"];
+  const warned = new Set<string>();
+  const result: SessionAdapter[] = [];
+
+  for (const id of ids) {
+    const adapter = REGISTRY.get(id);
+    if (!adapter) {
+      if (!warned.has(id)) {
+        console.warn(
+          `[adapters] Unknown adapter id "${id}" in enabledAdapters config. ` +
+            `Known adapters: ${[...REGISTRY.keys()].join(", ")}`
+        );
+        warned.add(id);
+      }
+      continue;
+    }
+    result.push(adapter);
+  }
+
+  return result;
+}
+
+export async function discoverAllSessions(
+  config: MinderConfig
+): Promise<SessionFile[]> {
+  const adapters = getEnabledAdapters(config);
+  const results = await Promise.all(adapters.map((a) => a.discover()));
+  return results.flat();
+}
+
+export type { SessionAdapter, SessionFile };

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -18,20 +18,25 @@ export function getAdapter(id: string): SessionAdapter | undefined {
   return REGISTRY.get(id);
 }
 
+export function getAdapterDisplayNameMap(): Map<string, string> {
+  return new Map([...REGISTRY.entries()].map(([id, a]) => [id, a.displayName]));
+}
+
+const _warnedUnknown = new Set<string>();
+
 export function getEnabledAdapters(config: MinderConfig): SessionAdapter[] {
   const ids = config.enabledAdapters ?? ["claude"];
-  const warned = new Set<string>();
   const result: SessionAdapter[] = [];
 
   for (const id of ids) {
     const adapter = REGISTRY.get(id);
     if (!adapter) {
-      if (!warned.has(id)) {
+      if (!_warnedUnknown.has(id)) {
         console.warn(
           `[adapters] Unknown adapter id "${id}" in enabledAdapters config. ` +
             `Known adapters: ${[...REGISTRY.keys()].join(", ")}`
         );
-        warned.add(id);
+        _warnedUnknown.add(id);
       }
       continue;
     }

--- a/src/lib/adapters/types.ts
+++ b/src/lib/adapters/types.ts
@@ -1,0 +1,16 @@
+import type { UsageTurn } from "@/lib/usage/types";
+import type { SessionTurnsMeta } from "@/lib/usage/parser";
+
+export interface SessionFile {
+  source: string;
+  filePath: string;
+  projectDirName: string;
+}
+
+export interface SessionAdapter {
+  id: string;
+  displayName: string;
+  discover(): Promise<SessionFile[]>;
+  parseFile(file: SessionFile): Promise<UsageTurn[]>;
+  parseFileWithMeta?(file: SessionFile): Promise<{ turns: UsageTurn[]; meta: SessionTurnsMeta }>;
+}

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -271,12 +271,13 @@ async function checkV3Gate(scope: string, db: DbHandle): Promise<boolean> {
  */
 async function runFileUsage(
   period: "today" | "week" | "month" | "all",
-  project: string | undefined
+  project: string | undefined,
+  source: string | undefined
 ): Promise<UsageResult> {
   // `getJsonlMaxMtime()` is captured AFTER report generation —
   // `parseAllSessions` warms the FileCache as a side effect, so a
   // pre-call read returns 0 on a cold process.
-  const report = await generateUsageReport(period, project);
+  const report = await generateUsageReport(period, project, source);
   return { report, meta: { backend: "file", maxMtimeMs: getJsonlMaxMtime() } };
 }
 
@@ -290,9 +291,10 @@ async function runFileUsage(
  */
 export async function getUsage(
   period: "today" | "week" | "month" | "all",
-  project?: string
+  project?: string,
+  source?: string
 ): Promise<UsageResult> {
-  if (!dbModeRequested()) return runFileUsage(period, project);
+  if (!dbModeRequested()) return runFileUsage(period, project, source);
 
   const db = await getReadyDb();
   if (await checkV3Gate("getUsage", db)) {
@@ -300,10 +302,10 @@ export async function getUsage(
       "getUsage",
       "DB awaiting v3 reconcile (cost_usd / category_costs not yet populated)"
     );
-    return runFileUsage(period, project);
+    return runFileUsage(period, project, source);
   }
   const report = await callDbLoader("getUsage", () =>
-    loadUsageReportFromSql(db, period, project)
+    loadUsageReportFromSql(db, period, project, source)
   );
   if (!project) await augmentPortfolioYield(report);
   return { report, meta: { backend: "db", maxMtimeMs: getDbMaxMtimeMs(db) } };

--- a/src/lib/data/sessionsListFromDb.ts
+++ b/src/lib/data/sessionsListFromDb.ts
@@ -137,6 +137,7 @@ interface SessionRow {
   work_mode_building_pct: number | null;
   work_mode_testing_pct: number | null;
   work_mode_other_pct: number | null;
+  source: string | null;
 }
 
 interface ToolCountRow {
@@ -192,7 +193,8 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
             has_thinking, cli_version, has_resume_anomaly, compact_boundary_count,
             generated_title, starred_at, distilled_at, distilled_text,
             work_mode_exploration_pct, work_mode_building_pct,
-            work_mode_testing_pct, work_mode_other_pct
+            work_mode_testing_pct, work_mode_other_pct,
+            source
      FROM sessions
      ORDER BY end_ts DESC`
   ).all() as SessionRow[];
@@ -347,6 +349,7 @@ export function loadSessionsListFromDb(db: DatabaseT.Database): SessionSummary[]
           }
         : undefined,
       isWorktree: isWorktreeEncodedDir(h.project_dir_name),
+      source: h.source ?? "claude",
     });
   }
 

--- a/src/lib/data/usageFromDb.ts
+++ b/src/lib/data/usageFromDb.ts
@@ -11,7 +11,7 @@ import type {
   McpServerStats,
   SourceBreakdown,
 } from "@/lib/usage/types";
-import { listAdapters } from "@/lib/adapters";
+import { getAdapterDisplayNameMap } from "@/lib/adapters";
 import { parseStoredArgs } from "@/lib/db/storedArgs";
 import { getPeriodStart } from "@/lib/usage/periods";
 import { groupByBinary } from "@/lib/usage/shellParser";
@@ -215,7 +215,7 @@ function queryBySource(db: DatabaseT.Database, f: FilterParams): SourceBreakdown
     )
     .all(f) as SourceRow[];
 
-  const adapterDisplayNames = new Map(listAdapters().map((a) => [a.id, a.displayName]));
+  const adapterDisplayNames = getAdapterDisplayNameMap();
   return rows.map((r) => ({
     source: r.source,
     displayName: adapterDisplayNames.get(r.source) ?? r.source,

--- a/src/lib/data/usageFromDb.ts
+++ b/src/lib/data/usageFromDb.ts
@@ -84,6 +84,8 @@ interface FilterParams {
   project: string | null;
   /** YYYY-MM-DD slice of `periodStart` for queries that filter by `day` column. */
   startDay: string | null;
+  /** Adapter source filter (e.g. "claude"). null for all sources. */
+  source: string | null;
 }
 
 /**
@@ -93,13 +95,15 @@ interface FilterParams {
 export function loadUsageReportFromSql(
   db: DatabaseT.Database,
   period: string,
-  project?: string
+  project?: string,
+  source?: string
 ): UsageReport {
   const periodStart = periodStartIso(period);
   const filter: FilterParams = {
     periodStart,
     project: project ?? null,
     startDay: periodStart?.slice(0, 10) ?? null,
+    source: source ?? null,
   };
 
   const totals = queryTotals(db, filter);
@@ -185,14 +189,16 @@ function queryTotals(db: DatabaseT.Database, f: FilterParams): TotalsRow {
        FROM turns t JOIN sessions s USING (session_id)
        WHERE t.role = 'assistant'
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
-         AND (@project IS NULL OR s.project_slug = @project)`
+         AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)`
     )
     .get(f) as Omit<TotalsRow, "distinct_sessions">;
   const sRow = prepCached(db,
       `SELECT COUNT(DISTINCT t.session_id) AS distinct_sessions
        FROM turns t JOIN sessions s USING (session_id)
        WHERE (@periodStart IS NULL OR t.ts >= @periodStart)
-         AND (@project IS NULL OR s.project_slug = @project)`
+         AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)`
     )
     .get(f) as { distinct_sessions: number };
   return { ...a, distinct_sessions: sRow.distinct_sessions };
@@ -210,6 +216,7 @@ function queryBySource(db: DatabaseT.Database, f: FilterParams): SourceBreakdown
        WHERE t.role = 'assistant'
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
          AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)
        GROUP BY s.source
        ORDER BY cost DESC`
     )
@@ -239,6 +246,7 @@ function queryByModel(db: DatabaseT.Database, f: FilterParams): ModelCost[] {
        WHERE t.role = 'assistant'
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
          AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)
        GROUP BY t.model
        ORDER BY cost DESC`
     )
@@ -258,6 +266,7 @@ function queryByProject(db: DatabaseT.Database, f: FilterParams): ProjectBreakdo
        WHERE t.role = 'assistant'
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
          AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)
        GROUP BY s.project_slug, s.project_dir_name
        ORDER BY cost DESC`
     )
@@ -300,6 +309,7 @@ function queryDaily(db: DatabaseT.Database, f: FilterParams): DailyBucket[] {
        WHERE t.role = 'assistant'
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
          AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)
        GROUP BY date
        ORDER BY date ASC`
     )
@@ -315,6 +325,7 @@ function queryTopTools(db: DatabaseT.Database, f: FilterParams): [string, number
        WHERE tu.tool_name NOT LIKE 'mcp__%'
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
          AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)
        GROUP BY tu.tool_name
        ORDER BY count DESC
        LIMIT 15`
@@ -332,6 +343,7 @@ function queryMcpStats(db: DatabaseT.Database, f: FilterParams): McpServerStats[
        WHERE tu.mcp_server IS NOT NULL
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
          AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)
        GROUP BY tu.mcp_server, tu.mcp_tool`
     )
     .all(f) as Array<{ server: string; tool: string; count: number }>;
@@ -367,8 +379,9 @@ function queryActivityTurns(
     `SELECT t.ts AS timestamp, t.cost_usd AS cost
        FROM turns t JOIN sessions s USING (session_id)
       WHERE t.role = 'assistant'
-        AND (@project IS NULL OR s.project_slug = @project)`
-  ).all({ project: f.project }) as Array<{ timestamp: string; cost: number }>;
+        AND (@project IS NULL OR s.project_slug = @project)
+        AND (@source IS NULL OR s.source = @source)`
+  ).all({ project: f.project, source: f.source }) as Array<{ timestamp: string; cost: number }>;
   return rows;
 }
 
@@ -384,7 +397,8 @@ function queryShellStats(db: DatabaseT.Database, f: FilterParams) {
        JOIN sessions s ON s.session_id = t.session_id
        WHERE tu.tool_name IN ('Bash', 'PowerShell')
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
-         AND (@project IS NULL OR s.project_slug = @project)`
+         AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)`
     )
     .all(f) as Array<{ arguments_json: string | null }>;
   const commands: string[] = [];
@@ -404,7 +418,8 @@ function queryOneShot(db: DatabaseT.Database, f: FilterParams) {
          COALESCE(SUM(one_shot_task_count), 0) AS oneShot
        FROM sessions
        WHERE (@periodStart IS NULL OR end_ts >= @periodStart)
-         AND (@project IS NULL OR project_slug = @project)`
+         AND (@project IS NULL OR project_slug = @project)
+         AND (@source IS NULL OR source = @source)`
     )
     .get(f) as { verified: number; oneShot: number };
   return {
@@ -429,6 +444,7 @@ function queryProjectDetails(db: DatabaseT.Database, f: FilterParams): ProjectDe
        WHERE t.role = 'assistant'
          AND (@periodStart IS NULL OR t.ts >= @periodStart)
          AND (@project IS NULL OR s.project_slug = @project)
+         AND (@source IS NULL OR s.source = @source)
        GROUP BY s.project_slug, s.project_dir_name
        ORDER BY cost DESC`
     )

--- a/src/lib/data/usageFromDb.ts
+++ b/src/lib/data/usageFromDb.ts
@@ -9,7 +9,9 @@ import type {
   DailyBucket,
   ProjectDetail,
   McpServerStats,
+  SourceBreakdown,
 } from "@/lib/usage/types";
+import { listAdapters } from "@/lib/adapters";
 import { parseStoredArgs } from "@/lib/db/storedArgs";
 import { getPeriodStart } from "@/lib/usage/periods";
 import { groupByBinary } from "@/lib/usage/shellParser";
@@ -101,6 +103,7 @@ export function loadUsageReportFromSql(
   };
 
   const totals = queryTotals(db, filter);
+  const bySource = queryBySource(db, filter);
   const byModel = queryByModel(db, filter);
   const byProject = queryByProject(db, filter);
   const byCategory = queryByCategory(db, filter);
@@ -150,6 +153,7 @@ export function loadUsageReportFromSql(
     byHourDay,
     streak,
     contributionCalendar,
+    bySource,
   };
 }
 
@@ -192,6 +196,33 @@ function queryTotals(db: DatabaseT.Database, f: FilterParams): TotalsRow {
     )
     .get(f) as { distinct_sessions: number };
   return { ...a, distinct_sessions: sRow.distinct_sessions };
+}
+
+function queryBySource(db: DatabaseT.Database, f: FilterParams): SourceBreakdown[] {
+  interface SourceRow { source: string; cost: number; tokens: number; sessionCount: number }
+  const rows = prepCached(db,
+      `SELECT
+         s.source,
+         COALESCE(SUM(t.cost_usd), 0) AS cost,
+         COALESCE(SUM(t.input_tokens + t.output_tokens + t.cache_read_tokens + t.cache_create_tokens), 0) AS tokens,
+         COUNT(DISTINCT t.session_id) AS sessionCount
+       FROM turns t JOIN sessions s USING (session_id)
+       WHERE t.role = 'assistant'
+         AND (@periodStart IS NULL OR t.ts >= @periodStart)
+         AND (@project IS NULL OR s.project_slug = @project)
+       GROUP BY s.source
+       ORDER BY cost DESC`
+    )
+    .all(f) as SourceRow[];
+
+  const adapterDisplayNames = new Map(listAdapters().map((a) => [a.id, a.displayName]));
+  return rows.map((r) => ({
+    source: r.source,
+    displayName: adapterDisplayNames.get(r.source) ?? r.source,
+    cost: r.cost,
+    tokens: r.tokens,
+    sessionCount: r.sessionCount,
+  }));
 }
 
 function queryByModel(db: DatabaseT.Database, f: FilterParams): ModelCost[] {

--- a/src/lib/db/ingest.ts
+++ b/src/lib/db/ingest.ts
@@ -267,6 +267,8 @@ interface ParsedSession {
   workModeBuildingPct: number | null;
   workModeTestingPct: number | null;
   workModeOtherPct: number | null;
+  /** Adapter source id (e.g. "claude"). */
+  source: string;
   turns: ParsedTurn[];
   // (day, project, model) tuples to recompute in daily_costs after this
   // session is replaced.
@@ -883,6 +885,7 @@ async function readJsonlSession(
       workModeBuildingPct: workMode.building,
       workModeTestingPct: workMode.testing,
       workModeOtherPct: workMode.other,
+      source: "claude",
       turns,
       affectedDays,
       affectedCategoryTuples,
@@ -983,7 +986,8 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
        has_thinking, cli_version, has_resume_anomaly, compact_boundary_count,
        derived_version, indexed_at_ms,
        work_mode_exploration_pct, work_mode_building_pct,
-       work_mode_testing_pct, work_mode_other_pct
+       work_mode_testing_pct, work_mode_other_pct,
+       source
      ) VALUES (
        @session_id, @project_slug, @project_dir_name, @file_path,
        @file_mtime_ms, @file_size, @byte_offset,
@@ -998,7 +1002,8 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
        @has_thinking, @cli_version, @has_resume_anomaly, @compact_boundary_count,
        @derived_version, @indexed_at_ms,
        @work_mode_exploration_pct, @work_mode_building_pct,
-       @work_mode_testing_pct, @work_mode_other_pct
+       @work_mode_testing_pct, @work_mode_other_pct,
+       @source
      )`
   ).run({
     session_id: s.sessionId,
@@ -1047,6 +1052,7 @@ function writeSession(db: DatabaseT.Database, s: ParsedSession): number {
     work_mode_building_pct: s.workModeBuildingPct,
     work_mode_testing_pct: s.workModeTestingPct,
     work_mode_other_pct: s.workModeOtherPct,
+    source: s.source,
   });
   rows++;
   if (PROFILE) tick("write.insertSession", performance.now() - tInsertSession);
@@ -1632,7 +1638,8 @@ function appendSessionTail(
        work_mode_exploration_pct = @work_mode_exploration_pct,
        work_mode_building_pct = @work_mode_building_pct,
        work_mode_testing_pct  = @work_mode_testing_pct,
-       work_mode_other_pct    = @work_mode_other_pct
+       work_mode_other_pct    = @work_mode_other_pct,
+       source                 = @source
      WHERE session_id = @session_id`
   ).run({
     ...statusUpdateParam,
@@ -1670,6 +1677,7 @@ function appendSessionTail(
     work_mode_building_pct: tailWorkMode.building,
     work_mode_testing_pct: tailWorkMode.testing,
     work_mode_other_pct: tailWorkMode.other,
+    source: parsed.source,
   });
   rows++;
 

--- a/src/lib/db/migrations.ts
+++ b/src/lib/db/migrations.ts
@@ -315,6 +315,20 @@ const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 11,
+    name: "wave10.2a: source column on sessions (multi-platform adapter)",
+    up: (db) => {
+      const sessionCols = db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>;
+      const sessionColNames = sessionCols.map((c) => c.name);
+      if (!sessionColNames.includes("source")) {
+        db.prepare("ALTER TABLE sessions ADD COLUMN source TEXT NOT NULL DEFAULT 'claude'").run();
+      }
+      db.prepare(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source)"
+      ).run();
+    },
+  },
 ];
 
 function resolveSchemaPath(): string {

--- a/src/lib/db/schema.sql
+++ b/src/lib/db/schema.sql
@@ -118,9 +118,12 @@ CREATE TABLE sessions (
   work_mode_exploration_pct REAL,
   work_mode_building_pct    REAL,
   work_mode_testing_pct     REAL,
-  work_mode_other_pct       REAL
+  work_mode_other_pct       REAL,
+  -- Wave 10.2a columns (schema v11): multi-platform adapter source id.
+  source TEXT NOT NULL DEFAULT 'claude'
 );
 
+CREATE INDEX idx_sessions_source          ON sessions(source);
 CREATE INDEX sessions_by_project_end      ON sessions(project_slug, end_ts DESC);
 CREATE INDEX sessions_by_end_ts      ON sessions(end_ts DESC);
 CREATE INDEX sessions_by_mtime       ON sessions(file_mtime_ms DESC);

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -25,6 +25,7 @@ export const helpMapping: Record<string, string> = {
   '/settings/terminal': 'terminal',
   '/settings/auto-title': 'auto-title',
   '/settings/live-activity': 'live-activity',
+  '/settings/adapters': 'adapters',
   '/kanban': 'kanban',
   '/tasks': 'tasks',
   '/schedule': 'tasks',

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -94,6 +94,7 @@ export const helpSlugs = [
   'cost',
   'tasks',
   'kanban',
+  'adapters',
 ] as const
 
 export type HelpSlug = (typeof helpSlugs)[number]

--- a/src/lib/scanner/claudeConversations.ts
+++ b/src/lib/scanner/claudeConversations.ts
@@ -400,6 +400,7 @@ async function scanSessionFile(
       hasToolFailureStreak: qualityHasToolFailureStreak,
       workMode: sessionWorkMode,
       isWorktree: isWorktreeEncodedDir(projectDirName),
+      source: "claude",
     };
   } catch {
     return null;

--- a/src/lib/sqlSchemaSnapshot.ts
+++ b/src/lib/sqlSchemaSnapshot.ts
@@ -30,6 +30,7 @@ export const SQL_SCHEMA: TableSchema[] = [
       "distilled_text",
       "work_mode_exploration_pct", "work_mode_building_pct",
       "work_mode_testing_pct", "work_mode_other_pct",
+      "source",
     ],
   },
   {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -338,6 +338,8 @@ export interface MinderConfig {
   pricingRules?: PricingRule[];
   /** When true, the task dispatcher loop skips all spawning until cleared. Wave 9.2 (emergency stop). */
   emergencyStop?: boolean;
+  /** Adapter ids to enable. Defaults to ["claude"]. Wave 10.2a (multi-platform). */
+  enabledAdapters?: string[];
 }
 
 export interface ClaudeUsageStats {
@@ -462,6 +464,8 @@ export interface SessionSummary {
   workMode?: { exploration: number; building: number; testing: number; other: number };
   /** True when this session came from a Claude Code worktree directory. */
   isWorktree?: boolean;
+  /** Adapter source id (e.g. "claude", "codex"). Defaults to "claude" for legacy sessions. */
+  source?: string;
 }
 
 export interface TimelineEvent {

--- a/src/lib/usage/aggregator.ts
+++ b/src/lib/usage/aggregator.ts
@@ -13,6 +13,7 @@ import { computeContributionCalendar } from "./contributionCalendar";
 import { computeProjectYield } from "./computeProjectYield";
 import { gatherProjectTurns, encodeProjectPath } from "./projectMatch";
 import { getCachedScan } from "@/lib/cache";
+import { listAdapters } from "@/lib/adapters";
 import type {
   UsageTurn,
   UsageReport,
@@ -24,6 +25,7 @@ import type {
   DailyBucket,
   ToolCall,
   PortfolioYield,
+  SourceBreakdown,
 } from "./types";
 
 type Period = "today" | "week" | "month" | "all";
@@ -196,6 +198,7 @@ export async function aggregateUsage(
     mcpMap: Map<string, number>; // server -> call count
   };
   const projectDetailAccum = new Map<string, ProjectDetailAccum>();
+  const sourceAccum = new Map<string, { cost: number; tokens: number; sessions: Set<string> }>();
   let totalInput = 0;
   let totalOutput = 0;
   let totalCacheRead = 0;
@@ -277,6 +280,16 @@ export async function aggregateUsage(
     }
     projectDetailAccum.set(turn.projectSlug, detail);
 
+    // Source
+    const src = turn.source ?? "claude";
+    {
+      const entry = sourceAccum.get(src) ?? { cost: 0, tokens: 0, sessions: new Set<string>() };
+      entry.cost += cost;
+      entry.tokens += tokens;
+      entry.sessions.add(turn.sessionId);
+      sourceAccum.set(src, entry);
+    }
+
     // Totals
     totalInput += turn.inputTokens;
     totalOutput += turn.outputTokens;
@@ -356,6 +369,18 @@ export async function aggregateUsage(
       mcpCalls: [...d.mcpMap.values()].reduce((s, n) => s + n, 0),
     }));
 
+  // By-source breakdown (computed from enriched loop data — cost already resolved)
+  const adapterDisplayNames = new Map(listAdapters().map((a) => [a.id, a.displayName]));
+  const bySource: SourceBreakdown[] = [...sourceAccum.entries()]
+    .sort((a, b) => b[1].cost - a[1].cost)
+    .map(([source, s]) => ({
+      source,
+      displayName: adapterDisplayNames.get(source) ?? source,
+      cost: s.cost,
+      tokens: s.tokens,
+      sessionCount: s.sessions.size,
+    }));
+
   return {
     period,
     totalCost,
@@ -385,5 +410,6 @@ export async function aggregateUsage(
     byHourDay: activity.byHourDay,
     streak: activity.streak,
     contributionCalendar: activity.contributionCalendar,
+    bySource,
   };
 }

--- a/src/lib/usage/aggregator.ts
+++ b/src/lib/usage/aggregator.ts
@@ -32,7 +32,8 @@ type Period = "today" | "week" | "month" | "all";
 
 export async function generateUsageReport(
   period: Period,
-  project?: string
+  project?: string,
+  source?: string
 ): Promise<UsageReport> {
   const sessionMap = await parseAllSessions();
 
@@ -41,10 +42,13 @@ export async function generateUsageReport(
     turns.push(...sessionTurns);
   }
 
-  // Project filter first (before period) — activity aggregates are project-scoped
-  // but use full history (not period-filtered).
+  // Project + source filters first (before period) — activity aggregates are
+  // project/source-scoped but use full history (not period-filtered).
   if (project) {
     turns = turns.filter((t) => t.projectSlug === project);
+  }
+  if (source) {
+    turns = turns.filter((t) => (t.source ?? "claude") === source);
   }
 
   const assistantTurnsFullHistory = turns.filter((t) => t.role === "assistant");

--- a/src/lib/usage/aggregator.ts
+++ b/src/lib/usage/aggregator.ts
@@ -13,7 +13,7 @@ import { computeContributionCalendar } from "./contributionCalendar";
 import { computeProjectYield } from "./computeProjectYield";
 import { gatherProjectTurns, encodeProjectPath } from "./projectMatch";
 import { getCachedScan } from "@/lib/cache";
-import { listAdapters } from "@/lib/adapters";
+import { getAdapterDisplayNameMap } from "@/lib/adapters";
 import type {
   UsageTurn,
   UsageReport,
@@ -370,7 +370,7 @@ export async function aggregateUsage(
     }));
 
   // By-source breakdown (computed from enriched loop data — cost already resolved)
-  const adapterDisplayNames = new Map(listAdapters().map((a) => [a.id, a.displayName]));
+  const adapterDisplayNames = getAdapterDisplayNameMap();
   const bySource: SourceBreakdown[] = [...sourceAccum.entries()]
     .sort((a, b) => b[1].cost - a[1].cost)
     .map(([source, s]) => ({

--- a/src/lib/usage/types.ts
+++ b/src/lib/usage/types.ts
@@ -35,6 +35,8 @@ export interface UsageTurn {
   parentToolUseId?: string;
   /** True when this turn belongs to a sidechain (subagent) session. */
   isSidechain?: boolean;
+  /** Adapter source id (e.g. "claude", "codex"). Optional; aggregator coerces absent to "claude". */
+  source?: string;
 }
 
 export type CategoryType =
@@ -127,6 +129,14 @@ export interface ProjectBreakdown {
   tokens: number;
   cost: number;
   turns: number;
+}
+
+export interface SourceBreakdown {
+  source: string;
+  displayName: string;
+  cost: number;
+  tokens: number;
+  sessionCount: number;
 }
 
 export interface ModelPricing {
@@ -232,4 +242,5 @@ export interface UsageReport {
   contributionCalendar: ContributionCell[];
   /** Portfolio-level yield aggregate. Populated by augmentPortfolioYield() on both backends. */
   portfolioYield?: PortfolioYield;
+  bySource: SourceBreakdown[];
 }

--- a/tests/adaptersRegistry.test.ts
+++ b/tests/adaptersRegistry.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Registry is a module singleton — import directly to test its public API.
+// We cannot easily reset the registry between tests, so we test against the
+// real registered state (claude registered at import time).
+
+describe("adapter registry", () => {
+  it("listAdapters returns claude by default", async () => {
+    const { listAdapters } = await import("@/lib/adapters");
+    const adapters = listAdapters();
+    expect(adapters.length).toBeGreaterThanOrEqual(1);
+    expect(adapters.map((a) => a.id)).toContain("claude");
+  });
+
+  it("getAdapter returns the claude adapter", async () => {
+    const { getAdapter } = await import("@/lib/adapters");
+    const adapter = getAdapter("claude");
+    expect(adapter).toBeDefined();
+    expect(adapter!.id).toBe("claude");
+    expect(adapter!.displayName).toBe("Claude Code");
+    expect(typeof adapter!.discover).toBe("function");
+    expect(typeof adapter!.parseFile).toBe("function");
+    expect(typeof adapter!.parseFileWithMeta).toBe("function");
+  });
+
+  it("getAdapter returns undefined for unknown id", async () => {
+    const { getAdapter } = await import("@/lib/adapters");
+    expect(getAdapter("nonexistent")).toBeUndefined();
+  });
+
+  it("getEnabledAdapters honors enabledAdapters config", async () => {
+    const { getEnabledAdapters } = await import("@/lib/adapters");
+    const adapters = getEnabledAdapters({ enabledAdapters: ["claude"] } as any);
+    expect(adapters.map((a) => a.id)).toEqual(["claude"]);
+  });
+
+  it("getEnabledAdapters silently drops unknown adapter ids (with warn)", async () => {
+    const { getEnabledAdapters } = await import("@/lib/adapters");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapters = getEnabledAdapters({ enabledAdapters: ["claude", "unknown-xyz"] } as any);
+    expect(adapters.map((a) => a.id)).toEqual(["claude"]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unknown-xyz"));
+    warnSpy.mockRestore();
+  });
+
+  it("discoverAllSessions returns SessionFile[] with source=claude from the claude adapter", async () => {
+    const { discoverAllSessions } = await import("@/lib/adapters");
+    // discover() reads ~home/.claude/projects which may or may not exist in CI.
+    // The important check is that whatever is returned has source='claude'.
+    const files = await discoverAllSessions({ enabledAdapters: ["claude"] } as any);
+    for (const f of files) {
+      expect(f.source).toBe("claude");
+      expect(typeof f.filePath).toBe("string");
+      expect(typeof f.projectDirName).toBe("string");
+    }
+  });
+});

--- a/tests/claudeAdapter.test.ts
+++ b/tests/claudeAdapter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+const FIXTURE_DIR = path.join(os.tmpdir(), "claude-adapter-test-" + Date.now());
+const PROJECTS_DIR = path.join(FIXTURE_DIR, ".claude", "projects");
+
+const SAMPLE_JSONL = JSON.stringify({
+  type: "user",
+  uuid: "aa",
+  timestamp: "2025-01-01T00:00:00Z",
+  message: { content: [{ type: "text", text: "Hello" }] },
+}) + "\n" + JSON.stringify({
+  type: "assistant",
+  uuid: "bb",
+  timestamp: "2025-01-01T00:01:00Z",
+  message: {
+    content: [{ type: "text", text: "Hi there" }],
+    model: "claude-opus-4-7",
+    usage: { input_tokens: 10, output_tokens: 5, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+  },
+}) + "\n";
+
+beforeAll(() => {
+  const projectDir = path.join(PROJECTS_DIR, "C--test-project");
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.writeFileSync(path.join(projectDir, "testsession.jsonl"), SAMPLE_JSONL, "utf-8");
+});
+
+afterAll(() => {
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+});
+
+describe("claude adapter", () => {
+  it("discover() finds JSONL files in the fixture projects dir", async () => {
+    const { default: claudeAdapter } = await import("@/lib/adapters/claude");
+    vi.spyOn(os, "homedir").mockReturnValue(FIXTURE_DIR);
+
+    const files = await claudeAdapter.discover();
+    expect(files.length).toBeGreaterThan(0);
+    expect(files[0].source).toBe("claude");
+    expect(files[0].filePath).toContain("testsession.jsonl");
+    expect(files[0].projectDirName).toBe("C--test-project");
+
+    vi.mocked(os.homedir).mockRestore();
+  });
+
+  it("parseFile stamps source: 'claude' on every turn", async () => {
+    const { default: claudeAdapter } = await import("@/lib/adapters/claude");
+    const filePath = path.join(PROJECTS_DIR, "C--test-project", "testsession.jsonl");
+    const file = { source: "claude", filePath, projectDirName: "C--test-project" };
+    const turns = await claudeAdapter.parseFile(file);
+    expect(turns.length).toBeGreaterThan(0);
+    for (const t of turns) {
+      expect(t.source).toBe("claude");
+    }
+  });
+
+  it("parseFileWithMeta returns { turns, meta } with source stamps", async () => {
+    const { default: claudeAdapter } = await import("@/lib/adapters/claude");
+    const filePath = path.join(PROJECTS_DIR, "C--test-project", "testsession.jsonl");
+    const file = { source: "claude", filePath, projectDirName: "C--test-project" };
+    const result = await claudeAdapter.parseFileWithMeta!(file);
+    expect(result).toHaveProperty("turns");
+    expect(result).toHaveProperty("meta");
+    expect(result.meta).toHaveProperty("compactBoundaries");
+    expect(result.meta).toHaveProperty("cliVersion");
+    expect(result.meta).toHaveProperty("hasThinking");
+    for (const t of result.turns) {
+      expect(t.source).toBe("claude");
+    }
+  });
+
+  it("discover() returns empty list when projects dir does not exist", async () => {
+    const { default: claudeAdapter } = await import("@/lib/adapters/claude");
+    vi.spyOn(os, "homedir").mockReturnValue(path.join(os.tmpdir(), "nonexistent-" + Date.now()));
+    const files = await claudeAdapter.discover();
+    expect(files).toEqual([]);
+    vi.mocked(os.homedir).mockRestore();
+  });
+});

--- a/tests/dataSessionsList.test.ts
+++ b/tests/dataSessionsList.test.ts
@@ -244,6 +244,7 @@ describe.skipIf(!driverAvailable)("data façade — getSessionsList backend pari
       expect(d.skillsUsed).toEqual(f.skillsUsed);
       expect(d.gitBranch).toBe(f.gitBranch);
       expect(d.isActive).toBe(f.isActive);
+      expect(d.source).toBe(f.source ?? "claude");
 
       // Documented divergences — assert the DB path's intentional differences.
       expect(d.recaps).toBeUndefined();

--- a/tests/dbIngest.test.ts
+++ b/tests/dbIngest.test.ts
@@ -200,6 +200,7 @@ describe.skipIf(!driverAvailable)("reconcileAllSessions", () => {
     expect(session.initial_prompt).toBe("fix the migration bug");
     expect(session.last_prompt).toBe("fix the migration bug");
     expect(session.derived_version).toBe(7);
+    expect(session.source).toBe("claude");
 
     const turnRows = db
       .prepare("SELECT role, category FROM turns WHERE session_id = 'abc-session' ORDER BY turn_index")

--- a/tests/dbMigrations.test.ts
+++ b/tests/dbMigrations.test.ts
@@ -81,8 +81,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     // but each still bumps the schema_version stamp. Note that v3
     // ALSO sets `meta.needs_reconcile_after_v3 = 1` even on fresh DBs;
     // that's harmless because the indexer's first reconcile clears it.
-    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    expect(result.schemaVersion).toBe(11);
 
     const db = await conn.getDb();
     expect(db).not.toBeNull();
@@ -104,7 +104,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
     expect(result.appliedMigrations).toEqual([]);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     second.conn.closeDb();
   });
 
@@ -134,7 +134,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
 
     expect(result.available).toBe(true);
     expect(result.quarantined).not.toBeNull();
-    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.appliedMigrations).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
     // The schema ran on the rebuilt empty DB.
     const db = await conn.getDb();
@@ -164,7 +164,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     expect(result.error).toBeNull();
     expect(result.available).toBe(true);
     expect(result.quarantined).not.toBeNull();
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
     second.conn.closeDb();
   });
 
@@ -218,8 +218,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.appliedMigrations).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    expect(result.schemaVersion).toBe(11);
 
     const db2 = await second.conn.getDb();
     const colsRecovered = db2!
@@ -254,8 +254,8 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const second = await reloadModulesPointingAt(tmpHome);
     const result = await second.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.appliedMigrations).toEqual([3, 4, 5, 6, 7, 8, 9, 10]);
-    expect(result.schemaVersion).toBe(10);
+    expect(result.appliedMigrations).toEqual([3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    expect(result.schemaVersion).toBe(11);
 
     const db2 = await second.conn.getDb();
     expect(db2).not.toBeNull();
@@ -284,7 +284,7 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const reloaded = await reloadModulesPointingAt(tmpHome);
     const result = await reloaded.mig.initDb();
     expect(result.error).toBeNull();
-    expect(result.schemaVersion).toBe(10);
+    expect(result.schemaVersion).toBe(11);
 
     const db = await reloaded.conn.getDb();
     expect(db).not.toBeNull();
@@ -300,6 +300,22 @@ describe.skipIf(!driverAvailable)("initDb", () => {
     const tuNames = tuCols.map((c) => c.name);
     expect(tuNames).toContain("error_category");
     expect(tuNames).toContain("invocation_source");
+
+    reloaded.conn.closeDb();
+  });
+
+  it("v11 migration adds source column to sessions", async () => {
+    const reloaded = await reloadModulesPointingAt(tmpHome);
+    const result = await reloaded.mig.initDb();
+    expect(result.error).toBeNull();
+    expect(result.schemaVersion).toBe(11);
+
+    const db = await reloaded.conn.getDb();
+    expect(db).not.toBeNull();
+
+    const sessionCols = db!.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>;
+    const sessionNames = sessionCols.map((c) => c.name);
+    expect(sessionNames).toContain("source");
 
     reloaded.conn.closeDb();
   });

--- a/tests/usageBySource.test.ts
+++ b/tests/usageBySource.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { aggregateUsage } from "@/lib/usage/aggregator";
+import { emptyActivity } from "@/lib/usage/activityBuckets";
+import type { UsageTurn } from "@/lib/usage/types";
+
+function makeTurn(overrides: Partial<UsageTurn> = {}): UsageTurn {
+  return {
+    timestamp: "2025-01-01T00:00:00Z",
+    sessionId: "sess1",
+    projectSlug: "project-a",
+    projectDirName: "C--project-a",
+    model: "claude-opus-4-7",
+    role: "assistant",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheCreateTokens: 0,
+    cacheReadTokens: 0,
+    toolCalls: [],
+    source: "claude",
+    ...overrides,
+  };
+}
+
+describe("aggregateUsage bySource", () => {
+  it("produces one bySource entry for claude-only turns", async () => {
+    const turns: UsageTurn[] = [
+      makeTurn({ sessionId: "s1" }),
+      makeTurn({ sessionId: "s1", role: "user", model: "<synthetic>", inputTokens: 0, outputTokens: 0 }),
+      makeTurn({ sessionId: "s2" }),
+    ];
+    const report = await aggregateUsage(turns, "all", emptyActivity());
+    expect(report.bySource).toHaveLength(1);
+    expect(report.bySource[0].source).toBe("claude");
+    expect(report.bySource[0].displayName).toBe("Claude Code");
+    expect(report.bySource[0].sessionCount).toBe(2);
+  });
+
+  it("produces multiple bySource entries for mixed sources", async () => {
+    const turns: UsageTurn[] = [
+      makeTurn({ sessionId: "s1", source: "claude" }),
+      makeTurn({ sessionId: "s2", source: "codex" }),
+    ];
+    const report = await aggregateUsage(turns, "all", emptyActivity());
+    expect(report.bySource).toHaveLength(2);
+    const sources = report.bySource.map((s) => s.source);
+    expect(sources).toContain("claude");
+    expect(sources).toContain("codex");
+  });
+
+  it("bySource totals match overall totals for single-source", async () => {
+    const turns: UsageTurn[] = [
+      makeTurn({ sessionId: "s1", inputTokens: 200, outputTokens: 100 }),
+      makeTurn({ sessionId: "s1", inputTokens: 50, outputTokens: 25 }),
+    ];
+    const report = await aggregateUsage(turns, "all", emptyActivity());
+    const claudeSource = report.bySource.find((s) => s.source === "claude");
+    expect(claudeSource).toBeDefined();
+    expect(claudeSource!.tokens).toBe(report.totalTokens);
+  });
+
+  it("coerces missing source to 'claude'", async () => {
+    const turns: UsageTurn[] = [
+      makeTurn({ source: undefined }),
+    ];
+    const report = await aggregateUsage(turns, "all", emptyActivity());
+    expect(report.bySource[0].source).toBe("claude");
+  });
+});


### PR DESCRIPTION
## Summary

Wave 10.2a — Cluster X (part 1): Establishes the adapter seam for multi-platform coding-agent session support (TODO #223). Codex (#219) and Gemini (#221) defer to 10.2b/c.

- **`src/lib/adapters/`** — `SessionAdapter` interface + module-singleton registry (`listAdapters`, `getEnabledAdapters`, `discoverAllSessions`, `getAdapterDisplayNameMap`). `claude` adapter wraps existing `parseSessionTurns`/`parseSessionTurnsWithMeta` — no behavior change, only formalization. Subdirectory reads parallelized with `Promise.all`.
- **DB schema v11** — `sessions.source TEXT NOT NULL DEFAULT 'claude'` + `idx_sessions_source`. Existing rows migrate automatically; no re-parse.
- **`enabledAdapters` config** — `MinderConfig.enabledAdapters?: string[]` (default `["claude"]`). `PATCH /api/config` validates IDs against registry; rejects unknown with 400. `GET /api/sessions` gates results by enabled set (disable Claude → empty list; re-enable → sessions return).
- **`source` field** threaded through `UsageTurn`, `SessionSummary`, `SessionDetail`, `SessionRow`. All existing sessions coerce to `"claude"`.
- **`bySource: SourceBreakdown[]`** on `UsageReport`, computed by both file-parse aggregator and DB `queryBySource()`. "By Source" section always visible on `/usage`.
- **`SourceBadge`** in session row + header — always visible (proves pipeline E2E with "Claude Code" today).
- **Source filter** dropdown in Sessions browser toolbar — always visible when sessions exist.
- **Adapters section** in Settings — enable/disable toggle; Claude is toggleable for verification.
- **`?source=`** on `/api/sessions` + `/api/usage` (ETag-aware).
- Help doc at `/settings/adapters`.

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 1699 passing (14 new: `adaptersRegistry`, `claudeAdapter`, `usageBySource`, + `dbIngest`/`dataSessionsList`/`dbMigrations` extensions)
- [ ] `/sessions` — every row shows "Claude Code" source badge; source filter dropdown visible in toolbar
- [ ] Click any session → header chip row shows "Claude Code" badge
- [ ] `/usage` → "By Source" section above "By Model" with one "Claude Code" row and full totals
- [ ] `/settings` → "Adapters" sidebar entry; Claude listed as Active with Disable toggle
- [ ] Toggle Claude off → `/sessions` shows empty list; toggle back on → 211 sessions return
- [ ] `GET /api/sessions?source=claude` → 211, `?source=codex` → 0
- [ ] DB: `SELECT DISTINCT source FROM sessions` → `claude` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)