### PR TITLE
feat(wave10.2b): Codex CLI adapter (TODO #219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Claude session reading wrapped as the `claude` adapter; existing `parser.ts` / `ingest.ts` functions stay public and are called by the adapter wrapper.
 - `claudeConversations.scanAllSessions` stamps `source: "claude"` directly (adapter-registry routing deferred to Wave 10.2b when Codex lands).
 
+- **Wave 10.2b — Cluster X (part 2): Codex CLI adapter.** TODO #219.
+  - New `src/lib/adapters/codex.ts`: `discover()` recursively walks `~/.codex/sessions/` and `~/.codex/archived_sessions/`, deduping sessions by ID. `parseFile()` translates Codex's event-stream JSONL format (session_meta / turn_context / response_item / event_msg) into `UsageTurn[]`.
+  - Token delta math: prefers `last_token_usage` per turn; falls back to delta from `total_token_usage` when absent. `cacheReadTokens = min(cached_input_tokens, input_tokens)`; `cacheCreateTokens` is always 0 (Codex does not report cache creation).
+  - Project slug derived from `cwd` in session metadata via `encodeProjectPath` + `toSlug` — same encoding used by the scanner, so Codex sessions correlate with the correct project in analytics.
+  - Help doc updated: Codex adapter status changed from "Coming" to "Active"; Codex-specific section added.
+
 - **Wave 10.1c — Cluster W (part 3): Multi-agent swarm dispatch.** TODO #247.
   - New `ops_swarms` table (migration v5) with `name`, `mode` (`worktree`|`shared`), `project_path`, `status`, `completed_at`. Two new nullable columns on `ops_tasks`: `swarm_id` (FK → `ops_swarms`) and `swarm_role` (`member`|`coordinator`), added via `ALTER TABLE ADD COLUMN` — zero migration cost for existing rows.
   - **Swarm creation**: `createSwarm()` — single SQLite transaction creates the swarm row + 2–8 member tasks (with `worktreePath`/`projectPath` in metadata for worktree mode) + optional coordinator task with `task_dependencies` edges to every member.

--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -1,5 +1,215 @@
 # Insights
 
+<!-- insight:00f7550bd851 | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T16:47:36.001Z -->
+## ★ Insight
+The client/server boundary is the core constraint here. `AdaptersSection` is a `"use client"` component — it can't import from `@/lib/adapters` (a server-only module using `fs`/`path`/`os`). Fetching from `/api/adapters` is the correct pattern: server module stays on server, client gets plain JSON.
+
+---
+
+<!-- insight:a37b58b8e2a0 | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T16:43:31.398Z -->
+## ★ Insight
+The SQL path uses `FilterParams` as a named-binding object passed directly to `prepCached` statements. Adding `source: string | null` to that struct automatically threads through to every query that references `@source` — no parameter-by-parameter surgery needed. The `category_costs` rollup table doesn't have a `source` column, so that one query stays unfiltered; everything else gets the filter via the sessions JOIN.
+
+---
+
+<!-- insight:6388f295667a | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T14:55:13.543Z -->
+## ★ Insight
+The `ALL_ADAPTERS` list hardcoded codex/gemini as `"Coming in Wave 10.2b/c"` — but the PATCH `/api/config` handler validates `enabledAdapters` against `listAdapters()` (the live registry). Enabling codex in the UI would immediately get a 400 rejection from the API. The correct pattern is: UI lists only what the registry knows about. Future adapters appear automatically when their registry entry is added.
+
+---
+
+<!-- insight:cd7404eade9f | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T14:54:50.013Z -->
+## ★ Insight
+The advisor identified a pattern mismatch: the plan treats "By Source" and the source filter as always-visible UI chrome that *proves* the architecture works end-to-end, not conditional UI that appears only when diversity exists. Hiding them until a second adapter ships means the §6.3 verification steps can never pass.
+
+---
+
+<!-- insight:afd5151a06bb | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T14:30:53.530Z -->
+## ★ Insight
+The `SourceBadge` uses the same visual token system as `QualityChip` but as a shared component, making it importable anywhere. When only one adapter exists, every session shows "Claude Code" — this provides a verified end-to-end proof that the `source` field flows correctly through the whole stack before any second adapter is introduced.
+
+---
+
+<!-- insight:359c52abb896 | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T14:27:21.780Z -->
+## ★ Insight
+The `source` field flows through four distinct layers: the adapter contract, the in-memory parse shape, the DB row, and the JSON API response. In each layer the coercion `?? "claude"` acts as a backward-compatibility shim — existing rows and test fixtures pre-dating the `source` field get the correct default without needing migration data, only a schema DEFAULT.
+
+---
+
+<!-- insight:dab28aa6db82 | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T14:22:12.361Z -->
+## ★ Insight
+The `SessionAdapter` interface uses the **optional method** pattern (`parseFileWithMeta?`) — adapters that have richer session metadata (compaction boundaries, CLI version) can opt in. This avoids forcing all adapters to implement metadata they don't have, while letting the caller fall back gracefully to an empty meta object. This is a clean extension point compared to using a base class or inheritance.
+
+---
+
+<!-- insight:e4db66d93b46 | session:6693a164-23dd-41c9-97e7-d81ba6e665d8 | 2026-05-09T14:07:06.519Z -->
+## ★ Insight
+The cluster has three TODOs (#223 refactor, #219 Codex, #221 Gemini), but they're not equal-effort. The refactor alone touches DB schema (`source` column migration), ingest, parser, ~10 UI files for source badges, and a new Settings section — that's a full session. Codex has a confirmed empirical schema (100+ files at `~/.codex/sessions/2025-2026/`). Gemini has a real research gap: the agentlytics reference (`agentlytics-repo/editors/gemini.js`) only handles the ≤v0.38 single-JSON format; the ≥v0.39 JSONL format is unknown both locally and in the reference.
+
+---
+
+<!-- insight:62310aa3c3cd | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T13:25:27.828Z -->
+## ★ Insight
+The shared-mode cwd bug was caught by two reviewers independently — it's a common mistake when metadata shapes change. The key lesson: when you add a new mode that omits a field (`worktreePath`), every consumer of that metadata needs to handle the partial case. The `runWorktreeTask` function was written assuming worktree presence meant "has both fields," but shared mode only sets one.
+
+---
+
+<!-- insight:92c5555ebf30 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T13:20:37.973Z -->
+## ★ Insight
+The reviews caught two structural bugs: (1) worktree paths derive uniqueness only from the swarm name slug, so two same-named swarms collide on the same directory; (2) the `runWorktreeTask` classic path never fires the `onComplete` callback, so swarm status rollups are silently skipped for classic-mode members. Both are quiet correctness issues that pass tests.
+
+---
+
+<!-- insight:c77afb96b0be | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T12:54:41.971Z -->
+## ★ Insight
+The net result is -70 lines despite adding one new file (`composer-fields.tsx`). This is the hallmark of a good extraction: the shared module is smaller than the sum of the copies it replaced. The `updateSwarmStatus` function also shrank meaningfully — removing the existence check eliminated 7 lines and one DB round-trip, and the correctness argument is simple: `tasks.length === 0` already handles a missing swarm with no additional query needed.
+
+---
+
+<!-- insight:6cb14e24df1d | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T12:47:12.549Z -->
+## ★ Insight
+The most important fix here is extracting `inputStyle`/`labelStyle`/`Field` into a shared module — not because of bundle size, but because this exact triplet will be copied into every future composer modal. A single shared source prevents 4 future divergences. The key rule: if two files are byte-for-byte identical on something, that something belongs in one place.
+
+---
+
+<!-- insight:5819c7534dab | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T12:42:39.391Z -->
+## ★ Insight
+The three agents below are examining orthogonal quality dimensions simultaneously. Rather than a single sequential review (which might linger on early findings), parallel agents each focus on one lens: reuse (are we duplicating?), quality (are the patterns clean?), and efficiency (are we doing unnecessary work?). This is especially valuable for a large diff like 10.1c where a single pass would naturally underweight later concerns.
+
+---
+
+<!-- insight:2958e4fdb937 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T12:41:29.568Z -->
+## ★ Insight
+Wave 10 Cluster W (TODOs #166, #167, #247) is now fully landed across three sessions spanning 10.1a–10.1c. The pattern here — splitting a large cluster into a, b, c sub-sessions with each one building directly on the previous session's schema/store additions — keeps individual PRs reviewable and lets tests grow incrementally rather than arriving all at once.
+
+---
+
+<!-- insight:ede05846c133 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T12:23:28.151Z -->
+## ★ Insight
+The `<!-- swarm-summaries-injected -->` HTML comment in the description acts as an idempotency guard — it's invisible to the claude CLI prompt but prevents duplicate injection if `updateSwarmStatus` is called multiple times with all members terminal. This is more reliable than checking swarm.status because the swarm might not yet be finalized when the guard is checked.
+
+---
+
+<!-- insight:df1a9b4ac44f | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T12:20:15.129Z -->
+## ★ Insight
+The key architectural pattern here: SQLite's `db.transaction()` callback in better-sqlite3 must be synchronous, so `createSwarm` will inline all DB operations rather than calling async `createTask`. The coordinator SQL guard uses a role-aware OR branch — non-coordinators need `bt.status != 'done'`, coordinators accept all terminal states — solving the "coordinator blocked forever" problem when members fail.
+
+---
+
+<!-- insight:ca1065daebcc | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T12:09:44.860Z -->
+## ★ Insight
+The `runStatements` helper (not `db.exec`) is the established pattern for multi-statement migrations — it strips `--` comments and runs each `;`-terminated statement individually, avoiding the security linter that flags the multi-statement exec name.
+
+---
+
+<!-- insight:d68853183b50 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T03:22:33.100Z -->
+## ★ Insight
+The depth guard `if (depth > nodes.length) return 0` is a blunt recursion limiter, not a real cycle detector. It terminates after too many stack frames but doesn't set `layerMap` for cycle participants, so they can be visited again with different depths. A `visiting` set (the DFS "gray" set) is the canonical fix: if we encounter a node already on the current recursion stack, we've found a cycle back-edge and can safely return 0 without infinite recursion.
+
+---
+
+<!-- insight:8fb2f4a2415f | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T03:21:56.992Z -->
+## ★ Insight
+The reason we use `allTasks` (not period-filtered `tasks`) for the status lookup is subtle: a blocker task completed 10 days ago would be excluded from the `last24h` view, making `taskStatusMap.get(dep.blocker_id)` return `undefined` — which isn't `'done'`, so the badge would persist incorrectly. `allTasks` is fetched before filtering, so it's the authoritative source of truth for blocker status regardless of the active time window.
+
+---
+
+<!-- insight:7ff9b6f0ce03 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T03:21:15.097Z -->
+## ★ Insight
+The `parseInt("12abc", 10)` silently returns `12` — JavaScript's partial parse. `parseId` uses a regex `/^\d+$/` to reject any string with non-digit characters before calling parseInt, making it a strict validator. That's the key difference from the current `Number.isFinite` check, which only catches `NaN` and `Infinity` but not partial parses.
+
+---
+
+<!-- insight:aaa2dccadf20 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T03:18:29.953Z -->
+## ★ Insight
+The Copilot review caught a subtle Gantt bug: `computeLayout` assigns `order` as a within-layer index (0..N per layer), but the Gantt used it as a global row index. With two layers, nodes in layer 1 get order=0 and overlap layer 0's first row. The fix must happen in the component, not in `computeLayout`, since the layout function's contract is layer-local ordering.
+
+---
+
+<!-- insight:11e63ff6b056 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T02:53:44.091Z -->
+## ★ Insight
+The biggest perf win is the DFS loop: `db.prepare()` compiles SQL every call. SQLite's `better-sqlite3` uses a prepared-statement cache API (`prepTasksCached`) for exactly this reason — the same SQL string returns the same compiled Statement object. Hoisting the prepare call above the loop converts O(n) compiles to O(1).
+
+---
+
+<!-- insight:11ef9fb50bb8 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T02:43:25.279Z -->
+## ★ Insight
+The `{ tasks: [...] }` wrapper pattern is an API convention: named properties are easier to extend later (add `total`, `nextCursor`, etc.) without breaking callers. But it requires consumers to unwrap correctly — a raw `Array.isArray()` guard will silently fail on a wrapped response. The fix extracts `.tasks` first, then validates the array.
+
+---
+
+<!-- insight:143583bd9923 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T02:35:03.787Z -->
+## ★ Insight
+The DFS direction matters critically for cycle detection. We want to check "if I add edge `blockerId → taskId`, does `taskId` already have a path back to `blockerId`?" — so we must traverse FROM `taskId` through downstream dependents looking for `blockerId`. Starting from `blockerId` instead detects existing paths `blockerId → taskId`, which falsely triggers on the exact existing edge being re-inserted (idempotent case).
+
+---
+
+<!-- insight:6dbceb988f78 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T02:24:15.700Z -->
+## ★ Insight
+The `dependencyLayout.ts` is a pure function with no side effects — it's ideal for unit testing. The store-level `addDependency` tests need a real (in-memory) SQLite instance. Looking at how other store tests work will reveal the testing pattern for this project.
+
+---
+
+<!-- insight:e746b0093184 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T02:18:13.274Z -->
+## ★ Insight
+The layered layout uses **longest-path layering**: each node gets layer = max(blocker layers) + 1. This is a standard Sugiyama step that ensures all edges go "left to right" (blockers always appear before their dependents). Since we prevent cycles at insert time, the DFS-based layer assignment is guaranteed to terminate.
+
+---
+
+<!-- insight:efe7d40f5665 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T02:14:36.599Z -->
+## ★ Insight
+The migration pattern (`MIGRATIONS[]` registry + `applyPendingMigrations`) means adding v4 requires zero changes to the migration runner — just append a new object to the array. SQLite's `ON DELETE CASCADE` on both FKs means deleting either task or blocker automatically cleans up the edge row, preventing orphaned dependency data.
+
+---
+
+<!-- insight:3e9c77b8f243 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T02:06:33.310Z -->
+## ★ Insight
+The migration pattern here is a numbered registry (v1, v2, v3...) where each migration is a function — identical to how Flyway/Liquibase work. Key insight: SQLite can't `ALTER TABLE ... ADD CONSTRAINT`, so changing an enum (like the `delegated-todo` quadrant in v2) requires rebuilding the table via `CREATE TABLE ... AS SELECT ... DROP ... RENAME`. This is why migration v2 is so large.
+
+---
+
+<!-- insight:c8abc1a69b26 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T01:52:27.258Z -->
+## ★ Insight
+The 11 comments collapse into 5 root causes: (1) wrong dedup key in the hook, (2) aspirational session→Done/Error path that has no data supply, (3) `cancelled` tasks escaping the always-include list, (4) feature flag not actually gating tasks, (5) `decisionCount` never populated. All fixable without breaking the API shape.
+
+---
+
+<!-- insight:2a6631acbd0e | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T00:11:25.508Z -->
+## ★ Insight
+Project Minder uses inline `style` objects throughout rather than Tailwind className strings — this is intentional for dark-mode-first CSS variable theming. The `color-mix(in srgb, ...)` technique produces alpha-blended backgrounds from a single color token without needing separate background tokens.
+
+---
+
+<!-- insight:c08b6bff73da | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T00:08:42.046Z -->
+## ★ Insight
+Writing exhaustive enumeration tests for `columnMap.ts` serves as a "change detector" — if a new `LiveSessionStatus` or `TaskStatus` is ever added to the upstream types, TypeScript will fail compilation at the `assertNever` call site inside `columnMap.ts`, making the gap impossible to ship silently.
+
+---
+
+<!-- insight:0d5b3a8e8ed3 | session:d0040c9c-f8c3-4c92-9c47-2da263a51212 | 2026-05-09T00:07:51.660Z -->
+## ★ Insight
+The `LiveSessionStatus` type has 4 values (`working`, `approval`, `waiting`, `other`) while `TaskStatus` has 6 values. The Kanban only has 5 columns, so both need to be mapped down — notably `other` maps conditionally based on the session's `SessionStatus`, and `cancelled` tasks go to `idle` (not `error`) since cancellation is intentional.
+
+---
+
+<!-- insight:0aea45fa87fa | session:aa6ac6db-3e8a-441e-9507-703090057d06 | 2026-05-08T22:53:27.855Z -->
+## ★ Insight
+Module-level mutable state in Next.js route handlers is shared across all clients in the same server process (but reset on redeploy). For edge-triggering, a better pattern is stateless: the client sends its last `generatedAt` timestamp, and the server compares against records newer than that epoch. No shared state, correct for any number of tabs.
+
+---
+
+<!-- insight:b108207a7e92 | session:aa6ac6db-3e8a-441e-9507-703090057d06 | 2026-05-08T22:52:06.389Z -->
+## ★ Insight
+The dedup bug here is subtle: SQLite UNIQUE indexes treat NULL as distinct from every other NULL (ISO SQL behavior), so `UNIQUE(session_id, prompt) WHERE decided_at IS NULL` never deduplicates rows where `session_id IS NULL`. The fix shifts to `(task_id, kind, prompt)` which are all NOT NULL. The `WHERE kind = 'decision'` predicate keeps INBOX rows from occupying the index permanently — inbox messages intentionally stack.
+
+---
+
+<!-- insight:b19621ab57d4 | session:aa6ac6db-3e8a-441e-9507-703090057d06 | 2026-05-08T22:48:06.511Z -->
+## ★ Insight
+The dedup index `UNIQUE(session_id, prompt) WHERE decided_at IS NULL` has two fundamental flaws: (1) SQLite NULLs don't compare equal, so rows with `session_id = NULL` can never collide, and (2) `inbox` kind rows with no `decided_at` live in the index forever. Changing to `(task_id, kind, prompt) WHERE kind = 'decision'` fixes both.
+
+---
+
 <!-- insight:9fdb15510b89 | session:aa6ac6db-3e8a-441e-9507-703090057d06 | 2026-05-08T20:06:59.408Z -->
 ## ★ Insight
 The InboxPanel issue is the only one with real ongoing cost (720 unnecessary HTTP+DB round-trips per hour per tab). The double stat-walk and sequential PID checks are correctness-adjacent; the rest are cosmetic cleanups.

--- a/docs/help/adapters.md
+++ b/docs/help/adapters.md
@@ -20,6 +20,8 @@ To enable Codex alongside Claude Code:
 { "enabledAdapters": ["claude", "codex"] }
 ```
 
+**Custom data location:** If your Codex data is not in `~/.codex/`, set the `CODEX_HOME` environment variable to the directory you want the adapter to scan. This takes precedence over the default `~/.codex/` path and is useful for CI environments or non-standard installs.
+
 Note: Codex does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Codex sessions. Cost estimates use OpenAI model pricing when available, falling back to Claude Sonnet pricing for unknown models.
 
 ## Managing adapters

--- a/docs/help/adapters.md
+++ b/docs/help/adapters.md
@@ -7,8 +7,20 @@ Project Minder reads AI coding-agent sessions through **adapters** — thin modu
 | Adapter | ID | Status |
 |---|---|---|
 | Claude Code | `claude` | Active |
-| Codex | `codex` | Coming in Wave 10.2b |
+| Codex | `codex` | Active |
 | Gemini | `gemini` | Coming in Wave 10.2c |
+
+## Codex adapter
+
+The Codex adapter reads sessions from `~/.codex/sessions/` and `~/.codex/archived_sessions/`, walking both recursively. Each session file is a JSONL event stream where the first line is session metadata (including the working directory). Sessions are deduped by their session ID so a file copied to the archive directory is not double-counted.
+
+To enable Codex alongside Claude Code:
+
+```json
+{ "enabledAdapters": ["claude", "codex"] }
+```
+
+Note: Codex does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Codex sessions. Cost estimates use OpenAI model pricing when available, falling back to Claude Sonnet pricing for unknown models.
 
 ## Managing adapters
 

--- a/public/help/adapters.md
+++ b/public/help/adapters.md
@@ -20,6 +20,8 @@ To enable Codex alongside Claude Code:
 { "enabledAdapters": ["claude", "codex"] }
 ```
 
+**Custom data location:** If your Codex data is not in `~/.codex/`, set the `CODEX_HOME` environment variable to the directory you want the adapter to scan. This takes precedence over the default `~/.codex/` path and is useful for CI environments or non-standard installs.
+
 Note: Codex does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Codex sessions. Cost estimates use OpenAI model pricing when available, falling back to Claude Sonnet pricing for unknown models.
 
 ## Managing adapters

--- a/public/help/adapters.md
+++ b/public/help/adapters.md
@@ -7,8 +7,20 @@ Project Minder reads AI coding-agent sessions through **adapters** — thin modu
 | Adapter | ID | Status |
 |---|---|---|
 | Claude Code | `claude` | Active |
-| Codex | `codex` | Coming in Wave 10.2b |
+| Codex | `codex` | Active |
 | Gemini | `gemini` | Coming in Wave 10.2c |
+
+## Codex adapter
+
+The Codex adapter reads sessions from `~/.codex/sessions/` and `~/.codex/archived_sessions/`, walking both recursively. Each session file is a JSONL event stream where the first line is session metadata (including the working directory). Sessions are deduped by their session ID so a file copied to the archive directory is not double-counted.
+
+To enable Codex alongside Claude Code:
+
+```json
+{ "enabledAdapters": ["claude", "codex"] }
+```
+
+Note: Codex does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Codex sessions. Cost estimates use OpenAI model pricing when available, falling back to Claude Sonnet pricing for unknown models.
 
 ## Managing adapters
 

--- a/src/lib/adapters/codex.ts
+++ b/src/lib/adapters/codex.ts
@@ -1,0 +1,381 @@
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
+import type { FileHandle } from "fs/promises";
+import type { SessionAdapter, SessionFile } from "./types";
+import type { UsageTurn, ToolCall } from "@/lib/usage/types";
+import { encodeProjectPath } from "@/lib/usage/projectMatch";
+import { toSlug } from "@/lib/scanner/claudeConversations";
+
+const ADAPTER_ID = "codex" as const;
+
+// ─── file walk ──────────────────────────────────────────────────────────────
+
+async function walkJsonlFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (entry.isFile() && entry.name.endsWith(".jsonl")) results.push(full);
+    }
+  }
+  return results.sort();
+}
+
+// ─── session meta ───────────────────────────────────────────────────────────
+
+interface SessionMeta {
+  id: string;
+  cwd: string;
+}
+
+// Reads only the first line via a small fixed buffer — avoids loading entire session files
+async function readSessionMeta(filePath: string): Promise<SessionMeta | null> {
+  let fh: FileHandle | undefined;
+  try {
+    fh = await fs.open(filePath, "r");
+    const buf = Buffer.allocUnsafe(1024);
+    const { bytesRead } = await fh.read(buf, 0, 1024, 0);
+    const chunk = buf.toString("utf-8", 0, bytesRead);
+    const newline = chunk.indexOf("\n");
+    const firstLine = newline >= 0 ? chunk.slice(0, newline) : chunk;
+    const entry = safeParseJson(firstLine);
+    if (!entry || entry.type !== "session_meta" || !entry.payload) return null;
+    const p = entry.payload as Record<string, unknown>;
+    return {
+      id: typeof p.id === "string" ? p.id : path.basename(filePath, ".jsonl"),
+      cwd: typeof p.cwd === "string" ? p.cwd : "",
+    };
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}
+
+// ─── parsing helpers ─────────────────────────────────────────────────────────
+
+function safeParseJson(line: string): Record<string, unknown> | null {
+  try {
+    const v = JSON.parse(line);
+    return v && typeof v === "object" && !Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseTimestamp(raw: unknown): string | null {
+  if (typeof raw === "string" && raw.trim()) return raw;
+  if (typeof raw === "number" && Number.isFinite(raw)) return new Date(raw).toISOString();
+  return null;
+}
+
+function extractModel(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const v = value as Record<string, unknown>;
+  const direct =
+    (typeof v.model === "string" && v.model.trim()) ||
+    (typeof v.model_name === "string" && v.model_name.trim());
+  if (direct) return direct as string;
+  if (v.info && typeof v.info === "object") {
+    const m = extractModel(v.info);
+    if (m) return m;
+  }
+  return null;
+}
+
+interface RawUsage {
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+}
+
+function normalizeRawUsage(value: unknown): RawUsage | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const v = value as Record<string, unknown>;
+  const n = (x: unknown) => (typeof x === "number" && Number.isFinite(x) ? x : 0);
+  return {
+    input_tokens: n(v.input_tokens),
+    cached_input_tokens: n(v.cached_input_tokens ?? v.cache_read_input_tokens),
+    output_tokens: n(v.output_tokens),
+  };
+}
+
+function subtractRawUsage(curr: RawUsage, prev: RawUsage | null): RawUsage {
+  return {
+    input_tokens: Math.max(curr.input_tokens - (prev?.input_tokens ?? 0), 0),
+    cached_input_tokens: Math.max(curr.cached_input_tokens - (prev?.cached_input_tokens ?? 0), 0),
+    output_tokens: Math.max(curr.output_tokens - (prev?.output_tokens ?? 0), 0),
+  };
+}
+
+function convertToDeltas(raw: RawUsage): { inputTokens: number; cacheReadTokens: number; outputTokens: number } {
+  const cacheReadTokens = Math.min(raw.cached_input_tokens, raw.input_tokens);
+  return {
+    inputTokens: Math.max(raw.input_tokens - cacheReadTokens, 0),
+    cacheReadTokens,
+    outputTokens: raw.output_tokens,
+  };
+}
+
+function isBootstrapMessage(text: string): boolean {
+  const t = text.trim();
+  return t.startsWith("<user_instructions>") || t.startsWith("<environment_context>");
+}
+
+function extractUserText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === "object" && !Array.isArray(item))
+    .filter((item) => item.type === "input_text" && typeof item.text === "string")
+    .map((item) => (item.text as string).trim())
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+// ─── event-stream parser ─────────────────────────────────────────────────────
+
+interface TurnState {
+  parts: string[];
+  toolCalls: ToolCall[];
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  model: string | null;
+}
+
+function createTurnState(): TurnState {
+  return { parts: [], toolCalls: [], inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, model: null };
+}
+
+const TEXT_CAP = 500;
+
+async function parseCodexFile(filePath: string, fallbackProjectDirName: string): Promise<UsageTurn[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lines = content.split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return [];
+
+  const firstEntry = safeParseJson(lines[0]);
+  if (!firstEntry || firstEntry.type !== "session_meta" || !firstEntry.payload) return [];
+  const metaPayload = firstEntry.payload as Record<string, unknown>;
+
+  const sessionId =
+    typeof metaPayload.id === "string" ? metaPayload.id : path.basename(filePath, ".jsonl");
+  const cwd = typeof metaPayload.cwd === "string" ? metaPayload.cwd : "";
+  const projectDirName = cwd ? encodeProjectPath(cwd) : fallbackProjectDirName;
+  const projectSlug = toSlug(projectDirName);
+
+  // Codex has no per-turn timestamps; use session creation time, falling back to file mtime
+  let sessionTimestamp: string =
+    parseTimestamp(metaPayload.timestamp) ??
+    (await fs.stat(filePath).then((s) => s.mtime.toISOString()).catch(() => new Date().toISOString()));
+
+  const turns: UsageTurn[] = [];
+  let currentModel: string | null =
+    typeof metaPayload.model === "string" && metaPayload.model.trim() ? metaPayload.model : null;
+  let previousTotals: RawUsage | null = null;
+  let currentTurn: TurnState = createTurnState();
+
+  const baseTurn = () => ({
+    timestamp: sessionTimestamp,
+    sessionId,
+    projectSlug,
+    projectDirName,
+    cacheCreateTokens: 0 as const,
+    source: ADAPTER_ID,
+  });
+
+  function flushTurn() {
+    const hasContent = currentTurn.parts.length > 0;
+    const hasTokens = currentTurn.inputTokens > 0 || currentTurn.outputTokens > 0 || currentTurn.cacheReadTokens > 0;
+    const hasTools = currentTurn.toolCalls.length > 0;
+    if (!hasContent && !hasTokens && !hasTools) {
+      currentTurn = createTurnState();
+      return;
+    }
+    turns.push({
+      ...baseTurn(),
+      model: currentTurn.model ?? currentModel ?? ADAPTER_ID,
+      role: "assistant",
+      inputTokens: currentTurn.inputTokens,
+      outputTokens: currentTurn.outputTokens,
+      cacheReadTokens: currentTurn.cacheReadTokens,
+      toolCalls: currentTurn.toolCalls,
+      assistantText: currentTurn.parts.join("\n").slice(0, TEXT_CAP) || undefined,
+    });
+    currentTurn = createTurnState();
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    const entry = safeParseJson(lines[i]);
+    if (!entry) continue;
+
+    // ── turn boundary ──────────────────────────────────────────────────────
+    if (entry.type === "turn_context") {
+      flushTurn();
+      const model = extractModel(entry.payload);
+      if (model) {
+        currentModel = model;
+        currentTurn.model = model;
+      }
+      continue;
+    }
+
+    // ── conversation items ─────────────────────────────────────────────────
+    if (entry.type === "response_item") {
+      const payload = entry.payload as Record<string, unknown> | undefined;
+      if (!payload) continue;
+
+      if (payload.type === "message") {
+        if (payload.role === "user") {
+          const text = extractUserText(payload.content);
+          if (!text || isBootstrapMessage(text)) continue;
+          flushTurn();
+          turns.push({
+            ...baseTurn(),
+            model: currentModel ?? ADAPTER_ID,
+            role: "user",
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            toolCalls: [],
+            userMessageText: text.slice(0, TEXT_CAP),
+          });
+        } else if (payload.role === "assistant") {
+          if (Array.isArray(payload.content)) {
+            for (const item of payload.content as unknown[]) {
+              if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+              const c = item as Record<string, unknown>;
+              if (c.type === "output_text" && typeof c.text === "string" && c.text.trim()) {
+                currentTurn.parts.push(c.text.trim());
+              }
+            }
+          }
+          if (!currentTurn.model && currentModel) currentTurn.model = currentModel;
+        }
+        continue;
+      }
+
+      // Tool calls
+      const isToolCall =
+        payload.type === "function_call" ||
+        payload.type === "custom_tool_call" ||
+        payload.type === "web_search_call";
+      if (isToolCall) {
+        const name =
+          typeof payload.name === "string"
+            ? payload.name
+            : payload.type === "web_search_call"
+            ? "web_search"
+            : "tool";
+        let args: Record<string, unknown> = {};
+        if (payload.type === "function_call" && typeof payload.arguments === "string") {
+          try {
+            args = JSON.parse(payload.arguments) as Record<string, unknown>;
+          } catch {
+            args = {};
+          }
+        }
+        const callId = typeof payload.call_id === "string" ? payload.call_id : undefined;
+        currentTurn.toolCalls.push({ name, arguments: args, id: callId });
+        continue;
+      }
+    }
+
+    // ── token counts ───────────────────────────────────────────────────────
+    if (entry.type === "event_msg") {
+      const payload = entry.payload as Record<string, unknown> | undefined;
+      if (!payload || payload.type !== "token_count") continue;
+
+      const tokenInfo = (payload.info ?? {}) as Record<string, unknown>;
+      const lastUsage = normalizeRawUsage(tokenInfo.last_token_usage);
+      const totalUsage = normalizeRawUsage(tokenInfo.total_token_usage);
+
+      let rawUsage = lastUsage;
+      if (!rawUsage && totalUsage) rawUsage = subtractRawUsage(totalUsage, previousTotals);
+      if (totalUsage) previousTotals = totalUsage;
+      if (!rawUsage) continue;
+
+      const { inputTokens, outputTokens, cacheReadTokens } = convertToDeltas(rawUsage);
+      if (inputTokens === 0 && outputTokens === 0 && cacheReadTokens === 0) continue;
+
+      currentTurn.inputTokens += inputTokens;
+      currentTurn.outputTokens += outputTokens;
+      currentTurn.cacheReadTokens += cacheReadTokens;
+
+      const model = extractModel(tokenInfo) ?? extractModel(payload);
+      if (model) {
+        currentModel = model;
+        currentTurn.model = model;
+      } else if (!currentTurn.model && currentModel) {
+        currentTurn.model = currentModel;
+      }
+    }
+  }
+
+  flushTurn();
+
+  return turns;
+}
+
+// ─── adapter ─────────────────────────────────────────────────────────────────
+
+const codexAdapter: SessionAdapter = {
+  id: ADAPTER_ID,
+  displayName: "Codex",
+
+  async discover(): Promise<SessionFile[]> {
+    const codexHome =
+      typeof process.env.CODEX_HOME === "string" && process.env.CODEX_HOME.trim()
+        ? path.resolve(process.env.CODEX_HOME.trim())
+        : path.join(os.homedir(), ".codex");
+
+    const searchDirs = [
+      path.join(codexHome, "sessions"),
+      path.join(codexHome, "archived_sessions"),
+    ];
+
+    // Walk both dirs in parallel; sessions/ takes priority over archived/ for dedup
+    const [sessionFiles, archivedFiles] = await Promise.all(searchDirs.map(walkJsonlFiles));
+    const allFiles = [...sessionFiles, ...archivedFiles];
+
+    // Read metadata for all files in parallel
+    const metas = await Promise.all(allFiles.map(readSessionMeta));
+
+    const seen = new Set<string>();
+    const files: SessionFile[] = [];
+    for (let i = 0; i < allFiles.length; i++) {
+      const meta = metas[i];
+      if (!meta || seen.has(meta.id)) continue;
+      seen.add(meta.id);
+      const projectDirName = meta.cwd
+        ? encodeProjectPath(meta.cwd)
+        : path.basename(allFiles[i], ".jsonl");
+      files.push({ source: ADAPTER_ID, filePath: allFiles[i], projectDirName });
+    }
+
+    return files;
+  },
+
+  async parseFile(file: SessionFile): Promise<UsageTurn[]> {
+    return parseCodexFile(file.filePath, file.projectDirName);
+  },
+};
+
+export default codexAdapter;

--- a/src/lib/adapters/codex.ts
+++ b/src/lib/adapters/codex.ts
@@ -8,6 +8,7 @@ import { encodeProjectPath } from "@/lib/usage/projectMatch";
 import { toSlug } from "@/lib/scanner/claudeConversations";
 
 const ADAPTER_ID = "codex" as const;
+const META_READ_CONCURRENCY = 16;
 
 // ─── file walk ──────────────────────────────────────────────────────────────
 
@@ -38,16 +39,33 @@ interface SessionMeta {
   cwd: string;
 }
 
-// Reads only the first line via a small fixed buffer — avoids loading entire session files
+// Reads the first line in 4KB chunks until a newline is found (max 64KB).
+// Avoids loading entire session files while handling arbitrarily long session_meta lines.
 async function readSessionMeta(filePath: string): Promise<SessionMeta | null> {
   let fh: FileHandle | undefined;
   try {
     fh = await fs.open(filePath, "r");
-    const buf = Buffer.allocUnsafe(1024);
-    const { bytesRead } = await fh.read(buf, 0, 1024, 0);
-    const chunk = buf.toString("utf-8", 0, bytesRead);
-    const newline = chunk.indexOf("\n");
-    const firstLine = newline >= 0 ? chunk.slice(0, newline) : chunk;
+    const CHUNK = 4096;
+    const MAX = 65536;
+    const buf = Buffer.allocUnsafe(CHUNK);
+    const chunks: string[] = [];
+    let offset = 0;
+    let firstLine = "";
+    while (offset < MAX) {
+      const { bytesRead } = await fh.read(buf, 0, CHUNK, offset);
+      if (bytesRead === 0) {
+        firstLine = chunks.join("");
+        break;
+      }
+      const chunk = buf.toString("utf-8", 0, bytesRead);
+      const nl = chunk.indexOf("\n");
+      if (nl >= 0) {
+        firstLine = chunks.join("") + chunk.slice(0, nl);
+        break;
+      }
+      chunks.push(chunk);
+      offset += bytesRead;
+    }
     const entry = safeParseJson(firstLine);
     if (!entry || entry.type !== "session_meta" || !entry.payload) return null;
     const p = entry.payload as Record<string, unknown>;
@@ -60,6 +78,15 @@ async function readSessionMeta(filePath: string): Promise<SessionMeta | null> {
   } finally {
     await fh?.close();
   }
+}
+
+// Runs fn over items in batches to cap concurrent open file handles
+async function batchedMap<T, R>(items: T[], fn: (item: T) => Promise<R>, limit: number): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += limit) {
+    results.push(...await Promise.all(items.slice(i, i + limit).map(fn)));
+  }
+  return results;
 }
 
 // ─── parsing helpers ─────────────────────────────────────────────────────────
@@ -211,7 +238,7 @@ async function parseCodexFile(filePath: string, fallbackProjectDirName: string):
     }
     turns.push({
       ...baseTurn(),
-      model: currentTurn.model ?? currentModel ?? ADAPTER_ID,
+      model: currentTurn.model ?? currentModel ?? "unknown",
       role: "assistant",
       inputTokens: currentTurn.inputTokens,
       outputTokens: currentTurn.outputTokens,
@@ -249,7 +276,7 @@ async function parseCodexFile(filePath: string, fallbackProjectDirName: string):
           flushTurn();
           turns.push({
             ...baseTurn(),
-            model: currentModel ?? ADAPTER_ID,
+            model: currentModel ?? "unknown",
             role: "user",
             inputTokens: 0,
             outputTokens: 0,
@@ -355,8 +382,8 @@ const codexAdapter: SessionAdapter = {
     const [sessionFiles, archivedFiles] = await Promise.all(searchDirs.map(walkJsonlFiles));
     const allFiles = [...sessionFiles, ...archivedFiles];
 
-    // Read metadata for all files in parallel
-    const metas = await Promise.all(allFiles.map(readSessionMeta));
+    // Read metadata in bounded batches to avoid hitting the FD limit (EMFILE)
+    const metas = await batchedMap(allFiles, readSessionMeta, META_READ_CONCURRENCY);
 
     const seen = new Set<string>();
     const files: SessionFile[] = [];

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -1,6 +1,7 @@
 import type { SessionAdapter, SessionFile } from "./types";
 import type { MinderConfig } from "@/lib/types";
 import claudeAdapter from "./claude";
+import codexAdapter from "./codex";
 
 const REGISTRY = new Map<string, SessionAdapter>();
 
@@ -9,6 +10,7 @@ function register(adapter: SessionAdapter): void {
 }
 
 register(claudeAdapter);
+register(codexAdapter);
 
 export function listAdapters(): SessionAdapter[] {
   return [...REGISTRY.values()];

--- a/tests/codexAdapter.test.ts
+++ b/tests/codexAdapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
 import path from "path";
 import os from "os";
 import fs from "fs";
@@ -26,6 +26,10 @@ beforeAll(() => {
   fs.writeFileSync(path.join(SESSIONS_DIR, `${SESSION_ID}.jsonl`), SAMPLE_JSONL, "utf-8");
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 afterAll(() => {
   fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
 });
@@ -41,7 +45,6 @@ describe("codex adapter", () => {
     expect(files[0].filePath).toContain(`${SESSION_ID}.jsonl`);
     expect(files[0].projectDirName).toContain("my-project");
 
-    vi.mocked(os.homedir).mockRestore();
   });
 
   it("parseFile() stamps source: 'codex' on every turn", async () => {
@@ -81,7 +84,6 @@ describe("codex adapter", () => {
     vi.spyOn(os, "homedir").mockReturnValue(path.join(os.tmpdir(), "nonexistent-codex-" + Date.now()));
     const files = await codexAdapter.discover();
     expect(files).toEqual([]);
-    vi.mocked(os.homedir).mockRestore();
   });
 
   it("discover() deduplicates sessions with the same id across sessions/ and archived_sessions/", async () => {
@@ -103,6 +105,5 @@ describe("codex adapter", () => {
     const matchingFiles = files.filter((f) => f.filePath.includes(SESSION_ID));
     expect(matchingFiles.length).toBe(1);
 
-    vi.mocked(os.homedir).mockRestore();
   });
 });

--- a/tests/codexAdapter.test.ts
+++ b/tests/codexAdapter.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+const FIXTURE_DIR = path.join(os.tmpdir(), "codex-adapter-test-" + Date.now());
+const SESSIONS_DIR = path.join(FIXTURE_DIR, ".codex", "sessions", "2025");
+
+// Minimal Codex JSONL with one user turn and one assistant turn
+const SESSION_ID = "test-session-abc";
+const PROJECT_CWD = "/home/user/my-project";
+
+const SAMPLE_JSONL =
+  JSON.stringify({ type: "session_meta", payload: { id: SESSION_ID, cwd: PROJECT_CWD, timestamp: "2025-06-01T10:00:00Z", cli_version: "1.0.0" } }) + "\n" +
+  // user message
+  JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Hello from Codex" }] } }) + "\n" +
+  // turn boundary
+  JSON.stringify({ type: "turn_context", payload: { model: "gpt-4o" } }) + "\n" +
+  // assistant text
+  JSON.stringify({ type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "Hi there" }] } }) + "\n" +
+  // token count
+  JSON.stringify({ type: "event_msg", payload: { type: "token_count", info: { last_token_usage: { input_tokens: 20, cached_input_tokens: 5, output_tokens: 8 }, model: "gpt-4o" } } }) + "\n";
+
+beforeAll(() => {
+  fs.mkdirSync(SESSIONS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(SESSIONS_DIR, `${SESSION_ID}.jsonl`), SAMPLE_JSONL, "utf-8");
+});
+
+afterAll(() => {
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+});
+
+describe("codex adapter", () => {
+  it("discover() finds JSONL files in nested sessions dir", async () => {
+    const { default: codexAdapter } = await import("@/lib/adapters/codex");
+    vi.spyOn(os, "homedir").mockReturnValue(FIXTURE_DIR);
+
+    const files = await codexAdapter.discover();
+    expect(files.length).toBeGreaterThan(0);
+    expect(files[0].source).toBe("codex");
+    expect(files[0].filePath).toContain(`${SESSION_ID}.jsonl`);
+    expect(files[0].projectDirName).toContain("my-project");
+
+    vi.mocked(os.homedir).mockRestore();
+  });
+
+  it("parseFile() stamps source: 'codex' on every turn", async () => {
+    const { default: codexAdapter } = await import("@/lib/adapters/codex");
+    const filePath = path.join(SESSIONS_DIR, `${SESSION_ID}.jsonl`);
+    const file = { source: "codex", filePath, projectDirName: "home-user-my-project" };
+    const turns = await codexAdapter.parseFile(file);
+    expect(turns.length).toBeGreaterThan(0);
+    for (const t of turns) {
+      expect(t.source).toBe("codex");
+    }
+  });
+
+  it("parseFile() produces user and assistant turns with correct token data", async () => {
+    const { default: codexAdapter } = await import("@/lib/adapters/codex");
+    const filePath = path.join(SESSIONS_DIR, `${SESSION_ID}.jsonl`);
+    const file = { source: "codex", filePath, projectDirName: "home-user-my-project" };
+    const turns = await codexAdapter.parseFile(file);
+
+    const user = turns.find((t) => t.role === "user");
+    const assistant = turns.find((t) => t.role === "assistant");
+
+    expect(user).toBeDefined();
+    expect(user!.userMessageText).toContain("Hello from Codex");
+
+    expect(assistant).toBeDefined();
+    expect(assistant!.model).toBe("gpt-4o");
+    // cacheRead = min(5, 20) = 5; billableInput = 20 - 5 = 15
+    expect(assistant!.cacheReadTokens).toBe(5);
+    expect(assistant!.inputTokens).toBe(15);
+    expect(assistant!.outputTokens).toBe(8);
+    expect(assistant!.cacheCreateTokens).toBe(0);
+  });
+
+  it("discover() returns empty list when .codex dir does not exist", async () => {
+    const { default: codexAdapter } = await import("@/lib/adapters/codex");
+    vi.spyOn(os, "homedir").mockReturnValue(path.join(os.tmpdir(), "nonexistent-codex-" + Date.now()));
+    const files = await codexAdapter.discover();
+    expect(files).toEqual([]);
+    vi.mocked(os.homedir).mockRestore();
+  });
+
+  it("discover() deduplicates sessions with the same id across sessions/ and archived_sessions/", async () => {
+    const { default: codexAdapter } = await import("@/lib/adapters/codex");
+    // Copy fixture file into archived_sessions too
+    const archivedDir = path.join(FIXTURE_DIR, ".codex", "archived_sessions", "2025");
+    fs.mkdirSync(archivedDir, { recursive: true });
+    fs.copyFileSync(
+      path.join(SESSIONS_DIR, `${SESSION_ID}.jsonl`),
+      path.join(archivedDir, `${SESSION_ID}.jsonl`)
+    );
+
+    vi.spyOn(os, "homedir").mockReturnValue(FIXTURE_DIR);
+    const files = await codexAdapter.discover();
+    const ids = files.map((f) => f.filePath);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+    // Only one file despite appearing in both dirs
+    const matchingFiles = files.filter((f) => f.filePath.includes(SESSION_ID));
+    expect(matchingFiles.length).toBe(1);
+
+    vi.mocked(os.homedir).mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/lib/adapters/codex.ts` implementing the `SessionAdapter` interface for Codex CLI sessions
- `discover()` recursively walks `~/.codex/sessions/` and `~/.codex/archived_sessions/` in parallel, reading only the first line of each file via a 1024-byte buffer — no full file loads during discovery
- `parseFile()` translates Codex's event-stream JSONL format (`session_meta` / `turn_context` / `response_item` / `event_msg`) into `UsageTurn[]`
- Registered in the adapter registry alongside the `claude` adapter

## Token math
- Prefers `last_token_usage` per turn; falls back to delta from `total_token_usage` (running total minus previous)
- `cacheReadTokens = min(cached_input_tokens, input_tokens)`; `cacheCreateTokens` always 0 (Codex does not report cache creation)
- Project slug derived from `cwd` via `encodeProjectPath` + `toSlug` — same encoding as the scanner, so Codex sessions correlate correctly with project analytics

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1704 passed, 1 skipped (159 test files)
- [x] 5 new cases in `tests/codexAdapter.test.ts`: discover, source stamps, token math, empty-when-missing, dedup across sessions/ and archived_sessions/

## Notes
- DB ingest (`src/lib/db/ingest.ts`) still hardcodes Claude paths — Codex sessions are available in file-parse mode only. Routing ingest through the adapter registry is deferred to a follow-up.
- Cost estimates for Codex sessions use LiteLLM pricing (covers many OpenAI models); unknown models fall back to Claude Sonnet pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)