### PR TITLE
feat(wave10.2c): Gemini CLI adapter (TODO #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Project slug derived from `cwd` in session metadata via `encodeProjectPath` + `toSlug` — same encoding used by the scanner, so Codex sessions correlate with the correct project in analytics.
   - Help doc updated: Codex adapter status changed from "Coming" to "Active"; Codex-specific section added.
 
+- **Wave 10.2c — Cluster X (part 3): Gemini CLI adapter.** TODO #221.
+  - New `src/lib/adapters/gemini.ts`: `discover()` walks `~/.gemini/tmp/<project>/chats/session-*.json`. Project folder paths resolved from `~/.gemini/projects.json` (primary) or `.project_root` files (fallback for hashed-directory layouts used by newer Gemini CLI versions). `parseFile()` parses Gemini's JSON session format (user / gemini / info messages) into `UsageTurn[]`.
+  - Token math: per-turn deltas directly from `tokens.{input, output, cached}` on each gemini message. `cacheReadTokens = min(cached, input)`; `cacheCreateTokens` is always 0.
+  - Thoughts and tool calls extracted and included in assistant turn text and `toolCalls` array.
+  - `GEMINI_HOME` environment variable overrides `~/.gemini/` for custom installs.
+  - Help doc updated: Gemini CLI adapter status changed from "Coming" to "Active"; Gemini-specific section added.
+
 - **Wave 10.1c — Cluster W (part 3): Multi-agent swarm dispatch.** TODO #247.
   - New `ops_swarms` table (migration v5) with `name`, `mode` (`worktree`|`shared`), `project_path`, `status`, `completed_at`. Two new nullable columns on `ops_tasks`: `swarm_id` (FK → `ops_swarms`) and `swarm_role` (`member`|`coordinator`), added via `ALTER TABLE ADD COLUMN` — zero migration cost for existing rows.
   - **Swarm creation**: `createSwarm()` — single SQLite transaction creates the swarm row + 2–8 member tasks (with `worktreePath`/`projectPath` in metadata for worktree mode) + optional coordinator task with `task_dependencies` edges to every member.

--- a/docs/help/adapters.md
+++ b/docs/help/adapters.md
@@ -8,7 +8,7 @@ Project Minder reads AI coding-agent sessions through **adapters** — thin modu
 |---|---|---|
 | Claude Code | `claude` | Active |
 | Codex | `codex` | Active |
-| Gemini | `gemini` | Coming in Wave 10.2c |
+| Gemini CLI | `gemini` | Active |
 
 ## Codex adapter
 
@@ -23,6 +23,20 @@ To enable Codex alongside Claude Code:
 **Custom data location:** If your Codex data is not in `~/.codex/`, set the `CODEX_HOME` environment variable to the directory you want the adapter to scan. This takes precedence over the default `~/.codex/` path and is useful for CI environments or non-standard installs.
 
 Note: Codex does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Codex sessions. Cost estimates use OpenAI model pricing when available, falling back to Claude Sonnet pricing for unknown models.
+
+## Gemini CLI adapter
+
+The Gemini CLI adapter reads sessions from `~/.gemini/tmp/<project>/chats/session-*.json`. Each session file is a JSON document containing an array of messages. Project folder paths are resolved from `~/.gemini/projects.json` (which maps folder paths to project names) or from `.project_root` files written by newer Gemini CLI versions that use hashed directory names.
+
+To enable Gemini CLI alongside Claude Code:
+
+```json
+{ "enabledAdapters": ["claude", "gemini"] }
+```
+
+**Custom data location:** Set the `GEMINI_HOME` environment variable to override the default `~/.gemini/` path.
+
+Note: Gemini CLI does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Gemini sessions. Token values are treated as per-turn deltas. Cost estimates use Google model pricing when available.
 
 ## Managing adapters
 

--- a/public/help/adapters.md
+++ b/public/help/adapters.md
@@ -8,7 +8,7 @@ Project Minder reads AI coding-agent sessions through **adapters** — thin modu
 |---|---|---|
 | Claude Code | `claude` | Active |
 | Codex | `codex` | Active |
-| Gemini | `gemini` | Coming in Wave 10.2c |
+| Gemini CLI | `gemini` | Active |
 
 ## Codex adapter
 
@@ -23,6 +23,20 @@ To enable Codex alongside Claude Code:
 **Custom data location:** If your Codex data is not in `~/.codex/`, set the `CODEX_HOME` environment variable to the directory you want the adapter to scan. This takes precedence over the default `~/.codex/` path and is useful for CI environments or non-standard installs.
 
 Note: Codex does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Codex sessions. Cost estimates use OpenAI model pricing when available, falling back to Claude Sonnet pricing for unknown models.
+
+## Gemini CLI adapter
+
+The Gemini CLI adapter reads sessions from `~/.gemini/tmp/<project>/chats/session-*.json`. Each session file is a JSON document containing an array of messages. Project folder paths are resolved from `~/.gemini/projects.json` (which maps folder paths to project names) or from `.project_root` files written by newer Gemini CLI versions that use hashed directory names.
+
+To enable Gemini CLI alongside Claude Code:
+
+```json
+{ "enabledAdapters": ["claude", "gemini"] }
+```
+
+**Custom data location:** Set the `GEMINI_HOME` environment variable to override the default `~/.gemini/` path.
+
+Note: Gemini CLI does not report cache-creation tokens, so `cacheCreateTokens` will always be 0 for Gemini sessions. Token values are treated as per-turn deltas. Cost estimates use Google model pricing when available.
 
 ## Managing adapters
 

--- a/src/lib/adapters/codex.ts
+++ b/src/lib/adapters/codex.ts
@@ -6,6 +6,7 @@ import type { SessionAdapter, SessionFile } from "./types";
 import type { UsageTurn, ToolCall } from "@/lib/usage/types";
 import { encodeProjectPath } from "@/lib/usage/projectMatch";
 import { toSlug } from "@/lib/scanner/claudeConversations";
+import { TEXT_CAP, makeBaseTurn } from "./utils";
 
 const ADAPTER_ID = "codex" as const;
 const META_READ_CONCURRENCY = 16;
@@ -185,8 +186,6 @@ function createTurnState(): TurnState {
   return { parts: [], toolCalls: [], inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, model: null };
 }
 
-const TEXT_CAP = 500;
-
 async function parseCodexFile(filePath: string, fallbackProjectDirName: string): Promise<UsageTurn[]> {
   let content: string;
   try {
@@ -219,14 +218,7 @@ async function parseCodexFile(filePath: string, fallbackProjectDirName: string):
   let previousTotals: RawUsage | null = null;
   let currentTurn: TurnState = createTurnState();
 
-  const baseTurn = () => ({
-    timestamp: sessionTimestamp,
-    sessionId,
-    projectSlug,
-    projectDirName,
-    cacheCreateTokens: 0 as const,
-    source: ADAPTER_ID,
-  });
+  const baseTurn = () => makeBaseTurn(ADAPTER_ID, sessionTimestamp, sessionId, projectSlug, projectDirName);
 
   function flushTurn() {
     const hasContent = currentTurn.parts.length > 0;

--- a/src/lib/adapters/gemini.ts
+++ b/src/lib/adapters/gemini.ts
@@ -5,9 +5,9 @@ import type { SessionAdapter, SessionFile } from "./types";
 import type { UsageTurn, ToolCall } from "@/lib/usage/types";
 import { encodeProjectPath } from "@/lib/usage/projectMatch";
 import { toSlug } from "@/lib/scanner/claudeConversations";
+import { TEXT_CAP, makeBaseTurn } from "./utils";
 
 const ADAPTER_ID = "gemini" as const;
-const TEXT_CAP = 500;
 
 // ─── project map ─────────────────────────────────────────────────────────────
 
@@ -84,7 +84,7 @@ function extractTokens(raw: unknown): { inputTokens: number; outputTokens: numbe
 
 // ─── file parser ──────────────────────────────────────────────────────────────
 
-async function parseGeminiFile(filePath: string, fallbackProjectDirName: string): Promise<UsageTurn[]> {
+async function parseGeminiFile(filePath: string, projectDirName: string): Promise<UsageTurn[]> {
   let content: string;
   try {
     content = await fs.readFile(filePath, "utf-8");
@@ -112,17 +112,8 @@ async function parseGeminiFile(filePath: string, fallbackProjectDirName: string)
     (typeof record.startTime === "string" && record.startTime.trim() ? record.startTime : null) ??
     (await fs.stat(filePath).then((s) => s.mtime.toISOString()).catch(() => new Date().toISOString()));
 
-  const projectDirName = fallbackProjectDirName;
   const projectSlug = toSlug(projectDirName);
-
-  const baseTurn = () => ({
-    timestamp: sessionTimestamp,
-    sessionId,
-    projectSlug,
-    projectDirName,
-    cacheCreateTokens: 0 as const,
-    source: ADAPTER_ID,
-  });
+  const baseTurn = () => makeBaseTurn(ADAPTER_ID, sessionTimestamp, sessionId, projectSlug, projectDirName);
 
   const turns: UsageTurn[] = [];
 
@@ -150,7 +141,6 @@ async function parseGeminiFile(filePath: string, fallbackProjectDirName: string)
     if (type === "gemini") {
       const { inputTokens, outputTokens, cacheReadTokens } = extractTokens(m.tokens);
 
-      // Build text parts from thoughts + main content
       const parts: string[] = [];
       if (m.thoughts && Array.isArray(m.thoughts)) {
         for (const t of m.thoughts as unknown[]) {
@@ -165,7 +155,6 @@ async function parseGeminiFile(filePath: string, fallbackProjectDirName: string)
       const mainText = extractTextContent(m.content ?? m.displayContent);
       if (mainText) parts.push(mainText);
 
-      // Build tool calls
       const toolCalls: ToolCall[] = [];
       if (Array.isArray(m.toolCalls)) {
         for (const tc of m.toolCalls as unknown[]) {
@@ -180,13 +169,11 @@ async function parseGeminiFile(filePath: string, fallbackProjectDirName: string)
         }
       }
 
-      // Skip gemini turns with no content and no tokens
       const hasContent = parts.length > 0 || toolCalls.length > 0;
       const hasTokens = inputTokens > 0 || outputTokens > 0 || cacheReadTokens > 0;
       if (!hasContent && !hasTokens) continue;
 
-      const model =
-        typeof m.model === "string" && m.model.trim() ? m.model : "unknown";
+      const model = typeof m.model === "string" && m.model.trim() ? m.model : "unknown";
 
       turns.push({
         ...baseTurn(),
@@ -220,8 +207,6 @@ const geminiAdapter: SessionAdapter = {
         : path.join(os.homedir(), ".gemini");
 
     const tmpDir = path.join(geminiHome, "tmp");
-
-    // projName → folderPath (from projects.json)
     const projectMap = await loadProjectMap(geminiHome);
 
     let projectEntries: import("fs").Dirent[];
@@ -231,41 +216,40 @@ const geminiAdapter: SessionAdapter = {
       return [];
     }
 
-    const files: SessionFile[] = [];
+    const results = await Promise.all(
+      projectEntries
+        .filter((entry) => entry.isDirectory())
+        .map(async (entry): Promise<SessionFile[]> => {
+          const projName = entry.name;
+          const projDir = path.join(tmpDir, projName);
+          const chatsDir = path.join(projDir, "chats");
 
-    for (const entry of projectEntries) {
-      if (!entry.isDirectory()) continue;
-      const projName = entry.name;
-      const projDir = path.join(tmpDir, projName);
-      const chatsDir = path.join(projDir, "chats");
+          let chatFiles: string[];
+          try {
+            const entries = await fs.readdir(chatsDir);
+            chatFiles = entries.filter((f) => f.startsWith("session-") && f.endsWith(".json"));
+          } catch {
+            return [];
+          }
+          if (chatFiles.length === 0) return [];
 
-      let chatFiles: string[];
-      try {
-        const entries = await fs.readdir(chatsDir);
-        chatFiles = entries.filter((f) => f.startsWith("session-") && f.endsWith(".json"));
-      } catch {
-        continue;
-      }
-      if (chatFiles.length === 0) continue;
+          // Resolve project folder path: projects.json → .project_root → fallback to dir name
+          const folderPath =
+            projectMap.get(projName) ??
+            (await readProjectRoot(projDir)) ??
+            null;
 
-      // Resolve project folder path: projects.json → .project_root → fallback to dir name
-      const folderPath =
-        projectMap.get(projName) ??
-        (await readProjectRoot(projDir)) ??
-        null;
+          const projectDirName = folderPath ? encodeProjectPath(folderPath) : projName;
 
-      const projectDirName = folderPath ? encodeProjectPath(folderPath) : projName;
+          return chatFiles.map((file) => ({
+            source: ADAPTER_ID,
+            filePath: path.join(chatsDir, file),
+            projectDirName,
+          }));
+        })
+    );
 
-      for (const file of chatFiles) {
-        files.push({
-          source: ADAPTER_ID,
-          filePath: path.join(chatsDir, file),
-          projectDirName,
-        });
-      }
-    }
-
-    return files;
+    return results.flat();
   },
 
   async parseFile(file: SessionFile): Promise<UsageTurn[]> {

--- a/src/lib/adapters/gemini.ts
+++ b/src/lib/adapters/gemini.ts
@@ -113,7 +113,6 @@ async function parseGeminiFile(filePath: string, projectDirName: string): Promis
     (await fs.stat(filePath).then((s) => s.mtime.toISOString()).catch(() => new Date().toISOString()));
 
   const projectSlug = toSlug(projectDirName);
-  const baseTurn = () => makeBaseTurn(ADAPTER_ID, sessionTimestamp, sessionId, projectSlug, projectDirName);
 
   const turns: UsageTurn[] = [];
 
@@ -121,6 +120,15 @@ async function parseGeminiFile(filePath: string, projectDirName: string): Promis
     if (!msg || typeof msg !== "object" || Array.isArray(msg)) continue;
     const m = msg as Record<string, unknown>;
     const type = m.type;
+
+    // Use per-message timestamp when present; fall back to session startTime.
+    // Gemini sessions can span hours, so per-message timestamps keep hourly
+    // and daily analytics accurate.
+    const turnTimestamp =
+      (typeof m.timestamp === "string" && m.timestamp.trim() ? m.timestamp : null) ??
+      sessionTimestamp;
+
+    const baseTurn = () => makeBaseTurn(ADAPTER_ID, turnTimestamp, sessionId, projectSlug, projectDirName);
 
     if (type === "user") {
       const text = extractTextContent(m.content ?? m.displayContent);
@@ -165,7 +173,8 @@ async function parseGeminiFile(filePath: string, projectDirName: string): Promis
             t.args && typeof t.args === "object" && !Array.isArray(t.args)
               ? (t.args as Record<string, unknown>)
               : {};
-          toolCalls.push({ name, arguments: args });
+          const isError = t.status === "error" ? true : undefined;
+          toolCalls.push({ name, arguments: args, isError });
         }
       }
 
@@ -185,10 +194,8 @@ async function parseGeminiFile(filePath: string, projectDirName: string): Promis
         toolCalls,
         assistantText: parts.join("\n").slice(0, TEXT_CAP) || undefined,
       });
-      continue;
     }
-
-    // Skip info / error / warning messages
+    // All other message types (info, error, warning) carry no turn data.
   }
 
   return turns;

--- a/src/lib/adapters/gemini.ts
+++ b/src/lib/adapters/gemini.ts
@@ -1,0 +1,276 @@
+import path from "path";
+import os from "os";
+import { promises as fs } from "fs";
+import type { SessionAdapter, SessionFile } from "./types";
+import type { UsageTurn, ToolCall } from "@/lib/usage/types";
+import { encodeProjectPath } from "@/lib/usage/projectMatch";
+import { toSlug } from "@/lib/scanner/claudeConversations";
+
+const ADAPTER_ID = "gemini" as const;
+const TEXT_CAP = 500;
+
+// ─── project map ─────────────────────────────────────────────────────────────
+
+// Loads ~/.gemini/projects.json and returns projName → folderPath mapping.
+// Format: { "projects": { "/path/to/folder": "projName" } }
+async function loadProjectMap(geminiHome: string): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  try {
+    const raw = await fs.readFile(path.join(geminiHome, "projects.json"), "utf-8");
+    const data = JSON.parse(raw) as { projects?: Record<string, unknown> };
+    if (data.projects && typeof data.projects === "object") {
+      for (const [folderPath, projName] of Object.entries(data.projects)) {
+        if (typeof projName === "string" && projName && typeof folderPath === "string") {
+          map.set(projName, folderPath);
+        }
+      }
+    }
+  } catch {
+    // projects.json may not exist or be unreadable
+  }
+  return map;
+}
+
+// Newer Gemini CLI versions use hashed directory names and write the actual
+// project path into a .project_root file in the same directory.
+async function readProjectRoot(projDir: string): Promise<string | null> {
+  try {
+    const content = await fs.readFile(path.join(projDir, ".project_root"), "utf-8");
+    const p = content.trim();
+    return p || null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── parsing helpers ──────────────────────────────────────────────────────────
+
+function extractTextContent(content: unknown): string {
+  if (!content) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return (content as unknown[])
+      .filter((p): p is Record<string, unknown> => !!p && typeof p === "object" && !Array.isArray(p))
+      .filter((p) => typeof p.text === "string" && p.text)
+      .map((p) => (p.text as string).trim())
+      .join("\n")
+      .trim();
+  }
+  if (typeof (content as Record<string, unknown>).text === "string") {
+    return ((content as Record<string, unknown>).text as string).trim();
+  }
+  return "";
+}
+
+// Token values in Gemini session files are per-turn deltas, not cumulative totals.
+// If this assumption proves wrong for a specific Gemini CLI version, the fix is
+// to add subtraction logic here (same as Codex's subtractRawUsage pattern).
+function extractTokens(raw: unknown): { inputTokens: number; outputTokens: number; cacheReadTokens: number } {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0 };
+  }
+  const t = raw as Record<string, unknown>;
+  const n = (x: unknown) => (typeof x === "number" && Number.isFinite(x) ? x : 0);
+  const rawInput = n(t.input);
+  const rawCached = n(t.cached);
+  const rawOutput = n(t.output);
+  const cacheReadTokens = Math.min(rawCached, rawInput);
+  return {
+    inputTokens: Math.max(rawInput - cacheReadTokens, 0),
+    outputTokens: rawOutput,
+    cacheReadTokens,
+  };
+}
+
+// ─── file parser ──────────────────────────────────────────────────────────────
+
+async function parseGeminiFile(filePath: string, fallbackProjectDirName: string): Promise<UsageTurn[]> {
+  let content: string;
+  try {
+    content = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  let record: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+    record = parsed as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(record.messages)) return [];
+
+  const sessionId =
+    typeof record.sessionId === "string" && record.sessionId.trim()
+      ? record.sessionId
+      : path.basename(filePath, ".json");
+
+  const sessionTimestamp =
+    (typeof record.startTime === "string" && record.startTime.trim() ? record.startTime : null) ??
+    (await fs.stat(filePath).then((s) => s.mtime.toISOString()).catch(() => new Date().toISOString()));
+
+  const projectDirName = fallbackProjectDirName;
+  const projectSlug = toSlug(projectDirName);
+
+  const baseTurn = () => ({
+    timestamp: sessionTimestamp,
+    sessionId,
+    projectSlug,
+    projectDirName,
+    cacheCreateTokens: 0 as const,
+    source: ADAPTER_ID,
+  });
+
+  const turns: UsageTurn[] = [];
+
+  for (const msg of record.messages as unknown[]) {
+    if (!msg || typeof msg !== "object" || Array.isArray(msg)) continue;
+    const m = msg as Record<string, unknown>;
+    const type = m.type;
+
+    if (type === "user") {
+      const text = extractTextContent(m.content ?? m.displayContent);
+      if (!text) continue;
+      turns.push({
+        ...baseTurn(),
+        model: "unknown",
+        role: "user",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        toolCalls: [],
+        userMessageText: text.slice(0, TEXT_CAP),
+      });
+      continue;
+    }
+
+    if (type === "gemini") {
+      const { inputTokens, outputTokens, cacheReadTokens } = extractTokens(m.tokens);
+
+      // Build text parts from thoughts + main content
+      const parts: string[] = [];
+      if (m.thoughts && Array.isArray(m.thoughts)) {
+        for (const t of m.thoughts as unknown[]) {
+          if (!t || typeof t !== "object" || Array.isArray(t)) continue;
+          const thought = t as Record<string, unknown>;
+          const desc =
+            typeof thought.description === "string" ? thought.description.trim() :
+            typeof thought.subject === "string" ? thought.subject.trim() : "";
+          if (desc) parts.push(desc);
+        }
+      }
+      const mainText = extractTextContent(m.content ?? m.displayContent);
+      if (mainText) parts.push(mainText);
+
+      // Build tool calls
+      const toolCalls: ToolCall[] = [];
+      if (Array.isArray(m.toolCalls)) {
+        for (const tc of m.toolCalls as unknown[]) {
+          if (!tc || typeof tc !== "object" || Array.isArray(tc)) continue;
+          const t = tc as Record<string, unknown>;
+          const name = typeof t.name === "string" && t.name ? t.name : "tool";
+          const args: Record<string, unknown> =
+            t.args && typeof t.args === "object" && !Array.isArray(t.args)
+              ? (t.args as Record<string, unknown>)
+              : {};
+          toolCalls.push({ name, arguments: args });
+        }
+      }
+
+      // Skip gemini turns with no content and no tokens
+      const hasContent = parts.length > 0 || toolCalls.length > 0;
+      const hasTokens = inputTokens > 0 || outputTokens > 0 || cacheReadTokens > 0;
+      if (!hasContent && !hasTokens) continue;
+
+      const model =
+        typeof m.model === "string" && m.model.trim() ? m.model : "unknown";
+
+      turns.push({
+        ...baseTurn(),
+        model,
+        role: "assistant",
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        toolCalls,
+        assistantText: parts.join("\n").slice(0, TEXT_CAP) || undefined,
+      });
+      continue;
+    }
+
+    // Skip info / error / warning messages
+  }
+
+  return turns;
+}
+
+// ─── adapter ─────────────────────────────────────────────────────────────────
+
+const geminiAdapter: SessionAdapter = {
+  id: ADAPTER_ID,
+  displayName: "Gemini CLI",
+
+  async discover(): Promise<SessionFile[]> {
+    const geminiHome =
+      typeof process.env.GEMINI_HOME === "string" && process.env.GEMINI_HOME.trim()
+        ? path.resolve(process.env.GEMINI_HOME.trim())
+        : path.join(os.homedir(), ".gemini");
+
+    const tmpDir = path.join(geminiHome, "tmp");
+
+    // projName → folderPath (from projects.json)
+    const projectMap = await loadProjectMap(geminiHome);
+
+    let projectEntries: import("fs").Dirent[];
+    try {
+      projectEntries = await fs.readdir(tmpDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+
+    const files: SessionFile[] = [];
+
+    for (const entry of projectEntries) {
+      if (!entry.isDirectory()) continue;
+      const projName = entry.name;
+      const projDir = path.join(tmpDir, projName);
+      const chatsDir = path.join(projDir, "chats");
+
+      let chatFiles: string[];
+      try {
+        const entries = await fs.readdir(chatsDir);
+        chatFiles = entries.filter((f) => f.startsWith("session-") && f.endsWith(".json"));
+      } catch {
+        continue;
+      }
+      if (chatFiles.length === 0) continue;
+
+      // Resolve project folder path: projects.json → .project_root → fallback to dir name
+      const folderPath =
+        projectMap.get(projName) ??
+        (await readProjectRoot(projDir)) ??
+        null;
+
+      const projectDirName = folderPath ? encodeProjectPath(folderPath) : projName;
+
+      for (const file of chatFiles) {
+        files.push({
+          source: ADAPTER_ID,
+          filePath: path.join(chatsDir, file),
+          projectDirName,
+        });
+      }
+    }
+
+    return files;
+  },
+
+  async parseFile(file: SessionFile): Promise<UsageTurn[]> {
+    return parseGeminiFile(file.filePath, file.projectDirName);
+  },
+};
+
+export default geminiAdapter;

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -2,6 +2,7 @@ import type { SessionAdapter, SessionFile } from "./types";
 import type { MinderConfig } from "@/lib/types";
 import claudeAdapter from "./claude";
 import codexAdapter from "./codex";
+import geminiAdapter from "./gemini";
 
 const REGISTRY = new Map<string, SessionAdapter>();
 
@@ -11,6 +12,7 @@ function register(adapter: SessionAdapter): void {
 
 register(claudeAdapter);
 register(codexAdapter);
+register(geminiAdapter);
 
 export function listAdapters(): SessionAdapter[] {
   return [...REGISTRY.values()];

--- a/src/lib/adapters/utils.ts
+++ b/src/lib/adapters/utils.ts
@@ -1,0 +1,20 @@
+/** Text capture limit applied to userMessageText and assistantText in every adapter. */
+export const TEXT_CAP = 500;
+
+/** Shared base fields emitted on every UsageTurn by all adapters. */
+export function makeBaseTurn(
+  source: string,
+  timestamp: string,
+  sessionId: string,
+  projectSlug: string,
+  projectDirName: string
+): {
+  source: string;
+  timestamp: string;
+  sessionId: string;
+  projectSlug: string;
+  projectDirName: string;
+  cacheCreateTokens: 0;
+} {
+  return { source, timestamp, sessionId, projectSlug, projectDirName, cacheCreateTokens: 0 };
+}

--- a/tests/geminiAdapter.test.ts
+++ b/tests/geminiAdapter.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
+import path from "path";
+import os from "os";
+import fs from "fs";
+
+const FIXTURE_DIR = path.join(os.tmpdir(), "gemini-adapter-test-" + Date.now());
+const TMP_DIR = path.join(FIXTURE_DIR, ".gemini", "tmp");
+
+const PROJECT_NAME = "my-project";
+const PROJECT_FOLDER = "/home/user/my-project";
+const SESSION_ID = "session-abc123";
+
+const SAMPLE_SESSION = {
+  sessionId: SESSION_ID,
+  startTime: "2025-06-01T10:00:00Z",
+  lastUpdated: "2025-06-01T10:05:00Z",
+  messages: [
+    {
+      type: "user",
+      content: [{ text: "Hello from Gemini" }],
+    },
+    {
+      type: "gemini",
+      content: "Hi there from Gemini",
+      model: "gemini-2.0-flash",
+      tokens: { input: 20, cached: 5, output: 8 },
+      toolCalls: [],
+    },
+    {
+      type: "info",
+      content: "Some informational message",
+    },
+  ],
+};
+
+const PROJECTS_JSON = {
+  projects: {
+    [PROJECT_FOLDER]: PROJECT_NAME,
+  },
+};
+
+beforeAll(() => {
+  const chatsDir = path.join(TMP_DIR, PROJECT_NAME, "chats");
+  fs.mkdirSync(chatsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(chatsDir, `${SESSION_ID}.json`),
+    JSON.stringify(SAMPLE_SESSION),
+    "utf-8"
+  );
+  fs.writeFileSync(
+    path.join(FIXTURE_DIR, ".gemini", "projects.json"),
+    JSON.stringify(PROJECTS_JSON),
+    "utf-8"
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+});
+
+describe("gemini adapter", () => {
+  it("discover() finds session JSON files under tmp/<proj>/chats/", async () => {
+    const { default: geminiAdapter } = await import("@/lib/adapters/gemini");
+    vi.spyOn(os, "homedir").mockReturnValue(FIXTURE_DIR);
+
+    const files = await geminiAdapter.discover();
+    expect(files.length).toBeGreaterThan(0);
+    expect(files[0].source).toBe("gemini");
+    expect(files[0].filePath).toContain(`${SESSION_ID}.json`);
+  });
+
+  it("discover() resolves projectDirName from projects.json", async () => {
+    const { default: geminiAdapter } = await import("@/lib/adapters/gemini");
+    vi.spyOn(os, "homedir").mockReturnValue(FIXTURE_DIR);
+
+    const files = await geminiAdapter.discover();
+    expect(files.length).toBeGreaterThan(0);
+    // encodeProjectPath("/home/user/my-project") → "-home-user-my-project"
+    expect(files[0].projectDirName).toContain("my-project");
+  });
+
+  it("parseFile() stamps source: 'gemini' on every turn", async () => {
+    const { default: geminiAdapter } = await import("@/lib/adapters/gemini");
+    const filePath = path.join(TMP_DIR, PROJECT_NAME, "chats", `${SESSION_ID}.json`);
+    const file = { source: "gemini", filePath, projectDirName: "home-user-my-project" };
+
+    const turns = await geminiAdapter.parseFile(file);
+    expect(turns.length).toBeGreaterThan(0);
+    for (const t of turns) {
+      expect(t.source).toBe("gemini");
+    }
+  });
+
+  it("parseFile() produces user and assistant turns with correct token data", async () => {
+    const { default: geminiAdapter } = await import("@/lib/adapters/gemini");
+    const filePath = path.join(TMP_DIR, PROJECT_NAME, "chats", `${SESSION_ID}.json`);
+    const file = { source: "gemini", filePath, projectDirName: "home-user-my-project" };
+
+    const turns = await geminiAdapter.parseFile(file);
+
+    const user = turns.find((t) => t.role === "user");
+    const assistant = turns.find((t) => t.role === "assistant");
+
+    expect(user).toBeDefined();
+    expect(user!.userMessageText).toContain("Hello from Gemini");
+
+    expect(assistant).toBeDefined();
+    expect(assistant!.model).toBe("gemini-2.0-flash");
+    // cacheReadTokens = min(5, 20) = 5; inputTokens = 20 - 5 = 15
+    expect(assistant!.cacheReadTokens).toBe(5);
+    expect(assistant!.inputTokens).toBe(15);
+    expect(assistant!.outputTokens).toBe(8);
+    expect(assistant!.cacheCreateTokens).toBe(0);
+  });
+
+  it("parseFile() skips info/error/warning messages", async () => {
+    const { default: geminiAdapter } = await import("@/lib/adapters/gemini");
+    const filePath = path.join(TMP_DIR, PROJECT_NAME, "chats", `${SESSION_ID}.json`);
+    const file = { source: "gemini", filePath, projectDirName: "home-user-my-project" };
+
+    const turns = await geminiAdapter.parseFile(file);
+    const roles = turns.map((t) => t.role);
+    // Only user and assistant — no system/info turns
+    expect(roles.every((r) => r === "user" || r === "assistant")).toBe(true);
+    expect(turns.length).toBe(2);
+  });
+
+  it("discover() returns empty list when .gemini/tmp does not exist", async () => {
+    const { default: geminiAdapter } = await import("@/lib/adapters/gemini");
+    vi.spyOn(os, "homedir").mockReturnValue(
+      path.join(os.tmpdir(), "nonexistent-gemini-" + Date.now())
+    );
+
+    const files = await geminiAdapter.discover();
+    expect(files).toEqual([]);
+  });
+
+  it("discover() falls back to .project_root when not in projects.json", async () => {
+    const { default: geminiAdapter } = await import("@/lib/adapters/gemini");
+    // Create a hashed-name project dir with .project_root but no projects.json entry
+    const hashedName = "abc123hash";
+    const hashedChatsDir = path.join(TMP_DIR, hashedName, "chats");
+    fs.mkdirSync(hashedChatsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(TMP_DIR, hashedName, ".project_root"),
+      "/home/user/other-project",
+      "utf-8"
+    );
+    fs.writeFileSync(
+      path.join(hashedChatsDir, "session-xyz.json"),
+      JSON.stringify({ ...SAMPLE_SESSION, sessionId: "session-xyz" }),
+      "utf-8"
+    );
+
+    vi.spyOn(os, "homedir").mockReturnValue(FIXTURE_DIR);
+
+    const files = await geminiAdapter.discover();
+    const hashedFile = files.find((f) => f.filePath.includes("session-xyz"));
+    expect(hashedFile).toBeDefined();
+    // encodeProjectPath("/home/user/other-project") → "-home-user-other-project"
+    expect(hashedFile!.projectDirName).toContain("other-project");
+  });
+});

--- a/tests/geminiAdapter.test.ts
+++ b/tests/geminiAdapter.test.ts
@@ -3,7 +3,7 @@ import path from "path";
 import os from "os";
 import fs from "fs";
 
-const FIXTURE_DIR = path.join(os.tmpdir(), "gemini-adapter-test-" + Date.now());
+const FIXTURE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-adapter-test-"));
 const TMP_DIR = path.join(FIXTURE_DIR, ".gemini", "tmp");
 
 const PROJECT_NAME = "my-project";


### PR DESCRIPTION
## Summary

- New `src/lib/adapters/gemini.ts` — Gemini CLI `SessionAdapter` implementation. `discover()` walks `~/.gemini/tmp/<proj>/chats/session-*.json`, resolving project paths from `~/.gemini/projects.json` (primary) or `.project_root` files (fallback for newer Gemini CLI hashed-directory layouts). `parseFile()` reads Gemini's JSON session format into `UsageTurn[]`.
- Token math: per-turn deltas from `tokens.{input, output, cached}`; `cacheReadTokens = min(cached, input)`; `cacheCreateTokens = 0`. Thoughts and tool calls extracted into text/toolCalls fields.
- `GEMINI_HOME` env var overrides `~/.gemini/` path.
- 7 tests in `tests/geminiAdapter.test.ts`: discover, parseFile, token math, info-message filtering, empty-dir handling, `.project_root` fallback.
- Adapter registered in `src/lib/adapters/index.ts`.
- Help doc updated: status "Coming" → "Active", Gemini-specific section added.
- CHANGELOG updated.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1711 tests passing, 1 skipped (via pre-commit hook)
- [ ] Enable Gemini via `{ "enabledAdapters": ["claude", "gemini"] }` in `.minder.json` — verify "Gemini CLI" badge appears in sessions browser (requires real Gemini session files)
- [ ] `/settings#adapters` shows Gemini listed as Active

## Notes

No Gemini session files exist on this machine (all `~/.gemini/tmp/*/chats/` directories are empty), so token semantics (per-turn vs cumulative) are assumed per-turn based on the reference implementation. A comment in `extractTokens()` documents this assumption and points to the Codex `subtractRawUsage` pattern as the fix if cumulative turns out to be the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)