### PR TITLE
feat(wave11.2b): curated template library + new-project wizard (#77, #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Wave 11.2b — Cluster Z (part 2): Curated template library and new-project wizard.**
+  - **#77 Curated template library**: `/library` page with 16 production-ready library items (5 commands, 7 skills, 4 agents). Items are inlined as TypeScript strings in `src/lib/template/library/index.ts` — no runtime fs reads. Apply any item to an existing project via `source.kind: "library"` in the apply endpoint. New `applyFromLibrary` dispatcher writes content to a temp dir and re-enters the existing apply primitives; temp dir is always cleaned up. Filter by kind (Command/Skill/Agent), search by name/description/tag, Apply or Preview per item.
+  - **#78 New-project wizard**: `/new-project` 4-step wizard: (1) name + folder; (2) stack selector (TypeScript / Python / Go / Rust); (3) library item selection with stack-based presets; (4) confirm → create. `POST /api/projects/new` bootstraps the directory, runs `git init`, and applies selected library items. Dashboard toolbar gets a **New** button; AppNav gets a **+ New** root link.
+
 - **Wave 11.2a — Cluster Z (part 1): Plugin-bundled hooks, bundled-skill UI polish, shareable stats image, GSD project planning tab.**
   - **#76 Plugin-bundled hooks**: Plugins can ship `hooks/hooks.json`; entries surface with a `plugin` provenance badge and are read-only. Wired via new `src/lib/scanner/pluginHooks.ts` (mirrors `pluginMcp.ts`). `HookSource` union widened to `"project" | "local" | "user" | "plugin"`.
   - **#70 Bundled-skill UI polish**: `ApplyResult` gains a structured `bundle?: { rootName, files, totalBytes }` field. `applyDirectory` populates it on both dry-run and real apply. `ApplyUnitButton` and `ApplyTemplateModal` render a `BundleTree` (📁/📄 file tree) when `bundle` is present, replacing the `<pre>` text wall.

--- a/docs/help/library.md
+++ b/docs/help/library.md
@@ -1,0 +1,35 @@
+# Library
+
+The Library is a curated collection of production-ready Claude Code configuration files — commands, skills, and agents — that ship with Project Minder and can be applied to any of your projects with one click.
+
+## What's in the library
+
+| Kind | Examples |
+|------|----------|
+| **Commands** | `/review`, `/commit`, `/debug`, `/test-gen`, `/document` |
+| **Skills** | `code-reviewer`, `test-writer`, `doc-writer`, `security-auditor`, `git-workflow`, `pr-reviewer`, `refactorer` |
+| **Agents** | `backend-architect`, `security-reviewer`, `test-engineer`, `code-explainer` |
+
+## Applying a library item
+
+1. Open **Catalog → Library**
+2. Find the item you want (search by name, description, or tag; filter by kind)
+3. Click a row to expand it
+4. Choose the target project from the dropdown
+5. Click **Preview** to see what would change (dry-run), or **Apply** to write the file
+
+Applied items use the `skip` conflict policy — if the file already exists in your project, it won't be overwritten.
+
+## Via the New Project wizard
+
+When you create a new project through **+ New** → **New Project**, you can select library items on the "Items" step. The chosen items are applied automatically after the project directory is created.
+
+## File locations
+
+Library items are written to the standard Claude Code config locations within your project:
+
+| Kind | Destination |
+|------|-------------|
+| Command | `.claude/commands/<name>.md` |
+| Skill | `.claude/skills/<name>.md` |
+| Agent | `.claude/agents/<name>.md` |

--- a/docs/help/new-project.md
+++ b/docs/help/new-project.md
@@ -1,0 +1,28 @@
+# New Project
+
+The New Project wizard creates a new project directory under your devRoot and optionally populates it with curated library items in one guided flow.
+
+## Steps
+
+1. **Details** — Enter a display name and folder name. The folder name is auto-derived from the display name but can be overridden. The folder is created at `devRoot/<folder-name>`.
+
+2. **Stack** — Choose your primary language (TypeScript, Python, Go, or Rust). This pre-selects relevant library items on the next step.
+
+3. **Items** — Review and adjust the pre-selected library items. Any item in the Library can be added or removed. These will be applied to your new project after creation.
+
+4. **Confirm** — Review your choices and click **Create project**. The wizard:
+   - Creates the directory
+   - Runs `git init`
+   - Applies all selected library items (using `skip` conflict policy)
+   - Redirects you to the dashboard where the new project appears
+
+## Access
+
+- Dashboard toolbar → **New** button
+- AppNav → **+ New**
+
+## Notes
+
+- The wizard only creates the project directory and applies Claude Code config files. It does not scaffold application code, install packages, or set up a framework — use your language's standard tooling for that.
+- If the target directory already exists, the wizard will show an error on the Confirm step.
+- Library items are applied with `conflict: "skip"` — existing files are never overwritten.

--- a/public/help/library.md
+++ b/public/help/library.md
@@ -1,0 +1,35 @@
+# Library
+
+The Library is a curated collection of production-ready Claude Code configuration files — commands, skills, and agents — that ship with Project Minder and can be applied to any of your projects with one click.
+
+## What's in the library
+
+| Kind | Examples |
+|------|----------|
+| **Commands** | `/review`, `/commit`, `/debug`, `/test-gen`, `/document` |
+| **Skills** | `code-reviewer`, `test-writer`, `doc-writer`, `security-auditor`, `git-workflow`, `pr-reviewer`, `refactorer` |
+| **Agents** | `backend-architect`, `security-reviewer`, `test-engineer`, `code-explainer` |
+
+## Applying a library item
+
+1. Open **Catalog → Library**
+2. Find the item you want (search by name, description, or tag; filter by kind)
+3. Click a row to expand it
+4. Choose the target project from the dropdown
+5. Click **Preview** to see what would change (dry-run), or **Apply** to write the file
+
+Applied items use the `skip` conflict policy — if the file already exists in your project, it won't be overwritten.
+
+## Via the New Project wizard
+
+When you create a new project through **+ New** → **New Project**, you can select library items on the "Items" step. The chosen items are applied automatically after the project directory is created.
+
+## File locations
+
+Library items are written to the standard Claude Code config locations within your project:
+
+| Kind | Destination |
+|------|-------------|
+| Command | `.claude/commands/<name>.md` |
+| Skill | `.claude/skills/<name>.md` |
+| Agent | `.claude/agents/<name>.md` |

--- a/public/help/new-project.md
+++ b/public/help/new-project.md
@@ -1,0 +1,28 @@
+# New Project
+
+The New Project wizard creates a new project directory under your devRoot and optionally populates it with curated library items in one guided flow.
+
+## Steps
+
+1. **Details** — Enter a display name and folder name. The folder name is auto-derived from the display name but can be overridden. The folder is created at `devRoot/<folder-name>`.
+
+2. **Stack** — Choose your primary language (TypeScript, Python, Go, or Rust). This pre-selects relevant library items on the next step.
+
+3. **Items** — Review and adjust the pre-selected library items. Any item in the Library can be added or removed. These will be applied to your new project after creation.
+
+4. **Confirm** — Review your choices and click **Create project**. The wizard:
+   - Creates the directory
+   - Runs `git init`
+   - Applies all selected library items (using `skip` conflict policy)
+   - Redirects you to the dashboard where the new project appears
+
+## Access
+
+- Dashboard toolbar → **New** button
+- AppNav → **+ New**
+
+## Notes
+
+- The wizard only creates the project directory and applies Claude Code config files. It does not scaffold application code, install packages, or set up a framework — use your language's standard tooling for that.
+- If the target directory already exists, the wizard will show an error on the Confirm step.
+- Library items are applied with `conflict: "skip"` — existing files are never overwritten.

--- a/src/app/api/claude-config/apply/route.ts
+++ b/src/app/api/claude-config/apply/route.ts
@@ -57,8 +57,12 @@ function validateRequest(body: unknown):
     if (typeof s.slug !== "string" || s.slug.length === 0) {
       return err("INVALID_SOURCE_SLUG", "source.slug must be a non-empty string.");
     }
+  } else if (s.kind === "library") {
+    if (typeof s.libraryId !== "string" || s.libraryId.length === 0) {
+      return err("INVALID_LIBRARY_ID", "source.libraryId must be a non-empty string.");
+    }
   } else if (s.kind !== "user") {
-    return err("INVALID_SOURCE_KIND", 'source.kind must be "project" or "user".');
+    return err("INVALID_SOURCE_KIND", 'source.kind must be "project", "user", or "library".');
   }
 
   // target
@@ -85,6 +89,8 @@ function validateRequest(body: unknown):
       source:
         s.kind === "project"
           ? { kind: "project", slug: s.slug as string }
+          : s.kind === "library"
+          ? { kind: "library", libraryId: s.libraryId as string }
           : { kind: "user" },
       target: { kind: "existing", slug: t.slug as string },
       conflict: b.conflict as ConflictPolicy,

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { LIBRARY, STACK_PRESETS } from "@/lib/template/library";
+
+export type LibraryIndexItem = {
+  id: string;
+  kind: string;
+  slug: string;
+  name: string;
+  description: string;
+  tags: string[];
+  stacks: string[];
+};
+
+export type LibraryResponse = {
+  items: LibraryIndexItem[];
+  stackPresets: Record<string, string[]>;
+};
+
+export async function GET() {
+  const items: LibraryIndexItem[] = LIBRARY.map(({ id, kind, slug, name, description, tags, stacks }) => ({
+    id,
+    kind,
+    slug,
+    name,
+    description,
+    tags,
+    stacks,
+  }));
+  return NextResponse.json({ items, stackPresets: STACK_PRESETS } satisfies LibraryResponse);
+}

--- a/src/app/api/projects/new/route.ts
+++ b/src/app/api/projects/new/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
+import path from "path";
 import { readConfig } from "@/lib/config";
 import { bootstrapNewProject } from "@/lib/template/bootstrap";
 import { applyUnit } from "@/lib/template/apply";
 import { invalidateCache } from "@/lib/cache";
 import { toSlug } from "@/lib/scanner";
+import { LIBRARY } from "@/lib/template/library";
 import type { ApplyResult } from "@/lib/types";
 
 export interface NewProjectRequest {
@@ -70,14 +72,16 @@ export async function POST(req: NextRequest) {
     } satisfies NewProjectResponse);
   }
 
-  const projectSlug = toSlug(relPath.split("/").pop() ?? relPath);
+  const projectSlug = toSlug(path.basename(bootstrap.createdPath));
 
   // Apply library items sequentially (simpler than parallel; each item is fast).
   const appliedItems: Array<{ id: string; result: ApplyResult }> = [];
   for (const libraryId of libraryIds) {
-    const [kind, slug] = libraryId.split("/") as [string, string];
+    const item = LIBRARY.find((i) => i.id === libraryId);
+    if (!item) continue;
+    const unitKey = item.kind === "skill" ? `${item.slug}:standalone` : item.slug;
     const result = await applyUnit({
-      unit: { kind: kind as "agent" | "skill" | "command", key: slug },
+      unit: { kind: item.kind, key: unitKey },
       source: { kind: "library", libraryId },
       target: { kind: "path", path: bootstrap.createdPath },
       conflict: "skip",

--- a/src/app/api/projects/new/route.ts
+++ b/src/app/api/projects/new/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readConfig } from "@/lib/config";
+import { bootstrapNewProject } from "@/lib/template/bootstrap";
+import { applyUnit } from "@/lib/template/apply";
+import { invalidateCache } from "@/lib/cache";
+import { toSlug } from "@/lib/scanner";
+import type { ApplyResult } from "@/lib/types";
+
+export interface NewProjectRequest {
+  /** Display name (not used as directory — relPath controls that). */
+  name: string;
+  /** Path relative to the first configured devRoot. */
+  relPath: string;
+  /** Run `git init` after creating the directory. Defaults to true. */
+  gitInit?: boolean;
+  /** Library item IDs to apply after creation. Applied with conflict: "skip". */
+  libraryIds?: string[];
+  /** When true: validate + preview but do not create or apply. */
+  dryRun?: boolean;
+}
+
+export interface NewProjectResponse {
+  ok: boolean;
+  projectPath?: string;
+  projectSlug?: string;
+  gitInitialized?: boolean;
+  /** Whether this was a dry-run (no disk writes). */
+  wouldCreate?: boolean;
+  /** Per-item apply results when libraryIds were provided. */
+  appliedItems?: Array<{ id: string; result: ApplyResult }>;
+  error?: { code: string; message: string };
+}
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonError("INVALID_JSON", "Request body is not valid JSON.", 400);
+  }
+
+  const b = body as Record<string, unknown>;
+  if (typeof b.name !== "string" || b.name.trim().length === 0) {
+    return jsonError("INVALID_NAME", "name must be a non-empty string.", 400);
+  }
+  if (typeof b.relPath !== "string" || b.relPath.trim().length === 0) {
+    return jsonError("INVALID_REL_PATH", "relPath must be a non-empty string.", 400);
+  }
+
+  const name = b.name.trim();
+  const relPath = b.relPath.trim();
+  const gitInit = b.gitInit !== false;
+  const dryRun = b.dryRun === true;
+  const libraryIds = Array.isArray(b.libraryIds)
+    ? (b.libraryIds as unknown[]).filter((id): id is string => typeof id === "string")
+    : [];
+
+  const config = await readConfig();
+  const bootstrap = await bootstrapNewProject(config, { name, relPath, gitInit, dryRun });
+
+  if (!bootstrap.ok) {
+    return NextResponse.json({ ok: false, error: bootstrap.error } satisfies NewProjectResponse);
+  }
+
+  if (dryRun) {
+    return NextResponse.json({
+      ok: true,
+      projectPath: bootstrap.createdPath,
+      wouldCreate: true,
+    } satisfies NewProjectResponse);
+  }
+
+  const projectSlug = toSlug(relPath.split("/").pop() ?? relPath);
+
+  // Apply library items sequentially (simpler than parallel; each item is fast).
+  const appliedItems: Array<{ id: string; result: ApplyResult }> = [];
+  for (const libraryId of libraryIds) {
+    const [kind, slug] = libraryId.split("/") as [string, string];
+    const result = await applyUnit({
+      unit: { kind: kind as "agent" | "skill" | "command", key: slug },
+      source: { kind: "library", libraryId },
+      target: { kind: "path", path: bootstrap.createdPath },
+      conflict: "skip",
+    });
+    appliedItems.push({ id: libraryId, result });
+  }
+
+  // Trigger scan so the dashboard picks up the new project immediately.
+  invalidateCache();
+
+  return NextResponse.json({
+    ok: true,
+    projectPath: bootstrap.createdPath,
+    projectSlug,
+    gitInitialized: bootstrap.gitInitialized,
+    appliedItems: appliedItems.length > 0 ? appliedItems : undefined,
+  } satisfies NewProjectResponse);
+}
+
+function jsonError(code: string, message: string, status: number) {
+  return NextResponse.json({ ok: false, error: { code, message } } satisfies NewProjectResponse, { status });
+}

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { LibraryBrowser } from "@/components/LibraryBrowser";
+
+export default function LibraryPage() {
+  return <LibraryBrowser />;
+}

--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { BookOpen, Check, ChevronRight } from "lucide-react";
+import type { LibraryResponse, LibraryIndexItem } from "@/app/api/library/route";
+import type { NewProjectRequest, NewProjectResponse } from "@/app/api/projects/new/route";
+
+type Stack = "typescript" | "python" | "go" | "rust";
+
+const STACKS: Array<{ id: Stack; label: string; ext: string }> = [
+  { id: "typescript", label: "TypeScript", ext: "ts/tsx" },
+  { id: "python",     label: "Python",     ext: ".py"    },
+  { id: "go",         label: "Go",         ext: ".go"    },
+  { id: "rust",       label: "Rust",       ext: ".rs"    },
+];
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+// ── Step indicators ────────────────────────────────────────────────────────────
+function StepBar({ current }: { current: number }) {
+  const steps = ["Details", "Stack", "Items", "Confirm"];
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "6px", marginBottom: "28px" }}>
+      {steps.map((label, i) => {
+        const n = i + 1;
+        const done = n < current;
+        const active = n === current;
+        return (
+          <div key={n} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+            <div style={{
+              width: 22, height: 22, borderRadius: "50%",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              fontSize: "0.65rem", fontFamily: "var(--font-mono)", fontWeight: 700,
+              background: done ? "#22c55e" : active ? "var(--accent)" : "var(--bg-elevated)",
+              color: done || active ? "var(--bg-surface)" : "var(--text-muted)",
+              border: done || active ? "none" : "1px solid var(--border-subtle)",
+              flexShrink: 0,
+            }}>
+              {done ? <Check style={{ width: 11, height: 11 }} /> : n}
+            </div>
+            <span style={{
+              fontSize: "0.72rem", fontFamily: "var(--font-body)",
+              color: active ? "var(--text-primary)" : "var(--text-muted)",
+              fontWeight: active ? 600 : 400,
+            }}>
+              {label}
+            </span>
+            {i < steps.length - 1 && (
+              <ChevronRight style={{ width: 10, height: 10, color: "var(--border-subtle)" }} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Step 1: Project details ────────────────────────────────────────────────────
+function Step1({
+  name, setName, relPath, setRelPath, onNext,
+}: {
+  name: string; setName: (v: string) => void;
+  relPath: string; setRelPath: (v: string) => void;
+  onNext: () => void;
+}) {
+  const autoPath = slugify(name);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <h2 style={{ fontSize: "0.9rem", fontWeight: 600, color: "var(--text-primary)", fontFamily: "var(--font-body)", margin: 0 }}>
+        Project details
+      </h2>
+
+      <label style={labelStyle}>
+        <span style={labelText}>Display name</span>
+        <input
+          autoFocus
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            if (!relPath || relPath === slugify(name)) setRelPath(slugify(e.target.value));
+          }}
+          placeholder="My New Project"
+          style={inputStyle}
+        />
+      </label>
+
+      <label style={labelStyle}>
+        <span style={labelText}>Folder name <span style={{ color: "var(--text-muted)", fontWeight: 400 }}>(relative to devRoot)</span></span>
+        <input
+          value={relPath || autoPath}
+          onChange={(e) => setRelPath(e.target.value)}
+          placeholder={autoPath || "my-new-project"}
+          style={inputStyle}
+        />
+        <span style={{ fontSize: "0.65rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
+          Directory will be created at: devRoot/{relPath || autoPath || "…"}
+        </span>
+      </label>
+
+      <footer style={footerStyle}>
+        <button
+          onClick={onNext}
+          disabled={!name.trim() || !(relPath || autoPath).trim()}
+          style={primaryBtn}
+        >
+          Next →
+        </button>
+      </footer>
+    </div>
+  );
+}
+
+// ── Step 2: Stack selector ─────────────────────────────────────────────────────
+function Step2({
+  stack, setStack, onBack, onNext,
+}: {
+  stack: Stack | null; setStack: (s: Stack) => void;
+  onBack: () => void; onNext: () => void;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <h2 style={{ fontSize: "0.9rem", fontWeight: 600, color: "var(--text-primary)", fontFamily: "var(--font-body)", margin: 0 }}>
+        Primary language / stack
+      </h2>
+      <p style={{ fontSize: "0.8rem", color: "var(--text-secondary)", fontFamily: "var(--font-body)", margin: 0 }}>
+        We'll pre-select relevant library items. You can adjust the selection in the next step.
+      </p>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px" }}>
+        {STACKS.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => setStack(s.id)}
+            style={{
+              padding: "14px 16px", borderRadius: "var(--radius)", cursor: "pointer",
+              border: stack === s.id ? "2px solid var(--accent)" : "1px solid var(--border-subtle)",
+              background: stack === s.id ? "rgba(var(--accent-rgb,234,179,8),0.08)" : "var(--bg-elevated)",
+              textAlign: "left",
+            }}
+          >
+            <div style={{ fontSize: "0.85rem", fontWeight: 600, color: "var(--text-primary)", fontFamily: "var(--font-body)" }}>
+              {s.label}
+            </div>
+            <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)", marginTop: "2px" }}>
+              {s.ext}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <footer style={footerStyle}>
+        <button onClick={onBack} style={secondaryBtn}>← Back</button>
+        <button onClick={onNext} disabled={!stack} style={primaryBtn}>Next →</button>
+      </footer>
+    </div>
+  );
+}
+
+// ── Step 3: Item selection ─────────────────────────────────────────────────────
+function Step3({
+  library, selectedIds, toggleId, onBack, onNext,
+}: {
+  library: LibraryIndexItem[] | null;
+  selectedIds: Set<string>;
+  toggleId: (id: string) => void;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  const KIND_LABEL: Record<string, string> = { command: "Command", skill: "Skill", agent: "Agent" };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <div>
+        <h2 style={{ fontSize: "0.9rem", fontWeight: 600, color: "var(--text-primary)", fontFamily: "var(--font-body)", margin: "0 0 4px" }}>
+          Select library items
+        </h2>
+        <p style={{ fontSize: "0.8rem", color: "var(--text-secondary)", fontFamily: "var(--font-body)", margin: 0 }}>
+          {selectedIds.size} item{selectedIds.size !== 1 ? "s" : ""} selected · these will be applied to your new project.
+        </p>
+      </div>
+
+      {!library && (
+        <p style={{ fontSize: "0.8rem", color: "var(--text-muted)", fontFamily: "var(--font-body)" }}>Loading…</p>
+      )}
+
+      {library && (
+        <div style={{ border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)", overflow: "hidden", maxHeight: "340px", overflowY: "auto" }}>
+          {library.map((item) => {
+            const checked = selectedIds.has(item.id);
+            return (
+              <div
+                key={item.id}
+                onClick={() => toggleId(item.id)}
+                style={{
+                  display: "flex", alignItems: "center", gap: "10px",
+                  padding: "9px 14px", cursor: "pointer",
+                  borderBottom: "1px solid var(--border-subtle)",
+                  background: checked ? "rgba(var(--accent-rgb,234,179,8),0.06)" : "transparent",
+                }}
+              >
+                <div style={{
+                  width: 16, height: 16, borderRadius: "3px", flexShrink: 0,
+                  border: checked ? "none" : "1px solid var(--border-subtle)",
+                  background: checked ? "var(--accent)" : "transparent",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                }}>
+                  {checked && <Check style={{ width: 10, height: 10, color: "var(--bg-surface)" }} />}
+                </div>
+                <span style={{
+                  fontSize: "0.62rem", fontFamily: "var(--font-mono)",
+                  color: "var(--text-muted)", minWidth: "52px", flexShrink: 0,
+                }}>
+                  {KIND_LABEL[item.kind] ?? item.kind}
+                </span>
+                <span style={{ fontSize: "0.8rem", fontFamily: "var(--font-body)", color: "var(--text-primary)", flex: 1 }}>
+                  {item.name}
+                </span>
+                <span style={{ fontSize: "0.72rem", fontFamily: "var(--font-body)", color: "var(--text-secondary)", maxWidth: "220px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {item.description}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <footer style={footerStyle}>
+        <button onClick={onBack} style={secondaryBtn}>← Back</button>
+        <button onClick={onNext} style={primaryBtn}>
+          Next →
+        </button>
+      </footer>
+    </div>
+  );
+}
+
+// ── Step 4: Confirm + create ───────────────────────────────────────────────────
+function Step4({
+  name, relPath, stack, selectedIds,
+  submitting, result,
+  onBack, onSubmit,
+}: {
+  name: string; relPath: string; stack: Stack | null;
+  selectedIds: Set<string>;
+  submitting: boolean;
+  result: NewProjectResponse | null;
+  onBack: () => void;
+  onSubmit: () => void;
+}) {
+  const successCount = result?.appliedItems?.filter((a) => a.result.ok).length ?? 0;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <h2 style={{ fontSize: "0.9rem", fontWeight: 600, color: "var(--text-primary)", fontFamily: "var(--font-body)", margin: 0 }}>
+        Confirm
+      </h2>
+
+      {!result && (
+        <>
+          <div style={{ background: "var(--bg-elevated)", borderRadius: "var(--radius)", padding: "14px 16px", display: "flex", flexDirection: "column", gap: "8px" }}>
+            <Row label="Name"   value={name} />
+            <Row label="Folder" value={relPath} />
+            {stack && <Row label="Stack" value={STACKS.find((s) => s.id === stack)?.label ?? stack} />}
+            <Row label="Library items" value={selectedIds.size > 0 ? `${selectedIds.size} selected` : "None"} />
+          </div>
+          <footer style={footerStyle}>
+            <button onClick={onBack} style={secondaryBtn} disabled={submitting}>← Back</button>
+            <button onClick={onSubmit} style={primaryBtn} disabled={submitting}>
+              {submitting ? "Creating…" : "Create project"}
+            </button>
+          </footer>
+        </>
+      )}
+
+      {result && !result.ok && (
+        <div style={{ padding: "14px 16px", background: "rgba(212,95,69,0.1)", borderRadius: "var(--radius)", border: "1px solid rgba(212,95,69,0.3)" }}>
+          <p style={{ fontSize: "0.8rem", color: "#d45f45", fontFamily: "var(--font-body)", margin: 0 }}>
+            {result.error?.message ?? "Unknown error"}
+          </p>
+          <footer style={{ ...footerStyle, marginTop: "12px" }}>
+            <button onClick={onBack} style={secondaryBtn}>← Back</button>
+          </footer>
+        </div>
+      )}
+
+      {result && result.ok && (
+        <div style={{ padding: "14px 16px", background: "rgba(34,197,94,0.08)", borderRadius: "var(--radius)", border: "1px solid rgba(34,197,94,0.2)" }}>
+          <p style={{ fontSize: "0.85rem", color: "#22c55e", fontFamily: "var(--font-body)", margin: "0 0 4px", fontWeight: 600 }}>
+            Project created
+          </p>
+          <p style={{ fontSize: "0.75rem", color: "var(--text-secondary)", fontFamily: "var(--font-mono)", margin: 0 }}>
+            {result.projectPath}
+          </p>
+          {successCount > 0 && (
+            <p style={{ fontSize: "0.75rem", color: "var(--text-secondary)", fontFamily: "var(--font-body)", margin: "6px 0 0" }}>
+              {successCount} library item{successCount !== 1 ? "s" : ""} applied
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: "flex", gap: "12px", alignItems: "baseline" }}>
+      <span style={{ fontSize: "0.72rem", fontFamily: "var(--font-body)", color: "var(--text-muted)", minWidth: "80px" }}>{label}</span>
+      <span style={{ fontSize: "0.8rem", fontFamily: "var(--font-mono)", color: "var(--text-primary)" }}>{value}</span>
+    </div>
+  );
+}
+
+// ── Shared styles ──────────────────────────────────────────────────────────────
+const labelStyle: React.CSSProperties = { display: "flex", flexDirection: "column", gap: "5px" };
+const labelText: React.CSSProperties = { fontSize: "0.72rem", fontFamily: "var(--font-body)", color: "var(--text-secondary)", fontWeight: 500 };
+const inputStyle: React.CSSProperties = {
+  fontSize: "0.8rem", fontFamily: "var(--font-body)", color: "var(--text-primary)",
+  background: "var(--bg-elevated)", border: "1px solid var(--border-subtle)",
+  borderRadius: "var(--radius)", padding: "7px 10px", outline: "none",
+};
+const footerStyle: React.CSSProperties = { display: "flex", gap: "8px", justifyContent: "flex-end", marginTop: "8px" };
+const primaryBtn: React.CSSProperties = {
+  fontSize: "0.8rem", fontFamily: "var(--font-body)", fontWeight: 600,
+  padding: "7px 18px", borderRadius: "var(--radius)", cursor: "pointer",
+  background: "var(--accent)", color: "var(--bg-surface)", border: "none",
+};
+const secondaryBtn: React.CSSProperties = {
+  fontSize: "0.8rem", fontFamily: "var(--font-body)",
+  padding: "7px 14px", borderRadius: "var(--radius)", cursor: "pointer",
+  background: "transparent", color: "var(--text-secondary)",
+  border: "1px solid var(--border-subtle)",
+};
+
+// ── Wizard root ────────────────────────────────────────────────────────────────
+export default function NewProjectPage() {
+  const router = useRouter();
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState("");
+  const [relPath, setRelPath] = useState("");
+  const [stack, setStack] = useState<Stack | null>(null);
+  const [library, setLibrary] = useState<LibraryIndexItem[] | null>(null);
+  const [, setStackPresets] = useState<Record<string, string[]>>({});
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<NewProjectResponse | null>(null);
+
+  // Fetch library when entering step 3
+  useEffect(() => {
+    if (step !== 3) return;
+    if (library) return;
+    fetch("/api/library")
+      .then((r) => r.json() as Promise<LibraryResponse>)
+      .then((data) => {
+        setLibrary(data.items);
+        setStackPresets(data.stackPresets);
+        // Pre-select based on stack
+        if (stack) {
+          const preset = data.stackPresets[stack] ?? data.stackPresets.generic ?? [];
+          setSelectedIds(new Set(preset));
+        }
+      })
+      .catch(() => {});
+  }, [step, library, stack]);
+
+  function toggleId(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    const resolvedPath = relPath || slugify(name);
+    try {
+      const body: NewProjectRequest = {
+        name,
+        relPath: resolvedPath,
+        gitInit: true,
+        libraryIds: [...selectedIds],
+      };
+      const res = await fetch("/api/projects/new", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json() as NewProjectResponse;
+      setResult(data);
+      if (data.ok) {
+        setTimeout(() => router.push("/"), 2000);
+      }
+    } catch (e) {
+      setResult({ ok: false, error: { code: "NETWORK_ERROR", message: e instanceof Error ? e.message : "Network error" } });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: "560px", margin: "0 auto" }}>
+      {/* Page header */}
+      <header style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "28px" }}>
+        <BookOpen style={{ width: 14, height: 14, color: "var(--text-muted)" }} />
+        <h1 style={{
+          fontSize: "0.72rem", fontWeight: 600, letterSpacing: "0.08em",
+          textTransform: "uppercase", color: "var(--text-secondary)",
+          fontFamily: "var(--font-body)", margin: 0,
+        }}>
+          New Project
+        </h1>
+      </header>
+
+      <StepBar current={step} />
+
+      <div style={{
+        background: "var(--bg-surface)", border: "1px solid var(--border-subtle)",
+        borderRadius: "var(--radius)", padding: "24px",
+      }}>
+        {step === 1 && (
+          <Step1
+            name={name} setName={setName}
+            relPath={relPath} setRelPath={setRelPath}
+            onNext={() => setStep(2)}
+          />
+        )}
+        {step === 2 && (
+          <Step2
+            stack={stack} setStack={setStack}
+            onBack={() => setStep(1)}
+            onNext={() => setStep(3)}
+          />
+        )}
+        {step === 3 && (
+          <Step3
+            library={library}
+            selectedIds={selectedIds}
+            toggleId={toggleId}
+            onBack={() => setStep(2)}
+            onNext={() => setStep(4)}
+          />
+        )}
+        {step === 4 && (
+          <Step4
+            name={name} relPath={relPath || slugify(name)} stack={stack}
+            selectedIds={selectedIds}
+            submitting={submitting}
+            result={result}
+            onBack={() => setStep(3)}
+            onSubmit={() => void handleSubmit()}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/new-project/page.tsx
+++ b/src/app/new-project/page.tsx
@@ -192,14 +192,17 @@ function Step3({
           {library.map((item) => {
             const checked = selectedIds.has(item.id);
             return (
-              <div
+              <button
                 key={item.id}
                 onClick={() => toggleId(item.id)}
+                role="checkbox"
+                aria-checked={checked}
                 style={{
                   display: "flex", alignItems: "center", gap: "10px",
                   padding: "9px 14px", cursor: "pointer",
                   borderBottom: "1px solid var(--border-subtle)",
                   background: checked ? "rgba(var(--accent-rgb,234,179,8),0.06)" : "transparent",
+                  border: "none", width: "100%", textAlign: "left",
                 }}
               >
                 <div style={{
@@ -222,7 +225,7 @@ function Step3({
                 <span style={{ fontSize: "0.72rem", fontFamily: "var(--font-body)", color: "var(--text-secondary)", maxWidth: "220px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                   {item.description}
                 </span>
-              </div>
+              </button>
             );
           })}
         </div>
@@ -344,12 +347,12 @@ export default function NewProjectPage() {
   const [relPath, setRelPath] = useState("");
   const [stack, setStack] = useState<Stack | null>(null);
   const [library, setLibrary] = useState<LibraryIndexItem[] | null>(null);
-  const [, setStackPresets] = useState<Record<string, string[]>>({});
+  const [stackPresets, setStackPresets] = useState<Record<string, string[]>>({});
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<NewProjectResponse | null>(null);
 
-  // Fetch library when entering step 3
+  // Effect 1: fetch library once when reaching step 3
   useEffect(() => {
     if (step !== 3) return;
     if (library) return;
@@ -358,14 +361,16 @@ export default function NewProjectPage() {
       .then((data) => {
         setLibrary(data.items);
         setStackPresets(data.stackPresets);
-        // Pre-select based on stack
-        if (stack) {
-          const preset = data.stackPresets[stack] ?? data.stackPresets.generic ?? [];
-          setSelectedIds(new Set(preset));
-        }
       })
       .catch(() => {});
-  }, [step, library, stack]);
+  }, [step, library]);
+
+  // Effect 2: recompute preset whenever stack or library changes (on step 3)
+  useEffect(() => {
+    if (step !== 3 || !library || !stack) return;
+    const preset = stackPresets[stack] ?? stackPresets.generic ?? [];
+    setSelectedIds(new Set(preset));
+  }, [step, stack, library, stackPresets]);
 
   function toggleId(id: string) {
     setSelectedIds((prev) => {
@@ -451,7 +456,7 @@ export default function NewProjectPage() {
             selectedIds={selectedIds}
             submitting={submitting}
             result={result}
-            onBack={() => setStep(3)}
+            onBack={() => { setResult(null); setStep(3); }}
             onSubmit={() => void handleSubmit()}
           />
         )}

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -33,7 +33,7 @@ function item(href: string, label: string, extras: { badge?: BadgeKey; matchType
   return { href, path: href.split("?")[0], label, ...extras };
 }
 
-const ROOT_ITEMS: NavItem[] = [item("/", "Projects")];
+const ROOT_ITEMS: NavItem[] = [item("/", "Projects"), item("/new-project", "+ New")];
 
 const GROUPS: Group[] = [
   {
@@ -44,6 +44,7 @@ const GROUPS: Group[] = [
       item("/commands",  "Commands"),
       item("/plugins",   "Plugins"),
       item("/templates", "Templates"),
+      item("/library",   "Library"),
     ],
   },
   {

--- a/src/components/DashboardGrid.tsx
+++ b/src/components/DashboardGrid.tsx
@@ -404,6 +404,24 @@ export function DashboardGrid({
           Quick Add
         </button>
 
+        {/* New Project */}
+        <Link
+          href="/new-project"
+          title="Create a new project"
+          className="toolbar-btn"
+          style={{
+            display: "flex", alignItems: "center", gap: "5px",
+            padding: "5px 11px", fontSize: "0.72rem", minHeight: "32px",
+            fontFamily: "var(--font-body)", letterSpacing: "0.03em",
+            color: "var(--text-secondary)", background: "var(--bg-surface)",
+            border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)",
+            cursor: "pointer", textDecoration: "none", flexShrink: 0,
+          }}
+        >
+          <Plus style={{ width: "11px", height: "11px" }} />
+          New
+        </Link>
+
         {/* Rescan */}
         <button
           onClick={onRescan}

--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -43,6 +43,8 @@ const slugTitles: Record<HelpSlug, string> = {
   kanban: "Mission Control Kanban",
   adapters: "Adapters",
   "mcp-security": "MCP Security Scanner",
+  library: "Library Browser",
+  "new-project": "New Project Wizard",
 };
 
 const iconBtnBase: React.CSSProperties = {

--- a/src/components/LibraryBrowser.tsx
+++ b/src/components/LibraryBrowser.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { BookOpen, Search, ChevronDown, ChevronRight, Check } from "lucide-react";
+import type { LibraryResponse, LibraryIndexItem } from "@/app/api/library/route";
+
+const KIND_LABELS: Record<string, string> = { command: "Command", skill: "Skill", agent: "Agent" };
+const KIND_COLORS: Record<string, string> = {
+  command: "rgba(93,163,198,0.15)",
+  skill: "rgba(34,197,94,0.12)",
+  agent: "rgba(168,85,247,0.12)",
+};
+const KIND_TEXT: Record<string, string> = {
+  command: "#5da3c6",
+  skill: "#22c55e",
+  agent: "#a855f7",
+};
+
+function KindChip({ kind }: { kind: string }) {
+  return (
+    <span style={{
+      fontSize: "0.6rem", fontFamily: "var(--font-mono)", fontWeight: 600,
+      letterSpacing: "0.06em", textTransform: "uppercase",
+      background: KIND_COLORS[kind] ?? "var(--bg-elevated)",
+      color: KIND_TEXT[kind] ?? "var(--text-muted)",
+      border: `1px solid ${KIND_TEXT[kind] ?? "var(--border-subtle)"}30`,
+      borderRadius: "3px", padding: "2px 5px", whiteSpace: "nowrap",
+    }}>
+      {KIND_LABELS[kind] ?? kind}
+    </span>
+  );
+}
+
+function TagChip({ tag }: { tag: string }) {
+  return (
+    <span style={{
+      fontSize: "0.6rem", fontFamily: "var(--font-mono)",
+      color: "var(--text-muted)", background: "var(--bg-elevated)",
+      border: "1px solid var(--border-subtle)",
+      borderRadius: "3px", padding: "2px 5px", whiteSpace: "nowrap",
+    }}>
+      {tag}
+    </span>
+  );
+}
+
+interface ApplyState {
+  loading: boolean;
+  ok?: boolean;
+  message?: string;
+}
+
+interface LibraryRowProps {
+  item: LibraryIndexItem;
+  projects: Array<{ slug: string; name: string }>;
+}
+
+function LibraryRow({ item, projects }: LibraryRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [targetSlug, setTargetSlug] = useState(projects[0]?.slug ?? "");
+  const [applyState, setApplyState] = useState<ApplyState>({ loading: false });
+
+  async function handleApply(dryRun: boolean) {
+    if (!targetSlug) return;
+    setApplyState({ loading: true });
+    try {
+      const res = await fetch("/api/claude-config/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          unit: { kind: item.kind, key: item.slug },
+          source: { kind: "library", libraryId: item.id },
+          target: { kind: "existing", slug: targetSlug },
+          conflict: "skip",
+          dryRun,
+        }),
+      });
+      const data = await res.json() as { ok: boolean; status: string; error?: { message: string }; diffPreview?: string };
+      if (!data.ok) {
+        setApplyState({ loading: false, ok: false, message: data.error?.message ?? "Apply failed" });
+      } else {
+        setApplyState({
+          loading: false,
+          ok: true,
+          message: dryRun
+            ? `Would ${data.status} ${item.name}`
+            : `${data.status.charAt(0).toUpperCase() + data.status.slice(1)} ${item.name}`,
+        });
+      }
+    } catch (e) {
+      setApplyState({ loading: false, ok: false, message: e instanceof Error ? e.message : "Network error" });
+    }
+  }
+
+  return (
+    <div style={{ borderBottom: "1px solid var(--border-subtle)" }}>
+      {/* Row header */}
+      <div
+        onClick={() => setExpanded((e) => !e)}
+        style={{
+          display: "flex", alignItems: "center", gap: "10px",
+          padding: "10px 14px", cursor: "pointer",
+          background: expanded ? "var(--bg-elevated)" : "transparent",
+        }}
+      >
+        {expanded
+          ? <ChevronDown style={{ width: 11, height: 11, color: "var(--text-muted)", flexShrink: 0 }} />
+          : <ChevronRight style={{ width: 11, height: 11, color: "var(--text-muted)", flexShrink: 0 }} />
+        }
+        <KindChip kind={item.kind} />
+        <span style={{
+          fontSize: "0.8rem", fontFamily: "var(--font-body)",
+          color: "var(--text-primary)", flex: 1, minWidth: 0,
+          overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+        }}>
+          {item.name}
+        </span>
+        <span style={{
+          fontSize: "0.72rem", fontFamily: "var(--font-body)",
+          color: "var(--text-secondary)", flexShrink: 0,
+          overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          maxWidth: "260px",
+        }}>
+          {item.description}
+        </span>
+      </div>
+
+      {/* Expanded panel */}
+      {expanded && (
+        <div style={{ padding: "12px 14px 14px 14px", background: "var(--bg-elevated)" }}>
+          {/* Tags */}
+          <div style={{ display: "flex", gap: "4px", flexWrap: "wrap", marginBottom: "12px" }}>
+            {item.tags.map((t) => <TagChip key={t} tag={t} />)}
+          </div>
+
+          {/* Apply controls */}
+          <div style={{ display: "flex", alignItems: "center", gap: "8px", flexWrap: "wrap" }}>
+            <label style={{ fontSize: "0.72rem", color: "var(--text-muted)", fontFamily: "var(--font-body)" }}>
+              Apply to
+            </label>
+            <select
+              value={targetSlug}
+              onChange={(e) => { setTargetSlug(e.target.value); setApplyState({ loading: false }); }}
+              style={{
+                fontSize: "0.72rem", fontFamily: "var(--font-body)",
+                background: "var(--bg-surface)", color: "var(--text-primary)",
+                border: "1px solid var(--border-subtle)", borderRadius: "4px",
+                padding: "3px 6px", maxWidth: "180px",
+              }}
+            >
+              {projects.map((p) => (
+                <option key={p.slug} value={p.slug}>{p.name}</option>
+              ))}
+            </select>
+            <button
+              onClick={(e) => { e.stopPropagation(); void handleApply(true); }}
+              disabled={applyState.loading || !targetSlug}
+              style={{
+                fontSize: "0.72rem", fontFamily: "var(--font-body)",
+                color: "var(--text-secondary)",
+                background: "var(--bg-surface)", border: "1px solid var(--border-subtle)",
+                borderRadius: "4px", padding: "4px 10px", cursor: "pointer",
+              }}
+            >
+              Preview
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); void handleApply(false); }}
+              disabled={applyState.loading || !targetSlug}
+              style={{
+                fontSize: "0.72rem", fontFamily: "var(--font-body)",
+                color: "var(--bg-surface)", background: "var(--accent)",
+                border: "none", borderRadius: "4px", padding: "4px 10px", cursor: "pointer",
+                opacity: applyState.loading || !targetSlug ? 0.5 : 1,
+              }}
+            >
+              {applyState.loading ? "…" : "Apply"}
+            </button>
+
+            {applyState.message && (
+              <span style={{
+                fontSize: "0.72rem", fontFamily: "var(--font-body)",
+                color: applyState.ok ? "#22c55e" : "#d45f45",
+                display: "flex", alignItems: "center", gap: "4px",
+              }}>
+                {applyState.ok && <Check style={{ width: 11, height: 11 }} />}
+                {applyState.message}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ProjectEntry { slug: string; name: string; }
+
+export function LibraryBrowser() {
+  const [data, setData] = useState<LibraryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [projects, setProjects] = useState<ProjectEntry[]>([]);
+  const [query, setQuery] = useState("");
+  const [kindFilter, setKindFilter] = useState<string>("all");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    Promise.all([
+      fetch("/api/library", { signal: controller.signal }).then((r) => r.json() as Promise<LibraryResponse>),
+      fetch("/api/projects", { signal: controller.signal }).then((r) => r.json() as Promise<Array<{ slug: string; name: string }>>),
+    ])
+      .then(([lib, projs]) => {
+        setData(lib);
+        setProjects(projs.map((p) => ({ slug: p.slug, name: p.name ?? p.slug })));
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        if (e instanceof Error && e.name === "AbortError") return;
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!data) return [];
+    const q = query.toLowerCase();
+    return data.items.filter((item) => {
+      if (kindFilter !== "all" && item.kind !== kindFilter) return false;
+      if (!q) return true;
+      return (
+        item.name.toLowerCase().includes(q) ||
+        item.description.toLowerCase().includes(q) ||
+        item.tags.some((t) => t.toLowerCase().includes(q))
+      );
+    });
+  }, [data, query, kindFilter]);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+      {/* Header */}
+      <header style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+        <BookOpen style={{ width: 14, height: 14, color: "var(--text-muted)" }} />
+        <h1 style={{
+          fontSize: "0.72rem", fontWeight: 600, letterSpacing: "0.08em",
+          textTransform: "uppercase", color: "var(--text-secondary)",
+          fontFamily: "var(--font-body)", margin: 0,
+        }}>
+          Library
+        </h1>
+        <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "var(--text-muted)" }}>
+          curated commands, skills & agents · apply to any project
+        </span>
+      </header>
+
+      {/* Filter bar */}
+      <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+        <div style={{
+          flex: 1, display: "flex", alignItems: "center", gap: "6px",
+          background: "var(--bg-elevated)", border: "1px solid var(--border-subtle)",
+          borderRadius: "var(--radius)", padding: "5px 10px",
+        }}>
+          <Search style={{ width: 12, height: 12, color: "var(--text-muted)", flexShrink: 0 }} />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search library…"
+            style={{
+              flex: 1, background: "transparent", border: "none", outline: "none",
+              fontSize: "0.8rem", fontFamily: "var(--font-body)", color: "var(--text-primary)",
+            }}
+          />
+        </div>
+        {(["all", "command", "skill", "agent"] as const).map((k) => (
+          <button
+            key={k}
+            onClick={() => setKindFilter(k)}
+            style={{
+              fontSize: "0.7rem", fontFamily: "var(--font-body)",
+              padding: "4px 10px", borderRadius: "var(--radius)", cursor: "pointer",
+              border: "1px solid var(--border-subtle)",
+              background: kindFilter === k ? "var(--accent)" : "var(--bg-elevated)",
+              color: kindFilter === k ? "var(--bg-surface)" : "var(--text-secondary)",
+            }}
+          >
+            {k === "all" ? "All" : KIND_LABELS[k]}
+          </button>
+        ))}
+        {data && (
+          <span style={{ fontSize: "0.65rem", fontFamily: "var(--font-mono)", color: "var(--text-muted)", whiteSpace: "nowrap" }}>
+            {filtered.length}/{data.items.length}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} style={{ height: "42px", borderRadius: "var(--radius)", background: "var(--bg-elevated)", opacity: 0.5, animation: "pulse 1.5s ease-in-out infinite" }} />
+          ))}
+        </div>
+      )}
+
+      {!loading && (
+        <div style={{ border: "1px solid var(--border-subtle)", borderRadius: "var(--radius)", overflow: "hidden" }}>
+          {filtered.length === 0 ? (
+            <p style={{ padding: "16px", fontSize: "0.8rem", color: "var(--text-muted)", fontFamily: "var(--font-body)", margin: 0 }}>
+              {query ? `No library items match "${query}".` : "No items in this category."}
+            </p>
+          ) : (
+            filtered.map((item) => (
+              <LibraryRow key={item.id} item={item} projects={projects} />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/LibraryBrowser.tsx
+++ b/src/components/LibraryBrowser.tsx
@@ -68,7 +68,7 @@ function LibraryRow({ item, projects }: LibraryRowProps) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          unit: { kind: item.kind, key: item.slug },
+          unit: { kind: item.kind, key: item.kind === "skill" ? `${item.slug}:standalone` : item.slug },
           source: { kind: "library", libraryId: item.id },
           target: { kind: "existing", slug: targetSlug },
           conflict: "skip",
@@ -95,12 +95,14 @@ function LibraryRow({ item, projects }: LibraryRowProps) {
   return (
     <div style={{ borderBottom: "1px solid var(--border-subtle)" }}>
       {/* Row header */}
-      <div
+      <button
         onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
         style={{
           display: "flex", alignItems: "center", gap: "10px",
-          padding: "10px 14px", cursor: "pointer",
+          padding: "10px 14px", cursor: "pointer", width: "100%",
           background: expanded ? "var(--bg-elevated)" : "transparent",
+          border: "none", textAlign: "left",
         }}
       >
         {expanded
@@ -123,7 +125,7 @@ function LibraryRow({ item, projects }: LibraryRowProps) {
         }}>
           {item.description}
         </span>
-      </div>
+      </button>
 
       {/* Expanded panel */}
       {expanded && (
@@ -207,11 +209,11 @@ export function LibraryBrowser() {
     const controller = new AbortController();
     Promise.all([
       fetch("/api/library", { signal: controller.signal }).then((r) => r.json() as Promise<LibraryResponse>),
-      fetch("/api/projects", { signal: controller.signal }).then((r) => r.json() as Promise<Array<{ slug: string; name: string }>>),
+      fetch("/api/projects", { signal: controller.signal }).then((r) => r.json() as Promise<{ projects: Array<{ slug: string; name: string }> }>),
     ])
       .then(([lib, projs]) => {
         setData(lib);
-        setProjects(projs.map((p) => ({ slug: p.slug, name: p.name ?? p.slug })));
+        setProjects(projs.projects.map((p) => ({ slug: p.slug, name: p.name ?? p.slug })));
         setLoading(false);
       })
       .catch((e: unknown) => {

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -33,6 +33,8 @@ export const helpMapping: Record<string, string> = {
   '/hooks': 'hooks',
   '/plugins': 'plugins',
   '/sql': 'sql',
+  '/library': 'library',
+  '/new-project': 'new-project',
 }
 
 /**

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -100,6 +100,8 @@ export const helpSlugs = [
   'kanban',
   'adapters',
   'mcp-security',
+  'library',
+  'new-project',
 ] as const
 
 export type HelpSlug = (typeof helpSlugs)[number]

--- a/src/lib/template/apply.ts
+++ b/src/lib/template/apply.ts
@@ -235,8 +235,14 @@ async function applyFromLibrary(
     await fs.writeFile(tmpFile, item.content, "utf-8");
 
     // Use path source/target to skip redundant resolution in the recursive call.
+    // Override unit.key for skills: the dispatcher's findSkill splits on ":" to get
+    // [slug, layout], so bare slugs produce layout=undefined and UNIT_NOT_FOUND.
     const pathRequest: ApplyRequest = {
       ...request,
+      unit: {
+        kind: item.kind,
+        key: item.kind === "skill" ? `${item.slug}:standalone` : item.slug,
+      },
       source: { kind: "path", path: tmpDir },
       target: { kind: "path", path: safeTargetPath },
     };

--- a/src/lib/template/apply.ts
+++ b/src/lib/template/apply.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { promises as fs } from "fs";
 import {
   ApplyRequest,
   ApplyResult,
@@ -9,6 +10,7 @@ import {
   MinderConfig,
   ScanResult,
 } from "../types";
+import { LIBRARY } from "./library";
 import { readConfig } from "../config";
 import { getCachedScan, setCachedScan, invalidateCache as invalidateScanCache } from "../cache";
 import { scanAllProjects, toSlug } from "../scanner";
@@ -173,6 +175,10 @@ function resolveSource(source: ApplySource, scan: ScanResult): ResolvedSource | 
       // and live-source projects. Slug is a synthetic placeholder used only by
       // walkers when they construct entry ids.
       return { kind: "project", path: source.path, slug: "template" };
+    case "library":
+      // Library sources are intercepted by applyUnit before resolveSource is
+      // called, so this branch should never be reached.
+      return { error: { code: "UNEXPECTED_LIBRARY_SOURCE", message: "Library source reached resolveSource — this is a bug." } };
   }
 }
 
@@ -200,6 +206,46 @@ function resolveTarget(target: ApplyTarget, scan: ScanResult): { path: string } 
   }
 }
 
+/** Resolve a library source by writing item content to a temp dir, then
+ *  re-entering applyUnit with source.kind="path". The temp dir is cleaned up
+ *  after the apply completes (success or failure). */
+async function applyFromLibrary(
+  request: ApplyRequest,
+  safeTargetPath: string,
+): Promise<ApplyResult> {
+  const libSrc = request.source as { kind: "library"; libraryId: string };
+  const item = LIBRARY.find((i) => i.id === libSrc.libraryId);
+  if (!item) {
+    return errorResult("LIBRARY_ITEM_NOT_FOUND", `Library item "${libSrc.libraryId}" not found.`);
+  }
+
+  let relPath: string;
+  switch (item.kind) {
+    case "agent":   relPath = path.join(".claude", "agents",   `${item.slug}.md`); break;
+    case "skill":   relPath = path.join(".claude", "skills",   `${item.slug}.md`); break;
+    case "command": relPath = path.join(".claude", "commands", `${item.slug}.md`); break;
+    default:
+      return errorResult("UNSUPPORTED_LIBRARY_KIND", `Library kind "${(item as { kind: string }).kind}" is not supported for apply.`);
+  }
+
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pm-lib-"));
+  try {
+    const tmpFile = path.join(tmpDir, relPath);
+    await fs.mkdir(path.dirname(tmpFile), { recursive: true });
+    await fs.writeFile(tmpFile, item.content, "utf-8");
+
+    // Use path source/target to skip redundant resolution in the recursive call.
+    const pathRequest: ApplyRequest = {
+      ...request,
+      source: { kind: "path", path: tmpDir },
+      target: { kind: "path", path: safeTargetPath },
+    };
+    return applyUnit(pathRequest);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
 /**
  * Top-level orchestrator. Resolves source + target paths, dispatches to the
  * right primitive, and (on a successful non-dryRun) invalidates the caches
@@ -222,6 +268,11 @@ export async function applyUnit(request: ApplyRequest): Promise<ApplyResult> {
       return errorResult(e.code, e.message);
     }
     throw e;
+  }
+
+  // Library source: write item content to a temp dir, then re-enter as path source.
+  if (request.source.kind === "library") {
+    return applyFromLibrary(request, safeTargetPath);
   }
 
   const sourceResolved = resolveSource(request.source, scan);

--- a/src/lib/template/library/index.ts
+++ b/src/lib/template/library/index.ts
@@ -1,0 +1,555 @@
+import type { UnitKind } from "@/lib/types";
+
+export interface LibraryItem {
+  /** Unique identifier: "<kind>/<slug>". Used as `libraryId` in ApplySource. */
+  id: string;
+  kind: Extract<UnitKind, "agent" | "skill" | "command">;
+  /** Filename slug — becomes `unit.key` in ApplyRequest and the output filename. */
+  slug: string;
+  name: string;
+  description: string;
+  /** Category tags for filtering. */
+  tags: string[];
+  /** Tech stacks this item is pre-selected for in the new-project wizard. */
+  stacks: Array<"typescript" | "python" | "go" | "rust" | "generic">;
+  /** Raw file content to write (includes YAML frontmatter). */
+  content: string;
+}
+
+export const LIBRARY: LibraryItem[] = [
+  // ── Commands ────────────────────────────────────────────────────────────────
+  {
+    id: "command/review",
+    kind: "command",
+    slug: "review",
+    name: "/review",
+    description: "Review staged changes for quality, bugs, and security issues",
+    tags: ["code-quality", "review"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+description: Review staged changes for quality, bugs, and security issues
+allowed-tools: Read, Glob, Grep, Bash
+---
+Review the changes in the current working directory.
+
+Run \`git diff HEAD\` to see what changed, then systematically review each file for:
+
+1. **Bugs** — logic errors, off-by-one, null/undefined handling, type mismatches
+2. **Security** — injection, XSS, path traversal, insecure defaults, leaked secrets
+3. **Code quality** — naming, readability, unnecessary complexity, duplication
+4. **Test coverage** — are new code paths tested? Are critical paths covered?
+
+Format findings as a numbered list grouped by severity: Critical → Major → Minor. For each finding, reference the file and line number. End with a brief summary of overall quality.
+`,
+  },
+  {
+    id: "command/commit",
+    kind: "command",
+    slug: "commit",
+    name: "/commit",
+    description: "Generate a conventional commit message for staged changes",
+    tags: ["git", "workflow"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+description: Generate a conventional commit message for staged changes
+allowed-tools: Bash
+---
+Generate a conventional commit message for the staged changes.
+
+Run \`git diff --cached\` to see what's staged, then:
+1. Identify the type: feat, fix, docs, style, refactor, test, chore
+2. Write a concise subject line (under 72 chars): \`<type>(<scope>): <description>\`
+3. If the changes are complex, add a body paragraph explaining WHY (not what)
+4. If there are breaking changes, add a \`BREAKING CHANGE:\` footer
+
+Output ONLY the commit message, formatted for direct use with \`git commit -m\`. Do not run git commands.
+`,
+  },
+  {
+    id: "command/debug",
+    kind: "command",
+    slug: "debug",
+    name: "/debug",
+    description: "Systematically investigate a bug using root-cause analysis",
+    tags: ["debugging", "diagnosis"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+description: Systematically investigate a bug using root-cause analysis
+allowed-tools: Read, Bash, Grep, Glob
+---
+Investigate the reported bug systematically:
+
+1. **Reproduce** — confirm you can reproduce the issue from the description
+2. **Hypothesize** — form 2-3 candidate root-cause hypotheses
+3. **Test** — for each hypothesis, locate the relevant code path and identify the specific line or condition that would produce the behavior
+4. **Diagnose** — state which hypothesis the evidence supports and why others are ruled out
+5. **Fix** — propose the minimal fix with an explanation of why it addresses the root cause
+
+Be specific: reference file names, line numbers, and variable names. Read existing tests to understand expected behavior before diving into implementation.
+`,
+  },
+  {
+    id: "command/test-gen",
+    kind: "command",
+    slug: "test-gen",
+    name: "/test-gen",
+    description: "Generate comprehensive tests for the current file or function",
+    tags: ["testing", "code-quality"],
+    stacks: ["typescript", "python", "go", "rust"],
+    content: `---
+description: Generate comprehensive tests for the current file or function
+allowed-tools: Read, Glob, Grep, Write
+---
+Generate comprehensive tests for the specified code.
+
+1. Read the file to understand the public API, edge cases, and error conditions
+2. Check existing test files (\`*.test.ts\`, \`*.spec.ts\`, \`__tests__/\`) to match the project's testing patterns
+3. Write tests covering:
+   - **Happy path** — standard inputs produce correct outputs
+   - **Edge cases** — empty input, single item, boundary values
+   - **Error cases** — invalid input, missing dependencies, IO failures
+   - **Type safety** — incorrect types (if TypeScript)
+
+Use the same testing framework and assertion style as existing project tests.
+`,
+  },
+  {
+    id: "command/document",
+    kind: "command",
+    slug: "document",
+    name: "/document",
+    description: "Generate documentation for the current file or module",
+    tags: ["documentation"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+description: Generate documentation for the current file or module
+allowed-tools: Read, Glob, Write
+---
+Generate documentation for the specified file or module.
+
+1. Read the file to understand its purpose, exports, and usage patterns
+2. Check \`README.md\`, \`docs/\`, and adjacent \`.md\` files for the project's documentation style
+3. Write documentation covering:
+   - **Overview** — what this module does and why it exists
+   - **API reference** — each exported function/class with parameters, return values, and examples
+   - **Usage examples** — 2-3 real-world usage patterns
+   - **Error handling** — what errors can occur and how to handle them
+
+Match the project's existing documentation style and tone.
+`,
+  },
+
+  // ── Skills ──────────────────────────────────────────────────────────────────
+  {
+    id: "skill/code-reviewer",
+    kind: "skill",
+    slug: "code-reviewer",
+    name: "code-reviewer",
+    description: "Systematic code review for quality, bugs, security, and maintainability",
+    tags: ["code-quality", "review", "security"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: code-reviewer
+description: Systematic code review for quality, bugs, security, and maintainability. Use after writing or modifying code, before committing or opening a PR.
+---
+# Code Reviewer
+
+Conduct a systematic review of recently changed code. Focus on issues that matter.
+
+## Review Order
+
+1. **Correctness** — does the code do what it claims? Check logic, data flow, null/undefined handling
+2. **Security** — injection vectors, unvalidated input at system boundaries, secrets in code
+3. **Error handling** — are failure modes handled? Any silent failures? Missing propagation?
+4. **Performance** — N+1 queries, unnecessary work in hot paths, unbounded data structures
+5. **Maintainability** — naming clarity, unnecessary complexity, missing tests for new behavior
+
+## Output Format
+
+Group findings by severity. Only report findings you're confident about.
+
+**Critical** (must fix): security vulnerabilities, data loss risk, broken behavior
+**Major** (should fix): logic errors, missing error handling, significant performance issues
+**Minor** (consider): naming, minor readability, missing edge case tests
+
+End with a verdict: APPROVE / REQUEST CHANGES / BLOCKING.
+`,
+  },
+  {
+    id: "skill/test-writer",
+    kind: "skill",
+    slug: "test-writer",
+    name: "test-writer",
+    description: "Generate comprehensive tests that catch real bugs",
+    tags: ["testing", "code-quality"],
+    stacks: ["typescript", "python", "go", "rust"],
+    content: `---
+name: test-writer
+description: Generate comprehensive, meaningful tests that catch real bugs. Use when adding tests for new or existing code.
+---
+# Test Writer
+
+Generate tests that provide real coverage — behavior coverage, not just line coverage.
+
+## Process
+
+1. **Read the source** — understand the function contract: inputs, outputs, side effects, error conditions
+2. **Check test patterns** — read existing test files to match framework, assertion style, and fixture patterns
+3. **Identify test cases**:
+   - Happy path (typical usage)
+   - Boundary values (empty, single, max)
+   - Invalid input (wrong types, missing required fields)
+   - Error conditions (IO failures, network errors, invalid state)
+
+## Quality Rules
+
+- Each test has exactly ONE reason to fail
+- Tests are hermetic — no shared mutable state between tests
+- Mock only at system boundaries (DB, network, filesystem)
+- Test names describe behavior: \`should return empty array when no matching items found\`
+
+Write the tests, not just a list of cases. Output runnable test code.
+`,
+  },
+  {
+    id: "skill/doc-writer",
+    kind: "skill",
+    slug: "doc-writer",
+    name: "doc-writer",
+    description: "Write clear, accurate documentation for code, APIs, and systems",
+    tags: ["documentation"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: doc-writer
+description: Write clear, accurate documentation for code, APIs, and systems. Use when creating or updating project documentation.
+---
+# Doc Writer
+
+Write documentation that helps developers understand and use the code effectively.
+
+## Principles
+
+- **Accuracy over completeness** — wrong docs are worse than no docs
+- **Examples are mandatory** — every API reference needs at least one working example
+- **Explain the why** — constraints, design decisions, non-obvious invariants
+- **No filler** — cut "This function is used to..." openers
+
+## Structure by Doc Type
+
+**API reference**: signature → description → parameters → return value → examples → errors
+**Guide/tutorial**: outcome → prerequisites → step-by-step → troubleshooting
+**Architecture doc**: purpose → components → data flow → key decisions → trade-offs
+
+## Process
+
+1. Read the source code — document what the code actually does, not what you assume
+2. Verify examples work by running them or reading the tests
+3. Re-read from the perspective of someone who has never seen this code
+`,
+  },
+  {
+    id: "skill/refactorer",
+    kind: "skill",
+    slug: "refactorer",
+    name: "refactorer",
+    description: "Identify and implement targeted refactors that improve clarity without changing behavior",
+    tags: ["code-quality", "refactoring"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: refactorer
+description: Identify and implement targeted code refactors that improve clarity and maintainability without changing behavior.
+---
+# Refactorer
+
+Improve code structure while preserving all existing behavior. Refactoring must be verifiable.
+
+## When to Refactor
+
+- Function does more than one thing (>20 lines often signals this)
+- Three or more similar code blocks that could be unified
+- Nested conditionals that are hard to follow (flatten with early returns)
+- Names that don't reflect what the code actually does
+
+## Rules
+
+1. **Tests first** — run existing tests before starting. They must pass after
+2. **One refactor at a time** — rename separately from extract, extract separately from simplify
+3. **Don't mix behavior changes** — if you find a bug, note it separately
+4. **Preserve the public API** — unless explicitly asked to change signatures
+
+## Output
+
+Describe the refactoring strategy, then implement it. For each change: state what you're doing and why it improves the code.
+`,
+  },
+  {
+    id: "skill/security-auditor",
+    kind: "skill",
+    slug: "security-auditor",
+    name: "security-auditor",
+    description: "Identify security vulnerabilities with enough specificity to fix them",
+    tags: ["security", "code-quality"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: security-auditor
+description: Identify security vulnerabilities in code. Use before deploying user-facing features or reviewing auth/input-handling code.
+---
+# Security Auditor
+
+Identify security vulnerabilities with enough specificity to fix them.
+
+## Priority Vulnerabilities
+
+1. **Injection** — SQL, command, path, LDAP. User input reaching a system call without sanitization
+2. **Authentication** — missing auth checks, session fixation, insecure token storage, weak secrets
+3. **Authorization** — privilege escalation, IDOR, missing object-level permission checks
+4. **Input validation** — unvalidated uploads, unchecked redirects, XML/JSON entity expansion
+5. **Secrets** — hardcoded credentials, API keys in source, sensitive data in logs or errors
+6. **Cryptography** — weak algorithms (MD5/SHA1 for secrets, ECB mode), insecure random for tokens
+
+## Process
+
+1. Identify trust boundaries — where does user-controlled data enter the system?
+2. Trace each input to its sink — DB query, file path, shell command, or HTML output?
+3. For each path: is there sanitization/validation/escaping appropriate to the sink?
+
+Report only confirmed or near-certain vulnerabilities. Include: file, line, attack scenario, severity (Critical/High/Medium), and proposed fix.
+`,
+  },
+  {
+    id: "skill/git-workflow",
+    kind: "skill",
+    slug: "git-workflow",
+    name: "git-workflow",
+    description: "Git workflow guidance for branching, commits, and preparing code for review",
+    tags: ["git", "workflow"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: git-workflow
+description: Git workflow guidance for branching, commits, conflict resolution, and preparing code for review.
+---
+# Git Workflow
+
+Help with branching, commits, conflict resolution, and preparing code for review.
+
+## Commit Quality
+
+Good commits: atomic (one logical change), passing (tests pass at every commit), explained (WHY in the message body). Conventional commit format: \`type(scope): description\`. Types: feat, fix, docs, refactor, test, chore.
+
+Avoid: mixing unrelated changes, committing broken states, messages that just say "fix" or "update".
+
+## Branch Strategy
+
+Feature branch off \`main\`, PR back into \`main\`. Branch name: \`<type>/<brief-description>\`. Keep branches short-lived — the longer they live, the more painful the merge.
+
+## Conflict Resolution
+
+1. Understand both sides before choosing
+2. Preserve the intent of both changes when possible
+3. After resolution: run tests. Wrong conflict resolution produces code that "runs" but is incorrect
+
+## Before Opening a PR
+
+- All commits are atomic with good messages
+- Branch is up to date with main
+- Tests pass
+- No debug artifacts (console.logs, commented-out code, TODO fixmes from development)
+`,
+  },
+  {
+    id: "skill/pr-reviewer",
+    kind: "skill",
+    slug: "pr-reviewer",
+    name: "pr-reviewer",
+    description: "Review pull requests for correctness, design, and standards compliance",
+    tags: ["review", "workflow"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: pr-reviewer
+description: Review pull requests for correctness, design, and standards compliance. Use when reviewing a teammate's PR or self-reviewing before requesting review.
+---
+# PR Reviewer
+
+Review pull requests with a systematic approach that catches real issues.
+
+## Review Order
+
+1. **Understand the intent** — read the PR description first
+2. **Holistic diff** — read all changed files together before diving into details
+3. **Correctness** — will this do what it claims? Are there unhandled edge cases?
+4. **Tests** — are the new tests meaningful? Do they cover the failure modes?
+5. **Design** — does this fit the existing architecture?
+6. **Standards** — naming, error handling patterns, logging conventions for this codebase
+
+## Commenting Rules
+
+- Be specific: "This will fail when X" not "This might be wrong"
+- Label clearly: BLOCKING (must fix), SUGGESTION (opinion), QUESTION (needs clarification)
+- Don't bikeshed: if code is correct and readable, the author's style preference wins
+
+## Verdict
+
+APPROVE / REQUEST CHANGES / COMMENT (feedback only)
+`,
+  },
+
+  // ── Agents ──────────────────────────────────────────────────────────────────
+  {
+    id: "agent/backend-architect",
+    kind: "agent",
+    slug: "backend-architect",
+    name: "backend-architect",
+    description: "Design backend APIs, data models, and system architecture",
+    tags: ["architecture", "backend", "api"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: backend-architect
+description: Design backend APIs, data models, and system architecture. Use when starting a new service, designing an API surface, or evaluating architectural trade-offs.
+tools: Read, Glob, Grep, WebFetch
+---
+You are a backend architect helping design APIs, data models, and service boundaries.
+
+When asked to design a system or API:
+
+1. **Clarify requirements first** — ask about expected load, consistency requirements, team size, and constraints before proposing
+2. **Model the data first** — correct data models make APIs obvious; wrong models make APIs painful forever
+3. **Design for failure modes** — what happens when the DB is slow? When a third-party service is down?
+4. **Prefer boring technology** — choose established solutions (PostgreSQL, Redis, REST) over novel ones without specific justification
+5. **Surface trade-offs explicitly** — for every non-obvious choice, explain what you're optimizing for and what you're giving up
+
+Output: ASCII data model diagram, API endpoint list with request/response shapes, key design decisions with rationale, and open questions that need answers before implementation.
+`,
+  },
+  {
+    id: "agent/security-reviewer",
+    kind: "agent",
+    slug: "security-reviewer",
+    name: "security-reviewer",
+    description: "Systematic security review of codebases, APIs, and configurations",
+    tags: ["security", "review"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: security-reviewer
+description: Systematic security review of codebases, APIs, and configurations. Use when assessing a new codebase or reviewing auth/permission logic.
+tools: Read, Glob, Grep, Bash
+---
+You are a security auditor conducting a systematic review for vulnerabilities.
+
+Your approach:
+1. **Map the attack surface** — what inputs does the system accept? From where? Authenticated or not?
+2. **Follow the data** — trace user-supplied data from entry point to every sink (DB, filesystem, shell, HTML)
+3. **Check trust boundaries** — is validation happening at each boundary crossing?
+4. **Assess authentication and authorization** — are auth checks present, correct, and consistently applied?
+5. **Review configuration** — hardcoded secrets, insecure defaults, overly permissive settings
+
+For each vulnerability:
+- State the exact location (file + line)
+- Describe the attack scenario in concrete terms
+- Assess severity: Critical / High / Medium / Low
+- Propose a specific fix
+
+Only report confirmed or near-certain vulnerabilities.
+`,
+  },
+  {
+    id: "agent/test-engineer",
+    kind: "agent",
+    slug: "test-engineer",
+    name: "test-engineer",
+    description: "Design and implement comprehensive test suites",
+    tags: ["testing", "code-quality"],
+    stacks: ["typescript", "python", "go", "rust"],
+    content: `---
+name: test-engineer
+description: Design and implement comprehensive test suites. Use when building a testing strategy for a new codebase or improving coverage on an existing one.
+tools: Read, Write, Bash, Glob, Grep
+---
+You are a test engineering specialist focused on building test suites that catch real bugs.
+
+Your philosophy:
+- Tests are code — they need the same care as production code
+- Test behavior, not implementation — what the function does, not how it does it
+- A test that can't fail is worse than no test — it gives false confidence
+- Integration tests find real bugs; unit tests pinpoint causes
+
+When adding tests to an existing codebase:
+1. Read existing tests first — understand patterns, fixtures, and test infrastructure in use
+2. Identify the highest-risk untested code paths (auth, data mutation, external integrations)
+3. Write tests that would have caught real bugs — not just happy-path coverage
+4. Ensure tests are deterministic — no time-dependent behavior, no global state leakage
+
+When building a test strategy for a new codebase:
+1. Recommend a testing pyramid: many unit tests, some integration tests, few E2E tests
+2. Identify what to mock vs. what to test with real implementations
+3. Set up CI integration so tests run on every PR
+`,
+  },
+  {
+    id: "agent/code-explainer",
+    kind: "agent",
+    slug: "code-explainer",
+    name: "code-explainer",
+    description: "Explain complex code clearly for developers unfamiliar with a codebase",
+    tags: ["documentation", "onboarding"],
+    stacks: ["typescript", "python", "go", "rust", "generic"],
+    content: `---
+name: code-explainer
+description: Explain complex code clearly for developers unfamiliar with a codebase or concept. Use when onboarding to a new codebase or understanding legacy code.
+tools: Read, Glob, Grep, Bash
+---
+You are an expert at explaining complex code to developers who are unfamiliar with it.
+
+When asked to explain code:
+1. **Start with the purpose** — what problem does this code solve? Why does it exist?
+2. **Explain the structure** — how is it organized? What are the main components?
+3. **Walk through the logic** — trace execution for a typical case
+4. **Highlight non-obvious parts** — what would surprise a new reader? What invariants must hold?
+5. **Show usage patterns** — how is this code called? What are the common use cases?
+
+Adapt your explanation to the asker's apparent level:
+- "What does X do?" — explain X in isolation with concrete examples
+- "How does the whole system work?" — architectural overview first, then drill down
+
+Use concrete examples, ASCII diagrams where helpful, and avoid jargon not already in the codebase. Reference actual file names and line numbers.
+`,
+  },
+];
+
+/** Stack → library item IDs pre-selected in the new-project wizard. */
+export const STACK_PRESETS: Record<string, string[]> = {
+  typescript: [
+    "command/review",
+    "command/commit",
+    "command/test-gen",
+    "skill/code-reviewer",
+    "skill/test-writer",
+    "skill/doc-writer",
+  ],
+  python: [
+    "command/review",
+    "command/commit",
+    "command/debug",
+    "skill/code-reviewer",
+    "skill/security-auditor",
+    "skill/doc-writer",
+  ],
+  go: [
+    "command/review",
+    "command/commit",
+    "command/test-gen",
+    "skill/code-reviewer",
+    "skill/test-writer",
+  ],
+  rust: [
+    "command/review",
+    "command/commit",
+    "skill/code-reviewer",
+    "skill/security-auditor",
+  ],
+  generic: [
+    "command/review",
+    "command/commit",
+    "skill/code-reviewer",
+    "skill/git-workflow",
+  ],
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -756,6 +756,7 @@ export type ConflictPolicy = "skip" | "overwrite" | "merge" | "rename";
 export type ApplySource =
   | { kind: "project"; slug: string }
   | { kind: "user" }
+  | { kind: "library"; libraryId: string }
   /** Internal-only: direct path to a "virtual project root" — used by the
    *  template apply layer. Never accepted by the public API validator
    *  (would be a path-safety hole). */

--- a/tests/library.test.ts
+++ b/tests/library.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { LIBRARY, STACK_PRESETS } from "@/lib/template/library";
+
+describe("LIBRARY index", () => {
+  it("has at least one item per kind", () => {
+    const kinds = new Set(LIBRARY.map((i) => i.kind));
+    expect(kinds.has("command")).toBe(true);
+    expect(kinds.has("skill")).toBe(true);
+    expect(kinds.has("agent")).toBe(true);
+  });
+
+  it("each item has a unique id", () => {
+    const ids = LIBRARY.map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("each item id matches <kind>/<slug>", () => {
+    for (const item of LIBRARY) {
+      expect(item.id).toBe(`${item.kind}/${item.slug}`);
+    }
+  });
+
+  it("each item has non-empty required fields", () => {
+    for (const item of LIBRARY) {
+      expect(item.id.length).toBeGreaterThan(0);
+      expect(item.slug.length).toBeGreaterThan(0);
+      expect(item.name.length).toBeGreaterThan(0);
+      expect(item.description.length).toBeGreaterThan(0);
+      expect(item.content.length).toBeGreaterThan(0);
+      expect(item.tags.length).toBeGreaterThan(0);
+      expect(item.stacks.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each item kind is agent, skill, or command", () => {
+    const valid = new Set(["agent", "skill", "command"]);
+    for (const item of LIBRARY) {
+      expect(valid.has(item.kind)).toBe(true);
+    }
+  });
+
+  it("each item content starts with YAML frontmatter", () => {
+    for (const item of LIBRARY) {
+      expect(item.content.trimStart()).toMatch(/^---\n/);
+    }
+  });
+});
+
+describe("STACK_PRESETS", () => {
+  it("covers all four stacks", () => {
+    for (const stack of ["typescript", "python", "go", "rust"]) {
+      expect(STACK_PRESETS[stack]).toBeDefined();
+      expect((STACK_PRESETS[stack] ?? []).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("each preset id references an existing library item", () => {
+    const ids = new Set(LIBRARY.map((i) => i.id));
+    for (const [stack, preset] of Object.entries(STACK_PRESETS)) {
+      for (const id of preset) {
+        expect(ids.has(id), `Stack "${stack}" preset references unknown id "${id}"`).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/newProjectLogic.test.ts
+++ b/tests/newProjectLogic.test.ts
@@ -59,6 +59,14 @@ describe("library item apply path derivation", () => {
     }
   });
 
+  it("skill apply key includes :standalone layout suffix", () => {
+    const skills = LIBRARY.filter((i) => i.kind === "skill");
+    for (const s of skills) {
+      const key = `${s.slug}:standalone`;
+      expect(key).toMatch(/^[a-z0-9-]+:standalone$/);
+    }
+  });
+
   it("commands map to .claude/commands/<slug>.md", () => {
     const commands = LIBRARY.filter((i) => i.kind === "command");
     for (const c of commands) {

--- a/tests/newProjectLogic.test.ts
+++ b/tests/newProjectLogic.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { LIBRARY, STACK_PRESETS } from "@/lib/template/library";
+
+/**
+ * Tests for the new-project wizard's logic (stack presets, library integration).
+ * The route handler itself exercises bootstrapNewProject which has its own integration
+ * concerns; here we verify the static data assumptions the wizard relies on.
+ */
+
+describe("stack preset → library item mapping", () => {
+  it("typescript preset selects at least a reviewer and test-writer", () => {
+    const ids = new Set(STACK_PRESETS.typescript ?? []);
+    const hasReviewer = [...ids].some((id) => id.includes("reviewer"));
+    const hasTesting = [...ids].some((id) => id.includes("test"));
+    expect(hasReviewer).toBe(true);
+    expect(hasTesting).toBe(true);
+  });
+
+  it("python preset selects at least a reviewer", () => {
+    const ids = new Set(STACK_PRESETS.python ?? []);
+    expect([...ids].some((id) => id.includes("reviewer"))).toBe(true);
+  });
+
+  it("go preset selects at least a reviewer", () => {
+    const ids = new Set(STACK_PRESETS.go ?? []);
+    expect([...ids].some((id) => id.includes("reviewer"))).toBe(true);
+  });
+
+  it("rust preset selects at least a reviewer", () => {
+    const ids = new Set(STACK_PRESETS.rust ?? []);
+    expect([...ids].some((id) => id.includes("reviewer"))).toBe(true);
+  });
+
+  it("all stack presets include the /review command", () => {
+    for (const [stack, preset] of Object.entries(STACK_PRESETS)) {
+      if (stack === "generic") continue;
+      expect(preset, `${stack} preset`).toContain("command/review");
+    }
+  });
+});
+
+describe("library item apply path derivation", () => {
+  it("agents map to .claude/agents/<slug>.md", () => {
+    const agents = LIBRARY.filter((i) => i.kind === "agent");
+    for (const a of agents) {
+      const expectedPath = `.claude/agents/${a.slug}.md`;
+      // Just validate slug doesn't contain path separators
+      expect(a.slug).not.toContain("/");
+      expect(a.slug).not.toContain("\\");
+      expect(expectedPath).toMatch(/^\.claude\/agents\/.+\.md$/);
+    }
+  });
+
+  it("skills map to .claude/skills/<slug>.md", () => {
+    const skills = LIBRARY.filter((i) => i.kind === "skill");
+    for (const s of skills) {
+      expect(s.slug).not.toContain("/");
+      expect(`.claude/skills/${s.slug}.md`).toMatch(/^\.claude\/skills\/.+\.md$/);
+    }
+  });
+
+  it("commands map to .claude/commands/<slug>.md", () => {
+    const commands = LIBRARY.filter((i) => i.kind === "command");
+    for (const c of commands) {
+      expect(c.slug).not.toContain("/");
+      expect(`.claude/commands/${c.slug}.md`).toMatch(/^\.claude\/commands\/.+\.md$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **#77 Curated template library** — `/library` page with 16 production-ready items (5 commands, 7 skills, 4 agents). Items inlined as TypeScript strings; no `fs.readFile`, no production build path issues. New `source.kind: "library"` in `ApplySource`; `applyFromLibrary` writes to a temp dir then re-enters existing primitives. Filter by kind, search by name/description/tag, expand row to apply to any project.
- **#78 New-project wizard** — `/new-project` 4-step form: details → stack (TypeScript/Python/Go/Rust) → library items (stack-based presets) → confirm. `POST /api/projects/new` bootstraps directory + git init + applies selected items. Dashboard **New** button and AppNav **+ New** root link.

## Test plan

- [ ] `/library` renders 16 items, kind filter buttons work, search filters rows
- [ ] Expand a row → project selector → **Preview** returns `would-apply` without writing; **Apply** writes file to `.claude/skills/` (or agents/commands)
- [ ] `/new-project` → fill name → Next → pick TypeScript → Next → items pre-selected → Next → Confirm → project directory created with `git init` and selected library files written
- [ ] New project appears on dashboard after redirect
- [ ] Dashboard **New** button navigates to `/new-project`
- [ ] AppNav Catalog → Library opens `/library`

## Verification

`npm run typecheck` clean · 1864 tests passing (171 files, +16 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)