### PR TITLE
ui-fix: stats overflow + standardize period toggles + real config-health score

### DIFF
--- a/src/app/api/home-health/route.ts
+++ b/src/app/api/home-health/route.ts
@@ -1,0 +1,104 @@
+import "server-only";
+import { NextResponse } from "next/server";
+import { efficiencyGradeCache } from "@/lib/efficiencyGradeCache";
+import {
+  getCacheEfficiency,
+  getEditAcceptance,
+  getPressureSnapshot,
+} from "@/lib/db/otelQueries";
+import { getAllFindings, getLatestRun } from "@/lib/scanner/mcp-security/store";
+import { computeHealthScore, type HealthInputs } from "@/lib/healthScore";
+
+export const dynamic = "force-dynamic";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * GET /api/home-health
+ *
+ * Aggregates the six configuration-health signals into a single weighted
+ * score for the Home page gauge. All inputs are DB-backed or memory-cached
+ * so this route is cheap to call on every Home mount; we don't add
+ * additional caching here.
+ */
+export async function GET(request: Request): Promise<NextResponse> {
+  const url = new URL(request.url);
+  const approvals = Number(url.searchParams.get("approvals") ?? "0") || 0;
+
+  const since = Date.now() - SEVEN_DAYS_MS;
+
+  // efficiencyGradeCache.getAll() is synchronous (in-memory map).
+  const grades = (() => {
+    try {
+      return efficiencyGradeCache.getAll();
+    } catch {
+      return {};
+    }
+  })();
+
+  // Pull the async signals in parallel. If any fails individually, fall back
+  // to the "no data" shape so the rest of the report still renders.
+  const [cache, mcpFindings, mcpRun, pressure, edit] = await Promise.all([
+    safeAwait(getCacheEfficiency({ period: "7d" }), null),
+    safeAwait(getAllFindings(), [] as Awaited<ReturnType<typeof getAllFindings>>),
+    safeAwait(getLatestRun(), null),
+    safeAwait(getPressureSnapshot({ since }), null),
+    safeAwait(getEditAcceptance({ since }), null),
+  ]);
+
+  const findingsBucket = bucketBySeverity(mcpFindings);
+
+  const inputs: HealthInputs = {
+    grades,
+    cacheHitRate: cache?.hasData ? cache.hitRate : null,
+    mcpFindings: findingsBucket,
+    mcpScanned: mcpRun !== null,
+    approvals,
+    pressure: pressure
+      ? {
+          retryExhaustion: pressure.retryExhaustionCount,
+          compactions: pressure.compactionCount,
+          hasData: pressure.hasData,
+        }
+      : { retryExhaustion: 0, compactions: 0, hasData: false },
+    editAcceptance: edit
+      ? { rate: deriveAcceptRate(edit.tools), n: edit.totalN, hasData: edit.hasData }
+      : { rate: 0, n: 0, hasData: false },
+  };
+
+  const report = computeHealthScore(inputs);
+
+  return NextResponse.json(report);
+}
+
+async function safeAwait<T>(p: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await p;
+  } catch {
+    return fallback;
+  }
+}
+
+function bucketBySeverity(
+  findings: Awaited<ReturnType<typeof getAllFindings>>,
+): { crit: number; high: number; med: number; low: number; info: number } {
+  const out = { crit: 0, high: 0, med: 0, low: 0, info: 0 };
+  for (const f of findings) {
+    const sev = f.severity as keyof typeof out;
+    if (sev in out) out[sev]++;
+  }
+  return out;
+}
+
+// Aggregate accept-rate across all tools weighted by sample count. Mirrors
+// what EditAcceptanceCard's headline shows but at a portfolio level.
+function deriveAcceptRate(
+  tools: Array<{ accepted: number; rejected: number }>,
+): number {
+  let accepted = 0, total = 0;
+  for (const t of tools) {
+    accepted += t.accepted;
+    total += t.accepted + t.rejected;
+  }
+  return total > 0 ? accepted / total : 0;
+}

--- a/src/app/api/home-health/route.ts
+++ b/src/app/api/home-health/route.ts
@@ -37,11 +37,19 @@ export async function GET(request: Request): Promise<NextResponse> {
   })();
 
   // Pull the async signals in parallel. If any fails individually, fall back
-  // to the "no data" shape so the rest of the report still renders.
-  const [cache, mcpFindings, mcpRun, pressure, edit] = await Promise.all([
+  // to the "no data" shape so the rest of the report still renders. We
+  // resolve the latest scan run first so the findings query can be scoped
+  // to that run only — `mcp_scan_findings` stores rows per run, so an
+  // unscoped query accumulates fixed findings across history and the
+  // health score would drift downward over time even as issues get fixed
+  // (PR #103 codex P1).
+  const mcpRun = await safeAwait(getLatestRun(), null);
+  const [cache, mcpFindings, pressure, edit] = await Promise.all([
     safeAwait(getCacheEfficiency({ period: "7d" }), null),
-    safeAwait(getAllFindings(), [] as Awaited<ReturnType<typeof getAllFindings>>),
-    safeAwait(getLatestRun(), null),
+    safeAwait(
+      mcpRun ? getAllFindings(undefined, mcpRun.id) : Promise.resolve([]),
+      [] as Awaited<ReturnType<typeof getAllFindings>>,
+    ),
     safeAwait(getPressureSnapshot({ since }), null),
     safeAwait(getEditAcceptance({ since }), null),
   ]);

--- a/src/app/api/kanban/route.ts
+++ b/src/app/api/kanban/route.ts
@@ -9,13 +9,20 @@ import type { Task } from "@/lib/tasks/types";
 
 export const dynamic = "force-dynamic";
 
-const VALID_PERIODS = new Set<KanbanPeriod>(["last24h", "last7d", "all"]);
+const VALID_PERIODS = new Set<KanbanPeriod>(["today", "7d", "30d", "all"]);
+// Legacy aliases for URLs/clients still on the old kanban-specific keys.
+// Resolve them to the standard vocabulary at the API boundary.
+const LEGACY_PERIODS: Record<string, KanbanPeriod> = {
+  last24h: "today",
+  last7d: "7d",
+};
 
 // Polling cadence is intentionally 6 s on the client so this route hits
 // getLiveStatusPayload()'s 6 s cache as a near-100% cache hit.
 export async function GET(request: Request): Promise<NextResponse> {
   const url = new URL(request.url);
-  const periodParam = url.searchParams.get("period") ?? "last24h";
+  const raw = url.searchParams.get("period") ?? "today";
+  const periodParam = LEGACY_PERIODS[raw] ?? raw;
 
   if (!VALID_PERIODS.has(periodParam as KanbanPeriod)) {
     return NextResponse.json(
@@ -86,9 +93,10 @@ function filterTasksByPeriod(
 ) {
   if (period === "all") return tasks;
 
-  const cutoffMs = period === "last24h"
-    ? 24 * 60 * 60 * 1000
-    : 7 * 24 * 60 * 60 * 1000;
+  const cutoffMs =
+    period === "today" ? 24 * 60 * 60 * 1000 :
+    period === "7d"    ? 7 * 24 * 60 * 60 * 1000 :
+                         30 * 24 * 60 * 60 * 1000;
 
   const cutoff = Date.now() - cutoffMs;
 

--- a/src/app/api/telemetry/cache-efficiency/route.ts
+++ b/src/app/api/telemetry/cache-efficiency/route.ts
@@ -7,8 +7,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
   const period = (searchParams.get("period") ?? "7d") as Period;
 
-  if (!["today", "7d", "30d"].includes(period)) {
-    return NextResponse.json({ error: "period must be today|7d|30d" }, { status: 400 });
+  if (!["today", "7d", "30d", "all"].includes(period)) {
+    return NextResponse.json({ error: "period must be today|7d|30d|all" }, { status: 400 });
   }
 
   try {

--- a/src/app/api/telemetry/token-usage/route.ts
+++ b/src/app/api/telemetry/token-usage/route.ts
@@ -7,8 +7,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
   const period = (searchParams.get("period") ?? "7d") as Period;
 
-  if (!["today", "7d", "30d"].includes(period)) {
-    return NextResponse.json({ error: "period must be today|7d|30d" }, { status: 400 });
+  if (!["today", "7d", "30d", "all"].includes(period)) {
+    return NextResponse.json({ error: "period must be today|7d|30d|all" }, { status: 400 });
   }
 
   try {

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -29,7 +29,7 @@ if (!globalForUsage.__usageCache) {
 
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
-  const safePeriod = validatePeriod(params.get("period") || "month");
+  const safePeriod = validatePeriod(params.get("period") || "30d");
   const project = params.get("project") || undefined;
   const source = params.get("source") || undefined;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -564,11 +564,21 @@ export default function HomePage() {
           <div className="gauge-wrap" style={{ marginBottom: 18 }}>
             <div className="gauge">
               <GaugeRing
-                pct={healthScore}
-                color={healthScore >= 75 ? "var(--good)" : healthScore >= 60 ? "var(--accent)" : "var(--danger)"}
+                // While the health report is loading we show an empty
+                // ring at the neutral track color rather than 0% red — a
+                // brief "0%" red flash on every Home mount made it look
+                // like the environment was unhealthy when it was just
+                // waiting on the fetch.
+                pct={health === null ? 0 : healthScore}
+                color={
+                  health === null ? "var(--bg-elev-2)"
+                  : healthScore >= 75 ? "var(--good)"
+                  : healthScore >= 60 ? "var(--accent)"
+                  : "var(--danger)"
+                }
               />
               <div className="center">
-                <div className="pct">{healthScore}%</div>
+                <div className="pct">{health === null ? "—" : `${healthScore}%`}</div>
                 <div className="lab">{healthLabel}</div>
               </div>
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useScope } from "@/components/ScopeProvider";
 import { usePulse } from "@/components/PulseProvider";
 import { projectColor } from "@/lib/projectColor";
+import type { HealthReport } from "@/lib/healthScore";
 import type { ProjectData, SessionSummary } from "@/lib/types";
 import type { UsageReport } from "@/lib/usage/types";
 
@@ -72,6 +73,7 @@ export default function HomePage() {
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [insightCount, setInsightCount] = useState<number>(0);
   const [pendingStepsCount, setPendingStepsCount] = useState<number>(0);
+  const [health, setHealth] = useState<HealthReport | null>(null);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -188,16 +190,30 @@ export default function HomePage() {
   // day-to-day.
   const cacheHitRate = usageAll?.cacheHitRate ?? 0;
 
-  // Health score: simple proxy = 100 - clamp(insights/issues per project)
-  const healthScore = useMemo(() => {
-    if (!projectCount) return 100;
-    const issues = insightCount + pendingStepsCount + (snapshot.approvalCount || 0);
-    const ratio = Math.min(1, issues / Math.max(1, projectCount * 4));
-    return Math.round(100 - ratio * 100);
-  }, [insightCount, pendingStepsCount, projectCount, snapshot.approvalCount]);
+  // Configuration health score is a weighted roll-up computed server-side
+  // by /api/home-health from real environment signals (project efficiency
+  // grades, cache utilization, MCP security findings, pending approvals,
+  // telemetry pressure, edit acceptance). See src/lib/healthScore.ts for
+  // the formula. We refetch when approvals change so the gauge moves
+  // immediately on approval action.
+  useEffect(() => {
+    const ctrl = new AbortController();
+    fetch(`/api/home-health?approvals=${snapshot.approvalCount}`, { signal: ctrl.signal })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: HealthReport | null) => d && setHealth(d))
+      .catch(() => {});
+    return () => ctrl.abort();
+  }, [snapshot.approvalCount]);
 
+  const healthScore = health?.score ?? 0;
+  const healthGrade = health?.grade ?? "—";
   const healthLabel =
-    healthScore >= 85 ? "Healthy" : healthScore >= 60 ? "Fair" : healthScore >= 30 ? "Needs work" : "At risk";
+    !health ? "—"
+    : healthScore >= 90 ? "Healthy"
+    : healthScore >= 75 ? "Good"
+    : healthScore >= 60 ? "Fair"
+    : healthScore >= 40 ? "Needs work"
+    : "At risk";
 
   // Token usage chart matches the active period toggle. For "today" we
   // expand back to the last 3 days so a single bar doesn't sit awkwardly
@@ -322,9 +338,13 @@ export default function HomePage() {
           sparkColor="var(--info)"
         />
         <Stat
-          label="Health score"
-          value={usageAll === null ? "—" : `${healthScore}%`}
-          sub={`${insightCount} insights · ${pendingStepsCount} steps`}
+          label="Config health"
+          value={health === null ? "—" : `${healthScore}%`}
+          sub={
+            health === null
+              ? "loading…"
+              : `${healthGrade} — ${healthLabel.toLowerCase()}`
+          }
           accent="var(--danger)"
         />
       </div>
@@ -530,7 +550,11 @@ export default function HomePage() {
         <Card>
           <CardHeader
             title="Config health"
-            sub={`${insightCount + pendingStepsCount + snapshot.approvalCount} items`}
+            sub={
+              health === null
+                ? "loading…"
+                : `${health.components.filter((c) => c.score !== null).length} of ${health.components.length} signals`
+            }
             right={
               <Link href="/insights" style={{ textDecoration: "none" }}>
                 <Pill style={{ height: 26 }}>Open <ArrowRight width={12} height={12} /></Pill>
@@ -539,17 +563,44 @@ export default function HomePage() {
           />
           <div className="gauge-wrap" style={{ marginBottom: 18 }}>
             <div className="gauge">
-              <GaugeRing pct={healthScore} color={healthScore >= 60 ? "var(--good)" : "var(--accent)"} />
+              <GaugeRing
+                pct={healthScore}
+                color={healthScore >= 75 ? "var(--good)" : healthScore >= 60 ? "var(--accent)" : "var(--danger)"}
+              />
               <div className="center">
                 <div className="pct">{healthScore}%</div>
                 <div className="lab">{healthLabel}</div>
               </div>
             </div>
             <div className="health-cat" style={{ flex: 1 }}>
-              <CategoryRow name="Approvals" pct={Math.min(100, snapshot.approvalCount * 25)} color="var(--danger)" count={`${snapshot.approvalCount}`} />
-              <CategoryRow name="Manual steps" pct={Math.min(100, pendingStepsCount * 10)} color="var(--warn)" count={`${pendingStepsCount}`} />
-              <CategoryRow name="Insights" pct={Math.min(100, insightCount * 5)} color="var(--info)" count={`${insightCount}`} />
-              <CategoryRow name="Sessions live" pct={Math.min(100, liveSessionCount * 25)} color="var(--good)" count={`${liveSessionCount}`} />
+              {health
+                ? health.components.map((c) => (
+                    <CategoryRow
+                      key={c.id}
+                      name={c.label}
+                      pct={c.score ?? 0}
+                      color={
+                        c.score === null
+                          ? "var(--bg-elev-2)"
+                          : c.score >= 75
+                            ? "var(--good)"
+                            : c.score >= 60
+                              ? "var(--accent)"
+                              : "var(--danger)"
+                      }
+                      count={c.score === null ? "—" : `${c.score}`}
+                      title={c.detail}
+                    />
+                  ))
+                : Array.from({ length: 6 }).map((_, i) => (
+                    <CategoryRow
+                      key={i}
+                      name=""
+                      pct={0}
+                      color="var(--bg-elev-2)"
+                      count=""
+                    />
+                  ))}
             </div>
           </div>
         </Card>
@@ -558,9 +609,22 @@ export default function HomePage() {
   );
 }
 
-function CategoryRow({ name, pct, color, count }: { name: string; pct: number; color: string; count: string }) {
+function CategoryRow({
+  name,
+  pct,
+  color,
+  count,
+  title,
+}: {
+  name: string;
+  pct: number;
+  color: string;
+  count: string;
+  /** Optional native tooltip — used to surface the component's `detail` line. */
+  title?: string;
+}) {
   return (
-    <div className="row">
+    <div className="row" title={title}>
       <span className="name">{name}</span>
       <div className="bar-wrap">
         <div className="seg-bar" style={{ width: `${pct}%`, background: color }} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,11 @@ import { projectColor } from "@/lib/projectColor";
 import type { ProjectData, SessionSummary } from "@/lib/types";
 import type { UsageReport } from "@/lib/usage/types";
 
-type Period = "today" | "week" | "month";
+// Match the standard period vocabulary in src/lib/usage/constants.ts.
+// Home doesn't currently surface the 'all' option in the toggle — the
+// daily-bucket array is already fetched with period=all and the four-way
+// toggle felt like more granularity than this overview surface needs.
+type Period = "today" | "7d" | "30d";
 
 // Shape of /api/insights — `{ insights: InsightEntry[], total: number }`.
 // Earlier this file declared a non-existent `{ results: …, total }` shape and
@@ -34,8 +38,8 @@ interface InsightsResponse {
 
 const PERIOD_OPTIONS: { value: Period; label: string }[] = [
   { value: "today", label: "Today" },
-  { value: "week", label: "7 days" },
-  { value: "month", label: "30 days" },
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
 ];
 
 function timeOfDayGreeting(): string {
@@ -155,19 +159,18 @@ export default function HomePage() {
   const liveProject = activeSlugs[0] ?? null;
 
   // Slice the full daily array based on the active period toggle.
-  // "today" = last 1 entry; "week" = last 7; "month" = last 30 — true
-  // rolling windows that match the toggle labels regardless of where in
-  // the calendar month we are.
+  // today=last 1, 7d=last 7, 30d=last 30 — true rolling windows that match
+  // the toggle labels regardless of where in the calendar month we are.
   const periodDays = useMemo(() => {
     if (!usageAll?.daily?.length) return [];
     const all = usageAll.daily;
     if (period === "today") return all.slice(-1);
-    if (period === "week") return all.slice(-7);
+    if (period === "7d") return all.slice(-7);
     return all.slice(-30);
   }, [period, usageAll]);
 
-  // Headline numbers come from the sliced daily buckets so they react to the
-  // toggle even when the calendar period (week/month) hasn't started yet.
+  // Headline numbers come from the sliced daily buckets so they react to
+  // the toggle deterministically.
   const headlineCost = useMemo(
     () => periodDays.reduce((s, d) => s + d.cost, 0),
     [periodDays],
@@ -203,7 +206,7 @@ export default function HomePage() {
     if (!usageAll?.daily?.length) return [];
     const slice =
       period === "today" ? usageAll.daily.slice(-3)
-      : period === "week" ? usageAll.daily.slice(-7)
+      : period === "7d" ? usageAll.daily.slice(-7)
       : usageAll.daily.slice(-30);
     return slice.map((d) => ({
       label: d.date.slice(5).replace("-", "/"),
@@ -256,7 +259,7 @@ export default function HomePage() {
 
   const periodSubtext =
     period === "today" ? `${now.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })}` :
-    period === "week" ? "Last 7 days" : "Last 30 days";
+    period === "7d" ? "Last 7 days" : "Last 30 days";
 
   return (
     <div className="shell-content wide">
@@ -293,7 +296,7 @@ export default function HomePage() {
           sub={
             period === "today"
               ? "today so far"
-              : period === "week"
+              : period === "7d"
                 ? "last 7 days"
                 : "last 30 days"
           }
@@ -378,7 +381,7 @@ export default function HomePage() {
             sub={
               period === "today"
                 ? "last 3 days"
-                : period === "week"
+                : period === "7d"
                   ? "last 7 days"
                   : "last 30 days"
             }

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -229,7 +229,7 @@ function filterCards(
 }
 
 export function KanbanBoard() {
-  const [period, setPeriod] = useState<KanbanPeriod>("last24h");
+  const [period, setPeriod] = useState<KanbanPeriod>("today");
   const [kindFilter, setKindFilter] = useState<KanbanKindFilter>("all");
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
@@ -391,8 +391,9 @@ export function KanbanBoard() {
             cursor: "pointer",
           }}
         >
-          <option value="last24h">Last 24 h</option>
-          <option value="last7d">Last 7 d</option>
+          <option value="today">Today</option>
+          <option value="7d">7 days</option>
+          <option value="30d">30 days</option>
           <option value="all">All time</option>
         </select>
 

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -17,7 +17,7 @@ export function ShareButton({ period, project, source }: ShareButtonProps) {
   const [previewPeriod, setPreviewPeriod] = useState<Period>(
     (VALID_PERIODS.map((p) => p.value) as string[]).includes(period)
       ? (period as Period)
-      : "month",
+      : "30d",
   );
 
   const svgUrl = buildUrl({ period: previewPeriod, theme, project, source });

--- a/src/components/UsageDashboard.tsx
+++ b/src/components/UsageDashboard.tsx
@@ -553,7 +553,7 @@ function ChartLabel({ children }: { children: import("react").ReactNode }) {
 // ── Main Dashboard ─────────────────────────────────────────────────────────
 
 export function UsageDashboard() {
-  const [period, setPeriod] = useState<string>("month");
+  const [period, setPeriod] = useState<string>("30d");
   const [project, setProject] = useState<string | undefined>(undefined);
   const [breakdownMode, setBreakdownMode] = useState<"aggregate" | "by-project">("aggregate");
   const { data, loading } = useUsage(period, project);

--- a/src/components/stats/CacheEfficiencyCard.tsx
+++ b/src/components/stats/CacheEfficiencyCard.tsx
@@ -37,15 +37,16 @@ export function CacheEfficiencyCard() {
         <>
           <div style={{ display: "flex", alignItems: "baseline", gap: "10px" }}>
             <span
+              title={data.hitRate > 1 || data.hitRate < 0 ? `Raw rate ${(data.hitRate * 100).toFixed(0)}% — clamped for display` : undefined}
               style={{
                 fontFamily: "var(--font-mono)",
                 fontSize: "2.2rem",
                 fontWeight: 700,
-                color: hitRateColor(data.hitRate),
+                color: hitRateColor(Math.max(0, Math.min(1, data.hitRate))),
                 lineHeight: 1,
               }}
             >
-              {Math.round(data.hitRate * 100)}%
+              {Math.round(Math.max(0, Math.min(1, data.hitRate)) * 100)}%
             </span>
             <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--text-muted)" }}>
               cache hit rate
@@ -73,20 +74,26 @@ export function CacheEfficiencyCard() {
                 borderTop: "1px dashed rgba(245,158,11,0.4)",
               }} />
               <div style={{ display: "flex", gap: "2px", alignItems: "flex-end", height: "100%" }}>
-                {data.daily.map((d) => (
-                  <div
-                    key={d.day}
-                    title={`${d.day}: ${Math.round(d.hitRate * 100)}%`}
-                    style={{
-                      flex: 1,
-                      height: `${Math.max(2, d.hitRate * 32)}px`,
-                      background: hitRateColor(d.hitRate),
-                      borderRadius: "1px",
-                      opacity: 0.7,
-                      minWidth: "2px",
-                    }}
-                  />
-                ))}
+                {data.daily.map((d) => {
+                  const clamped = Math.max(0, Math.min(1, d.hitRate));
+                  const tooltip = d.hitRate > 1 || d.hitRate < 0
+                    ? `${d.day}: ${Math.round(d.hitRate * 100)}% (clamped)`
+                    : `${d.day}: ${Math.round(d.hitRate * 100)}%`;
+                  return (
+                    <div
+                      key={d.day}
+                      title={tooltip}
+                      style={{
+                        flex: 1,
+                        height: `${Math.max(2, clamped * 32)}px`,
+                        background: hitRateColor(clamped),
+                        borderRadius: "1px",
+                        opacity: 0.7,
+                        minWidth: "2px",
+                      }}
+                    />
+                  );
+                })}
               </div>
             </div>
           )}

--- a/src/components/stats/CacheEfficiencyCard.tsx
+++ b/src/components/stats/CacheEfficiencyCard.tsx
@@ -37,16 +37,15 @@ export function CacheEfficiencyCard() {
         <>
           <div style={{ display: "flex", alignItems: "baseline", gap: "10px" }}>
             <span
-              title={data.hitRate > 1 ? `Raw rate ${(data.hitRate * 100).toFixed(0)}% — clamped to 100% for display (cache reads exceeded billable tokens this period)` : undefined}
               style={{
                 fontFamily: "var(--font-mono)",
                 fontSize: "2.2rem",
                 fontWeight: 700,
-                color: hitRateColor(Math.min(1, data.hitRate)),
+                color: hitRateColor(data.hitRate),
                 lineHeight: 1,
               }}
             >
-              {Math.min(100, Math.round(data.hitRate * 100))}%
+              {Math.round(data.hitRate * 100)}%
             </span>
             <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--text-muted)" }}>
               cache hit rate
@@ -61,12 +60,10 @@ export function CacheEfficiencyCard() {
           </div>
 
           {data.daily.length > 1 && (
-            // overflow: hidden defensively clips the daily mini-bars at the
-            // container's 32px ceiling. Without it, a hitRate value > 1
-            // (which the API can return when cache reads exceed billable
-            // tokens) would scale the bar to 32 * hitRate pixels and burst
-            // out of the card. We also clamp hitRate per-day before
-            // multiplying to keep the visual tied to the [0, 1] domain.
+            // overflow: hidden is belt-and-suspenders defense in case the
+            // hitRate ever drifts outside [0, 1] again (the formula in
+            // otelQueries is bounded as of this commit, but it's a cheap
+            // guarantee that bad data can't burst out of the card).
             <div style={{ position: "relative", height: "32px", overflow: "hidden" }}>
               <div style={{
                 position: "absolute",
@@ -76,23 +73,20 @@ export function CacheEfficiencyCard() {
                 borderTop: "1px dashed rgba(245,158,11,0.4)",
               }} />
               <div style={{ display: "flex", gap: "2px", alignItems: "flex-end", height: "100%" }}>
-                {data.daily.map((d) => {
-                  const clamped = Math.max(0, Math.min(1, d.hitRate));
-                  return (
-                    <div
-                      key={d.day}
-                      title={`${d.day}: ${Math.round(d.hitRate * 100)}%${d.hitRate > 1 ? " (clamped)" : ""}`}
-                      style={{
-                        flex: 1,
-                        height: `${Math.max(2, clamped * 32)}px`,
-                        background: hitRateColor(clamped),
-                        borderRadius: "1px",
-                        opacity: 0.7,
-                        minWidth: "2px",
-                      }}
-                    />
-                  );
-                })}
+                {data.daily.map((d) => (
+                  <div
+                    key={d.day}
+                    title={`${d.day}: ${Math.round(d.hitRate * 100)}%`}
+                    style={{
+                      flex: 1,
+                      height: `${Math.max(2, d.hitRate * 32)}px`,
+                      background: hitRateColor(d.hitRate),
+                      borderRadius: "1px",
+                      opacity: 0.7,
+                      minWidth: "2px",
+                    }}
+                  />
+                ))}
               </div>
             </div>
           )}

--- a/src/components/stats/CacheEfficiencyCard.tsx
+++ b/src/components/stats/CacheEfficiencyCard.tsx
@@ -36,14 +36,17 @@ export function CacheEfficiencyCard() {
       {!loading && data?.hasData && (
         <>
           <div style={{ display: "flex", alignItems: "baseline", gap: "10px" }}>
-            <span style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "2.2rem",
-              fontWeight: 700,
-              color: hitRateColor(data.hitRate),
-              lineHeight: 1,
-            }}>
-              {Math.round(data.hitRate * 100)}%
+            <span
+              title={data.hitRate > 1 ? `Raw rate ${(data.hitRate * 100).toFixed(0)}% — clamped to 100% for display (cache reads exceeded billable tokens this period)` : undefined}
+              style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: "2.2rem",
+                fontWeight: 700,
+                color: hitRateColor(Math.min(1, data.hitRate)),
+                lineHeight: 1,
+              }}
+            >
+              {Math.min(100, Math.round(data.hitRate * 100))}%
             </span>
             <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.68rem", color: "var(--text-muted)" }}>
               cache hit rate
@@ -58,7 +61,13 @@ export function CacheEfficiencyCard() {
           </div>
 
           {data.daily.length > 1 && (
-            <div style={{ position: "relative", height: "32px" }}>
+            // overflow: hidden defensively clips the daily mini-bars at the
+            // container's 32px ceiling. Without it, a hitRate value > 1
+            // (which the API can return when cache reads exceed billable
+            // tokens) would scale the bar to 32 * hitRate pixels and burst
+            // out of the card. We also clamp hitRate per-day before
+            // multiplying to keep the visual tied to the [0, 1] domain.
+            <div style={{ position: "relative", height: "32px", overflow: "hidden" }}>
               <div style={{
                 position: "absolute",
                 top: `${(1 - TARGET_HIT_RATE) * 32}px`,
@@ -67,16 +76,23 @@ export function CacheEfficiencyCard() {
                 borderTop: "1px dashed rgba(245,158,11,0.4)",
               }} />
               <div style={{ display: "flex", gap: "2px", alignItems: "flex-end", height: "100%" }}>
-                {data.daily.map((d) => (
-                  <div key={d.day} title={`${d.day}: ${Math.round(d.hitRate * 100)}%`} style={{
-                    flex: 1,
-                    height: `${Math.max(2, d.hitRate * 32)}px`,
-                    background: hitRateColor(d.hitRate),
-                    borderRadius: "1px",
-                    opacity: 0.7,
-                    minWidth: "2px",
-                  }} />
-                ))}
+                {data.daily.map((d) => {
+                  const clamped = Math.max(0, Math.min(1, d.hitRate));
+                  return (
+                    <div
+                      key={d.day}
+                      title={`${d.day}: ${Math.round(d.hitRate * 100)}%${d.hitRate > 1 ? " (clamped)" : ""}`}
+                      style={{
+                        flex: 1,
+                        height: `${Math.max(2, clamped * 32)}px`,
+                        background: hitRateColor(clamped),
+                        borderRadius: "1px",
+                        opacity: 0.7,
+                        minWidth: "2px",
+                      }}
+                    />
+                  );
+                })}
               </div>
             </div>
           )}

--- a/src/components/stats/PeriodToggle.tsx
+++ b/src/components/stats/PeriodToggle.tsx
@@ -7,22 +7,30 @@ interface PeriodToggleProps {
   onChange: (p: Period) => void;
 }
 
-const PERIODS: Period[] = ["today", "7d", "30d"];
+// Standard four-option vocabulary used across every period toggle in the app.
+// Labels are display-friendly; values are the raw period keys passed to the
+// API. Mirrors VALID_PERIODS in src/lib/usage/constants.ts.
+const PERIODS: { value: Period; label: string }[] = [
+  { value: "today", label: "today" },
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "all", label: "all" },
+];
 
 export function PeriodToggle({ value, onChange }: PeriodToggleProps) {
   return (
     <div style={{ display: "flex", gap: "4px" }}>
       {PERIODS.map((p) => (
-        <button key={p} onClick={() => onChange(p)} style={{
+        <button key={p.value} onClick={() => onChange(p.value)} style={{
           fontFamily: "var(--font-mono)",
           fontSize: "0.65rem",
           padding: "2px 8px",
           borderRadius: "4px",
-          border: `1px solid ${value === p ? "var(--accent)" : "var(--border-subtle)"}`,
-          background: value === p ? "rgba(245,158,11,0.1)" : "transparent",
-          color: value === p ? "var(--accent)" : "var(--text-muted)",
+          border: `1px solid ${value === p.value ? "var(--accent)" : "var(--border-subtle)"}`,
+          background: value === p.value ? "rgba(245,158,11,0.1)" : "transparent",
+          color: value === p.value ? "var(--accent)" : "var(--text-muted)",
           cursor: "pointer",
-        }}>{p}</button>
+        }}>{p.label}</button>
       ))}
     </div>
   );

--- a/src/components/stats/PeriodToggle.tsx
+++ b/src/components/stats/PeriodToggle.tsx
@@ -7,9 +7,12 @@ interface PeriodToggleProps {
   onChange: (p: Period) => void;
 }
 
-// Standard four-option vocabulary used across every period toggle in the app.
-// Labels are display-friendly; values are the raw period keys passed to the
-// API. Mirrors VALID_PERIODS in src/lib/usage/constants.ts.
+// Standard four-option vocabulary used across every period toggle in the
+// app. Values mirror VALID_PERIODS in src/lib/usage/constants.ts; labels
+// are intentionally compact (lowercase abbreviations) because this toggle
+// renders inline inside small stats cards where the full "Today / 7 days /
+// 30 days / All time" labels would wrap. The Home / Kanban / Usage
+// surfaces use the full-width labels.
 const PERIODS: { value: Period; label: string }[] = [
   { value: "today", label: "today" },
   { value: "7d", label: "7d" },

--- a/src/hooks/useKanban.ts
+++ b/src/hooks/useKanban.ts
@@ -13,7 +13,7 @@ function emptySnapshot(): KanbanSnapshot {
   };
 }
 
-export function useKanban(period: KanbanPeriod = "last24h") {
+export function useKanban(period: KanbanPeriod = "today") {
   const [snapshot, setSnapshot] = useState<KanbanSnapshot>(emptySnapshot);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -272,7 +272,7 @@ async function checkV3Gate(scope: string, db: DbHandle): Promise<boolean> {
  * migration.
  */
 async function runFileUsage(
-  period: "today" | "week" | "month" | "all",
+  period: "today" | "7d" | "30d" | "all" | "week" | "month",
   project: string | undefined,
   source: string | undefined
 ): Promise<UsageResult> {
@@ -292,7 +292,7 @@ async function runFileUsage(
  * - DB mode + DB unhealthy: throws `DbUnavailableError` → 500.
  */
 export async function getUsage(
-  period: "today" | "week" | "month" | "all",
+  period: "today" | "7d" | "30d" | "all" | "week" | "month",
   project?: string,
   source?: string
 ): Promise<UsageResult> {

--- a/src/lib/db/otelQueries.ts
+++ b/src/lib/db/otelQueries.ts
@@ -314,19 +314,25 @@ export async function getCacheEfficiency(opts: { period: Period }): Promise<Cach
   if (rows.length === 0) return empty;
 
   const daily: CacheDay[] = [];
-  let sumCacheRead = 0, sumBillable = 0;
+  let sumCacheRead = 0, sumBillable = 0, sumTotalFlow = 0;
 
   for (const d of pivotTokenRows(rows)) {
-    // Denominator excludes cacheRead: "what fraction of full-price tokens were served from cache?"
+    // Hit rate is "what fraction of total token flow came from cache?"
+    // — bounded to [0, 1]. The denominator includes cacheRead so the ratio
+    // can't exceed 1 (an earlier formula divided cacheRead by billable
+    // tokens only and produced ratios of 1500%+ for sessions that re-read
+    // a large cached system prompt across many turns).
     const billable = d.input + d.output + d.cacheCreation;
-    const rate = billable > 0 ? d.cacheRead / billable : 0;
+    const totalFlow = billable + d.cacheRead;
+    const rate = totalFlow > 0 ? d.cacheRead / totalFlow : 0;
     daily.push({ day: d.day, hitRate: rate });
     sumCacheRead += d.cacheRead;
     sumBillable += billable;
+    sumTotalFlow += totalFlow;
   }
 
   return {
-    hitRate: sumBillable > 0 ? sumCacheRead / sumBillable : 0,
+    hitRate: sumTotalFlow > 0 ? sumCacheRead / sumTotalFlow : 0,
     daily,
     totalBillable: sumBillable,
     hasData: true,

--- a/src/lib/db/otelQueries.ts
+++ b/src/lib/db/otelQueries.ts
@@ -58,7 +58,7 @@ import { getDb, prepCached } from "./connection";
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
-export type Period = "today" | "7d" | "30d";
+export type Period = "today" | "7d" | "30d" | "all";
 
 function periodToMs(period: Period): number {
   const now = Date.now();
@@ -68,7 +68,9 @@ function periodToMs(period: Period): number {
     return d.getTime();
   }
   if (period === "7d")  return now - 7 * 24 * 60 * 60 * 1000;
-  return now - 30 * 24 * 60 * 60 * 1000;
+  if (period === "30d") return now - 30 * 24 * 60 * 60 * 1000;
+  // "all" — return 0 so the SQL `WHERE timestamp >= ?` matches every row.
+  return 0;
 }
 
 // otel_events.ts is TEXT (ISO-8601); comparison with toISOString() strings is safe.

--- a/src/lib/healthScore.ts
+++ b/src/lib/healthScore.ts
@@ -1,0 +1,275 @@
+/**
+ * Configuration health score for the Home page gauge.
+ *
+ * Earlier versions of the gauge were a generic "stuff to do" counter that
+ * combined insights, manual steps, and approvals into one ratio. That
+ * surfaced user task backlog rather than environment health, so a freshly
+ * configured Claude Code setup with an unread INSIGHTS.md would look
+ * "unhealthy" even though everything was actually working fine.
+ *
+ * This module replaces that with a weighted roll-up of signals that
+ * actually reflect Claude Code environment health: per-project efficiency
+ * grades, cache utilization, MCP security findings, pending approvals,
+ * telemetry pressure (errors / retries / compactions), and edit
+ * acceptance rate.
+ *
+ * Each component contributes a 0–100 sub-score and a weight. Components
+ * that don't have enough data to score (e.g., no cache telemetry yet,
+ * no graded projects) are dropped from the calculation and the remaining
+ * weights are renormalized — so a brand-new install reports a health
+ * score derived from whichever signals it does have, not "0 because no
+ * data" or "100 because no problems detected".
+ */
+import type { EfficiencyGrade } from "./efficiencyGradeCache";
+
+export type HealthLetter = "A" | "B" | "C" | "D" | "F";
+
+export interface HealthComponent {
+  /** Stable id so the UI can render component-specific affordances. */
+  id:
+    | "project-grades"
+    | "cache-efficiency"
+    | "mcp-security"
+    | "approvals"
+    | "pressure"
+    | "edit-acceptance";
+  /** Human-readable label for the breakdown row. */
+  label: string;
+  /** Relative weight before normalization. */
+  weight: number;
+  /** 0–100 sub-score, or null when there is not enough data to score. */
+  score: number | null;
+  /** One-line explanation of what the score reflects (shown as a tooltip / sub). */
+  detail: string;
+}
+
+export interface HealthInputs {
+  /** Per-project efficiency grades. Empty object/array → component dropped. */
+  grades: Record<string, EfficiencyGrade>;
+  /** Cache hit rate from the last 7 days, 0–1. null when no telemetry. */
+  cacheHitRate: number | null;
+  /** MCP security findings broken out by severity bucket. */
+  mcpFindings: { crit: number; high: number; med: number; low: number; info: number };
+  /** True when an MCP scan has run; false → component dropped. */
+  mcpScanned: boolean;
+  /** Pending approvals count from pulse. */
+  approvals: number;
+  /** Telemetry pressure signals from getPressureSnapshot. */
+  pressure: { retryExhaustion: number; compactions: number; hasData: boolean };
+  /** Edit acceptance: rate (0–1) and sample size. Need ≥10 samples to score. */
+  editAcceptance: { rate: number; n: number; hasData: boolean };
+}
+
+export interface HealthReport {
+  /** Weighted overall score, 0–100. */
+  score: number;
+  /** Letter grade derived from `score`. */
+  grade: HealthLetter;
+  /** Each component, including dropped ones (with score=null). */
+  components: HealthComponent[];
+  /** True when at least one component contributed to the score. */
+  hasData: boolean;
+}
+
+const GRADE_TO_NUM: Record<EfficiencyGrade, number> = {
+  A: 95, B: 85, C: 70, D: 50, F: 20,
+};
+
+const SEVERITY_WEIGHT = { crit: 10, high: 5, med: 2, low: 0.5, info: 0 };
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+function letterFor(score: number): HealthLetter {
+  if (score >= 90) return "A";
+  if (score >= 80) return "B";
+  if (score >= 70) return "C";
+  if (score >= 60) return "D";
+  return "F";
+}
+
+export function computeHealthScore(input: HealthInputs): HealthReport {
+  const components: HealthComponent[] = [];
+
+  // 1. Project grades — 30%. Average the per-project grade numbers.
+  {
+    const values = Object.values(input.grades);
+    if (values.length === 0) {
+      components.push({
+        id: "project-grades",
+        label: "Project grades",
+        weight: 30,
+        score: null,
+        detail: "No graded projects yet",
+      });
+    } else {
+      const avg = values.reduce((s, g) => s + GRADE_TO_NUM[g], 0) / values.length;
+      const counts = values.reduce<Record<EfficiencyGrade, number>>(
+        (acc, g) => ({ ...acc, [g]: (acc[g] ?? 0) + 1 }),
+        { A: 0, B: 0, C: 0, D: 0, F: 0 },
+      );
+      const detail = (["A", "B", "C", "D", "F"] as const)
+        .filter((g) => counts[g] > 0)
+        .map((g) => `${counts[g]}${g}`)
+        .join(" · ");
+      components.push({
+        id: "project-grades",
+        label: "Project grades",
+        weight: 30,
+        score: Math.round(avg),
+        detail: `${values.length} graded — ${detail}`,
+      });
+    }
+  }
+
+  // 2. Cache efficiency — 20%. hitRate is bounded [0, 1] in the new formula
+  //    (cacheRead / total token flow). Direct linear mapping to 0–100.
+  {
+    if (input.cacheHitRate === null) {
+      components.push({
+        id: "cache-efficiency",
+        label: "Cache efficiency",
+        weight: 20,
+        score: null,
+        detail: "No telemetry yet",
+      });
+    } else {
+      const score = Math.round(clamp(input.cacheHitRate * 100, 0, 100));
+      components.push({
+        id: "cache-efficiency",
+        label: "Cache efficiency",
+        weight: 20,
+        score,
+        detail: `${score}% cache hit rate (7d)`,
+      });
+    }
+  }
+
+  // 3. MCP security — 20%. Sum severity-weighted finding count. 5 points off
+  //    per weight-unit, so a single critical finding (weight 10) drops the
+  //    sub-score to 50; a clean scan stays at 100.
+  {
+    if (!input.mcpScanned) {
+      components.push({
+        id: "mcp-security",
+        label: "MCP security",
+        weight: 20,
+        score: null,
+        detail: "Run /api/mcp-security/findings?refresh=1",
+      });
+    } else {
+      const f = input.mcpFindings;
+      const weighted =
+        f.crit * SEVERITY_WEIGHT.crit +
+        f.high * SEVERITY_WEIGHT.high +
+        f.med  * SEVERITY_WEIGHT.med  +
+        f.low  * SEVERITY_WEIGHT.low;
+      const score = Math.round(clamp(100 - weighted * 5, 0, 100));
+      const totalCount = f.crit + f.high + f.med + f.low + f.info;
+      const detail = totalCount === 0
+        ? "Clean — no findings"
+        : [
+            f.crit > 0 && `${f.crit} crit`,
+            f.high > 0 && `${f.high} high`,
+            f.med  > 0 && `${f.med} med`,
+            f.low  > 0 && `${f.low} low`,
+          ].filter(Boolean).join(" · ");
+      components.push({
+        id: "mcp-security",
+        label: "MCP security",
+        weight: 20,
+        score,
+        detail,
+      });
+    }
+  }
+
+  // 4. Pending approvals — 10%. Each pending approval drops the sub-score
+  //    by 10. Pending approvals block in-flight work, so they're heavier
+  //    per-unit than the other "things to fix" categories.
+  {
+    const score = Math.round(clamp(100 - input.approvals * 10, 0, 100));
+    components.push({
+      id: "approvals",
+      label: "Approvals",
+      weight: 10,
+      score,
+      detail: input.approvals === 0 ? "No pending approvals" : `${input.approvals} pending`,
+    });
+  }
+
+  // 5. Telemetry pressure — 10%. Only retry-exhaustion meaningfully reflects
+  //    config health (rate-limit headroom, network reliability, retry policy).
+  //    Compactions are user-behavior signal (long sessions) and we
+  //    intentionally don't penalize them — they show up in the detail line
+  //    as context but don't move the score.
+  {
+    if (!input.pressure.hasData) {
+      components.push({
+        id: "pressure",
+        label: "Runtime pressure",
+        weight: 10,
+        score: null,
+        detail: "No telemetry yet",
+      });
+    } else {
+      const { retryExhaustion, compactions } = input.pressure;
+      const score = Math.round(clamp(100 - retryExhaustion * 10, 0, 100));
+      const parts: string[] = [];
+      parts.push(`${retryExhaustion} retry exhaust`);
+      if (compactions > 0) parts.push(`${compactions} compactions`);
+      const detail = retryExhaustion === 0
+        ? compactions === 0 ? "No retries or compactions" : `${compactions} compactions (info only)`
+        : parts.join(" · ");
+      components.push({
+        id: "pressure",
+        label: "Runtime pressure",
+        weight: 10,
+        score,
+        detail,
+      });
+    }
+  }
+
+  // 6. Edit acceptance — 10%. Need a minimum sample so a single rejected
+  //    edit doesn't tank the score. Below the threshold we drop the
+  //    component rather than report a noisy number.
+  {
+    const { rate, n, hasData } = input.editAcceptance;
+    if (!hasData || n < 10) {
+      components.push({
+        id: "edit-acceptance",
+        label: "Edit acceptance",
+        weight: 10,
+        score: null,
+        detail: hasData ? `Need ${10 - n} more samples` : "No edit telemetry yet",
+      });
+    } else {
+      const score = Math.round(clamp(rate * 100, 0, 100));
+      components.push({
+        id: "edit-acceptance",
+        label: "Edit acceptance",
+        weight: 10,
+        score,
+        detail: `${score}% accepted (n=${n})`,
+      });
+    }
+  }
+
+  // Renormalize weights over the components that contributed a score.
+  const scored = components.filter((c) => c.score !== null);
+  const totalWeight = scored.reduce((s, c) => s + c.weight, 0) || 1;
+  const overall = scored.length === 0
+    ? 0
+    : Math.round(
+        scored.reduce((s, c) => s + (c.score ?? 0) * (c.weight / totalWeight), 0),
+      );
+
+  return {
+    score: overall,
+    grade: letterFor(overall),
+    components,
+    hasData: scored.length > 0,
+  };
+}

--- a/src/lib/kanban/types.ts
+++ b/src/lib/kanban/types.ts
@@ -66,7 +66,12 @@ export type KanbanCard =
 export type KanbanKindFilter = "all" | "sessions" | "tasks";
 export const KANBAN_KIND_FILTERS = ["all", "sessions", "tasks"] as const satisfies readonly KanbanKindFilter[];
 
-export type KanbanPeriod = "last24h" | "last7d" | "all";
+// Mirrors the standard period vocabulary in src/lib/usage/constants.ts.
+// Kanban deliberately drops the "today" option (calendar boundary doesn't
+// match the rolling-window mental model the rest of this surface uses) and
+// keeps a 24-hour rolling lookback as the default. 'today' still validates
+// here as an alias for parity with other surfaces.
+export type KanbanPeriod = "today" | "7d" | "30d" | "all";
 
 export interface KanbanSnapshot {
   columns: Record<KanbanColumn, KanbanCard[]>;

--- a/src/lib/kanban/types.ts
+++ b/src/lib/kanban/types.ts
@@ -67,10 +67,9 @@ export type KanbanKindFilter = "all" | "sessions" | "tasks";
 export const KANBAN_KIND_FILTERS = ["all", "sessions", "tasks"] as const satisfies readonly KanbanKindFilter[];
 
 // Mirrors the standard period vocabulary in src/lib/usage/constants.ts.
-// Kanban deliberately drops the "today" option (calendar boundary doesn't
-// match the rolling-window mental model the rest of this surface uses) and
-// keeps a 24-hour rolling lookback as the default. 'today' still validates
-// here as an alias for parity with other surfaces.
+// All four options surface in the Kanban toolbar; the 'today' bucket maps
+// to a 24-hour rolling lookback (the same window the page used before the
+// vocabulary standardization, just renamed from 'last24h').
 export type KanbanPeriod = "today" | "7d" | "30d" | "all";
 
 export interface KanbanSnapshot {

--- a/src/lib/shareImage.ts
+++ b/src/lib/shareImage.ts
@@ -50,16 +50,20 @@ export function composeShareSvg(
   opts: ShareImageOptions = {},
 ): string {
   const theme = opts.theme ?? "dark";
-  const period = opts.period ?? "month";
+  const period = opts.period ?? "30d";
   const width = opts.width ?? WIDTH;
   const height = Math.round((width / WIDTH) * HEIGHT);
   const p = PALETTES[theme];
 
-  const periodLabel: Record<Period, string> = {
+  // Map periods to display labels. Includes legacy `week`/`month` keys for
+  // back-compat with stored ShareButton URLs that haven't been re-rendered.
+  const periodLabel: Record<string, string> = {
     today: "Today",
-    week: "This Week",
-    month: "This Month",
-    all: "All Time",
+    "7d": "Last 7 days",
+    "30d": "Last 30 days",
+    all: "All time",
+    week: "Last 7 days",
+    month: "Last 30 days",
   };
 
   const parts: string[] = [];

--- a/src/lib/usage/aggregator.ts
+++ b/src/lib/usage/aggregator.ts
@@ -28,7 +28,11 @@ import type {
   SourceBreakdown,
 } from "./types";
 
-type Period = "today" | "week" | "month" | "all";
+// Local Period type kept loose so the aggregator accepts both the new
+// today/7d/30d/all vocabulary and legacy week/month strings — the periods.ts
+// switch normalizes both. validatePeriod() at the API boundary maps
+// week→7d, month→30d before this function ever sees the value.
+type Period = "today" | "7d" | "30d" | "all" | "week" | "month";
 
 export async function generateUsageReport(
   period: Period,

--- a/src/lib/usage/constants.ts
+++ b/src/lib/usage/constants.ts
@@ -1,13 +1,27 @@
+// Standard time-slice vocabulary used across every period toggle in the app
+// (Home, Stats telemetry cards, Kanban, Usage dashboard). Four options always:
+// today / rolling-7d / rolling-30d / all-time. Earlier this file used
+// calendar-aligned "this week" / "this month", which collided with the
+// rolling labels other surfaces used and made early-month data confusing.
 export const VALID_PERIODS = [
   { value: "today", label: "Today" },
-  { value: "week", label: "This Week" },
-  { value: "month", label: "This Month" },
-  { value: "all", label: "All Time" },
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+  { value: "all", label: "All time" },
 ] as const;
 
 export type Period = (typeof VALID_PERIODS)[number]["value"];
 
+// Legacy aliases — prior versions of the API and stored URLs may pass
+// `week` or `month`. We normalize them to the rolling-window equivalents
+// rather than reject so deep links keep working.
+const LEGACY_ALIASES: Record<string, Period> = {
+  week: "7d",
+  month: "30d",
+};
+
 export function validatePeriod(input: string): Period {
+  if (LEGACY_ALIASES[input]) return LEGACY_ALIASES[input];
   const valid = VALID_PERIODS.map((p) => p.value as string);
-  return valid.includes(input) ? (input as Period) : "month";
+  return valid.includes(input) ? (input as Period) : "30d";
 }

--- a/src/lib/usage/constants.ts
+++ b/src/lib/usage/constants.ts
@@ -15,13 +15,18 @@ export type Period = (typeof VALID_PERIODS)[number]["value"];
 // Legacy aliases — prior versions of the API and stored URLs may pass
 // `week` or `month`. We normalize them to the rolling-window equivalents
 // rather than reject so deep links keep working.
-const LEGACY_ALIASES: Record<string, Period> = {
-  week: "7d",
-  month: "30d",
-};
+//
+// Use a Map (not a plain object) for the lookup so untrusted query input
+// like ?period=__proto__ or ?period=toString can't return inherited keys
+// and bypass validation (PR #103 codex P2).
+const LEGACY_ALIASES = new Map<string, Period>([
+  ["week", "7d"],
+  ["month", "30d"],
+]);
 
 export function validatePeriod(input: string): Period {
-  if (LEGACY_ALIASES[input]) return LEGACY_ALIASES[input];
+  const aliased = LEGACY_ALIASES.get(input);
+  if (aliased) return aliased;
   const valid = VALID_PERIODS.map((p) => p.value as string);
   return valid.includes(input) ? (input as Period) : "30d";
 }

--- a/src/lib/usage/periods.ts
+++ b/src/lib/usage/periods.ts
@@ -1,14 +1,19 @@
 // Shared period-boundary helper. Both the file-parse aggregator
 // (`generateUsageReport`) and the SQLite-backed rehydrate path
 // (`loadFilteredUsageTurns`) need to compute the inclusive lower bound
-// for a `period` filter. Centralizing it here means a future change —
-// e.g. switching "week" from Sunday-start to Monday-start — applies to
-// both backends in lockstep.
+// for a `period` filter. Centralizing it here means a future change
+// applies to both backends in lockstep.
 //
 // `now` is injectable so tests can pin the boundary deterministically;
 // production callers omit it and get `new Date()`.
+//
+// Period vocabulary is rolling-window (today / 7d / 30d / all), matching
+// the labels users see on the toggle. Legacy `week` / `month` keys still
+// resolve here as aliases for `7d` / `30d` so old URLs keep working;
+// validatePeriod() in constants.ts normalizes incoming requests at the
+// API boundary.
 
-export type Period = "today" | "week" | "month" | "all" | string;
+export type Period = "today" | "7d" | "30d" | "all" | string;
 
 export function getPeriodStart(period: Period, now: Date = new Date()): Date | null {
   switch (period) {
@@ -17,14 +22,12 @@ export function getPeriodStart(period: Period, now: Date = new Date()): Date | n
       start.setHours(0, 0, 0, 0);
       return start;
     }
-    case "week": {
-      const start = new Date(now);
-      start.setDate(start.getDate() - start.getDay());
-      start.setHours(0, 0, 0, 0);
-      return start;
-    }
-    case "month":
-      return new Date(now.getFullYear(), now.getMonth(), 1);
+    case "7d":
+    case "week": // legacy alias — was Sunday-start calendar week
+      return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    case "30d":
+    case "month": // legacy alias — was 1st-of-month calendar
+      return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
     case "all":
       return null;
     default:

--- a/tests/healthScore.test.ts
+++ b/tests/healthScore.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { computeHealthScore, type HealthInputs } from "@/lib/healthScore";
+
+const empty: HealthInputs = {
+  grades: {},
+  cacheHitRate: null,
+  mcpFindings: { crit: 0, high: 0, med: 0, low: 0, info: 0 },
+  mcpScanned: false,
+  approvals: 0,
+  pressure: { retryExhaustion: 0, compactions: 0, hasData: false },
+  editAcceptance: { rate: 0, n: 0, hasData: false },
+};
+
+describe("computeHealthScore", () => {
+  it("returns hasData=false when no signals are populated except approvals=0", () => {
+    const r = computeHealthScore(empty);
+    // Approvals component scores 100 when there are zero pending — that's the
+    // only contributor in this scenario. So hasData IS true (1 component).
+    // Confirms the renormalization: we don't insist all 6 signals are
+    // present, just at least one.
+    expect(r.hasData).toBe(true);
+    expect(r.score).toBe(100);
+    expect(r.grade).toBe("A");
+  });
+
+  it("drops components without data and renormalizes the remaining weights", () => {
+    const r = computeHealthScore({
+      ...empty,
+      cacheHitRate: 0.8, // 80% — sub-score 80, weight 20
+      approvals: 2,      // sub-score 80, weight 10
+    });
+    // Weighted average over (cache=80, weight=20) and (approvals=80, weight=10):
+    // (80*20 + 80*10) / 30 = 80
+    expect(r.score).toBe(80);
+    expect(r.grade).toBe("B");
+    const cache = r.components.find((c) => c.id === "cache-efficiency");
+    expect(cache?.score).toBe(80);
+    const grades = r.components.find((c) => c.id === "project-grades");
+    expect(grades?.score).toBeNull(); // dropped — no data
+  });
+
+  it("averages efficiency grades with the documented weights", () => {
+    const r = computeHealthScore({
+      ...empty,
+      grades: { p1: "A", p2: "A", p3: "C" },
+    });
+    // (95 + 95 + 70) / 3 = 86.67 → 87
+    const grades = r.components.find((c) => c.id === "project-grades");
+    expect(grades?.score).toBe(87);
+    expect(grades?.detail).toContain("3 graded");
+  });
+
+  it("penalizes critical MCP findings heavily", () => {
+    const r = computeHealthScore({
+      ...empty,
+      mcpScanned: true,
+      mcpFindings: { crit: 1, high: 0, med: 0, low: 0, info: 0 },
+    });
+    // weighted = 1 * 10 = 10; score = 100 - 10*5 = 50
+    const mcp = r.components.find((c) => c.id === "mcp-security");
+    expect(mcp?.score).toBe(50);
+  });
+
+  it("scores a clean MCP scan as 100", () => {
+    const r = computeHealthScore({
+      ...empty,
+      mcpScanned: true,
+      mcpFindings: { crit: 0, high: 0, med: 0, low: 0, info: 0 },
+    });
+    const mcp = r.components.find((c) => c.id === "mcp-security");
+    expect(mcp?.score).toBe(100);
+    expect(mcp?.detail).toMatch(/clean/i);
+  });
+
+  it("requires ≥10 edit-acceptance samples to score", () => {
+    const tooFew = computeHealthScore({
+      ...empty,
+      editAcceptance: { rate: 0.9, n: 5, hasData: true },
+    });
+    expect(tooFew.components.find((c) => c.id === "edit-acceptance")?.score).toBeNull();
+
+    const enough = computeHealthScore({
+      ...empty,
+      editAcceptance: { rate: 0.9, n: 50, hasData: true },
+    });
+    expect(enough.components.find((c) => c.id === "edit-acceptance")?.score).toBe(90);
+  });
+
+  it("clamps approval penalty at 0", () => {
+    const r = computeHealthScore({ ...empty, approvals: 99 });
+    expect(r.components.find((c) => c.id === "approvals")?.score).toBe(0);
+  });
+
+  it("maps the overall score to a letter grade", () => {
+    expect(computeHealthScore({ ...empty, approvals: 0 }).grade).toBe("A"); // 100
+    expect(computeHealthScore({ ...empty, approvals: 2 }).grade).toBe("B"); // 80
+    expect(computeHealthScore({ ...empty, approvals: 4 }).grade).toBe("D"); // 60
+    expect(computeHealthScore({ ...empty, approvals: 5 }).grade).toBe("F"); // 50
+  });
+});

--- a/tests/healthScore.test.ts
+++ b/tests/healthScore.test.ts
@@ -12,12 +12,11 @@ const empty: HealthInputs = {
 };
 
 describe("computeHealthScore", () => {
-  it("returns hasData=false when no signals are populated except approvals=0", () => {
+  it("scores 100/A from approvals alone when no other signals are populated", () => {
     const r = computeHealthScore(empty);
-    // Approvals component scores 100 when there are zero pending — that's the
-    // only contributor in this scenario. So hasData IS true (1 component).
-    // Confirms the renormalization: we don't insist all 6 signals are
-    // present, just at least one.
+    // Approvals scores 100 at zero pending — that's the only contributor in
+    // this scenario. Confirms the renormalization: we don't require all 6
+    // signals to be present, just at least one.
     expect(r.hasData).toBe(true);
     expect(r.score).toBe(100);
     expect(r.grade).toBe("A");

--- a/tests/otelQueries.test.ts
+++ b/tests/otelQueries.test.ts
@@ -309,8 +309,11 @@ describe.skipIf(!driverAvailable)("getCacheEfficiency", () => {
 
       const result = await queries.getCacheEfficiency({ period: "7d" });
       expect(result.hasData).toBe(true);
-      // hitRate = cacheRead / (input + output + cacheCreation) = 400 / (800+200+100) = 400/1100 ≈ 0.364
-      expect(result.hitRate).toBeCloseTo(400 / 1100);
+      // hitRate = cacheRead / (cacheRead + input + output + cacheCreation)
+      //         = 400 / (400 + 800 + 200 + 100)
+      //         = 400 / 1500 ≈ 0.267
+      // (bounded to [0, 1] — see formula change in src/lib/db/otelQueries.ts)
+      expect(result.hitRate).toBeCloseTo(400 / 1500);
       expect(result.totalBillable).toBe(1100);
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Summary

Three loosely-related fixes that all surfaced from the same Home/Stats walkthrough:

1. **Cache Efficiency chart was bursting out of its card** — the underlying formula could produce ratios > 100% (1527% on this dev box). Redefined as a true bounded 0-100% rate and added defensive UI clamping.
2. **Period toggles disagreed across surfaces** — Stats said `today/7d/30d`, Usage said `today/week/month/all`, Home said `today/week/month` with rolling labels, Kanban said `last24h/last7d/all`. Standardized everything to `today / 7d / 30d / all` with rolling-window semantics, with backward-compat aliases for old URLs.
3. **Home health score was a generic 'stuff to do' counter** — replaced with a weighted roll-up of six real environment signals (project efficiency grades, cache hit rate, MCP security findings, pending approvals, retry-exhaustion pressure, edit acceptance).

## Commits

- `269200a fix(stats): keep cache efficiency chart inside its card bounds` — defensive UI clamp
- `c80fcdf fix(stats): redefine cache hit rate as a true 0-100% bounded ratio` — formula now `cacheRead / (cacheRead + billable)` instead of `cacheRead / billable`
- `fa7375d feat(periods): standardize to today/7d/30d/all vocabulary` — single source of truth in `src/lib/usage/constants.ts`, legacy aliases in `validatePeriod()` and `getPeriodStart()`
- `eacb6d8 feat(stats): add 'all' option to telemetry period toggle` — fourth button + route validation
- `068c2fa feat(kanban): standardize time slicer to today/7d/30d/all` — `last24h`/`last7d` URLs still resolve via API alias
- `204b96f feat(home): adopt standard today/7d/30d period vocabulary` — Home keeps three options (no `all` — overview surface)
- `999d5d3 feat(home): replace ad-hoc health score with real config-health roll-up` — see scoring table below

## New config-health score

| Signal              | Wt | Source                              | Subscore   |
|---------------------|---:|-------------------------------------|------------|
| Project grades      | 30 | `efficiencyGradeCache.getAll()`     | A=95..F=20 |
| Cache efficiency    | 20 | `getCacheEfficiency(7d)`            | rate × 100 |
| MCP security        | 20 | `mcp-security/store.getAllFindings()` | severity-weighted |
| Pending approvals   | 10 | pulse `snapshot.approvalCount`      | 100 - N×10 |
| Runtime pressure    | 10 | `getPressureSnapshot`               | retries only (compactions are info) |
| Edit acceptance     | 10 | `getEditAcceptance(7d)` (n≥10)      | rate × 100 |

Components without enough data drop out and remaining weights renormalize, so brand-new installs don't get a misleading 0% or 100%.

## Verification

- `npm run typecheck` — 0 errors
- `npm test` — **1913 passing**, 1 skipped, 1 pre-existing failure (`tests/setupHooks.test.ts`, Vitest 4 + `.mjs` hashbang on Windows; identical on `main`). Includes 8 new tests for the health-score function.
- Browser-verified Home, Stats, Kanban with the new vocabulary.

## Test plan

- [ ] Open `/` — Config Health gauge shows a score with a 6-component breakdown; hover any row to see the detail line
- [ ] Toggle Today / 7 days / 30 days on the Home period switcher and confirm headline numbers + chart all update
- [ ] Open `/stats#telemetry` — Cache Efficiency reads ≤100%, fits inside its card; PeriodToggle has four buttons including `all`
- [ ] Open `/kanban` — period dropdown reads Today / 7 days / 30 days / All time; old URLs (`?period=last24h`) still load
- [ ] Open `/usage` — period switcher reads Today / 7 days / 30 days / All time
- [ ] Visit any old `?period=month` URL → verify back-compat alias resolves to 30d

🤖 Generated with [Claude Code](https://claude.com/claude-code)