### PR TITLE
Phase 2: cross-tier memory file browser at /memory (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`renameWithRetry`** (`src/lib/atomicWrite.ts`) — extends retry-eligible code list to include `ENOTEMPTY` (Windows directory-handle release lag).
 
 ### Added
+- **Phase 2 (#193) — Memory file browser at `/memory`.** Replaces the ComingSoon stub with a cross-tier inventory + inline editor that unifies three scopes: user (`~/.claude/CLAUDE.md`), project (`<project>/CLAUDE.md`), and auto-memory (`~/.claude/projects/<encoded>/memory/*.md`).
+  - **Discovery (`src/lib/memory/index.ts`)**: `listMemoryFiles({ projects })` walks all three tiers with a 60 s in-module cache. Each entry carries `{ id, scope, projectSlug?, projectName?, absPath, mtimeMs, sizeBytes, preview, stale }`. The `id` is `base64url(absPath)` — opaque + path-traversal safe. Stale heuristic flags `ageOver30d` and `brokenImports[]` (the latter reuses `expandImports` from the audit pipeline so semantics match `ClaudeMdAuditPanel`).
+  - **Path-safety allowlist (`src/lib/memory/safety.ts`)**: `classifyMemoryPath(absPath, projects)` returns scope info only when the resolved path is exactly `~/.claude/CLAUDE.md`, a scanned project's `CLAUDE.md`, or an `*.md` file directly inside that project's auto-memory dir (no dotfiles, no subdir traversal). PUT rejects with **400 PATH_NOT_ALLOWED** before any snapshot or write.
+  - **`GET /api/memory`** — cross-tier list.
+  - **`GET /api/memory/by-id/[id]`** — `{ content, mtimeMs, sizeBytes, scope, projectSlug? }`. Routed under `by-id/` so the existing `/api/memory/[slug]` per-project route stays untouched.
+  - **`PUT /api/memory/by-id/[id]`** — body `{ content: string, mtimeMs: number }`. Validates allowlist → enforces 2 MB cap (413 TOO_LARGE) → checks mtime under `withFileLock` (409 MTIME_CONFLICT on drift > 1 ms) → records configHistory snapshot (label `memoryEditor`) → atomic write → invalidates inventory cache and the per-project `scanMemory` cache when the target is auto-tier.
+  - **`GET /api/memory/by-id/[id]/snapshot`** — most recent configHistory snapshot for this file, used by the editor's diff view.
+  - **`MemoryBrowser.tsx`** — left rail grouped by scope with search, scope chips, and a stale filter; right pane mounts `MemoryEditor.tsx` (view → edit → save → optional diff toggle showing a hand-rolled LCS-based unified diff against the latest config-history snapshot). 409 surfaces a "File changed externally — Reload" banner.
+  - **AppSidebar**: `/memory` row no longer carries `comingSoon`.
+  - **18 new tests** across `tests/memoryDiscovery.test.ts` (10) and `tests/memoryByIdRoute.test.ts` (8).
 - **`GET /api/health`** — lightweight endpoint returning the schema-readiness state-machine snapshot (`{ ok, db: { state, attempts, quarantineRuns, failedAt, lastError } }`). 200 when healthy/initializing, 503 when in transient/permanent failure. No-store cache header.
 - **Settings → DB status row** — always-visible footer in the Settings page polls `/api/health` every 15 s and renders state, attempts count, quarantine count, and last error message.
 - **Wave 12.2 — Cluster AA (part 2): Command palette, keyboard shortcut customization, Insights Report viewer.** TODO #9 kbd, #10, #48.

--- a/docs/help/memory.md
+++ b/docs/help/memory.md
@@ -1,5 +1,34 @@
 # Memory Browser
 
+Project Minder ships two complementary memory views:
+
+- **`/memory`** — cross-tier browser that lists every CLAUDE.md and auto-memory file across all scopes in one place. Edit any of them inline.
+- **Project detail → Memory tab** — per-project view scoped to one project's auto-memory directory.
+
+This page documents both.
+
+## Cross-tier `/memory` page
+
+The `/memory` page unifies three scopes:
+
+- **User** — `~/.claude/CLAUDE.md`
+- **Project** — `<project>/CLAUDE.md` for every scanned project
+- **Auto-memory** — every `.md` file inside `~/.claude/projects/<encoded>/memory/` for every scanned project
+
+Each row shows the display name, owning project (where applicable), preview text, modification time, and a `STALE` badge when the file is over 30 days old or contains broken `@import` references. Filter by scope or stale status with the chips above the list.
+
+Click any row to open it in the right pane. **Edit** switches into a textarea; **Save** writes back atomically. The editor takes a snapshot via `~/.minder/config-history/` before every save so you can roll back from the Config History page. **Diff** compares your draft against the most recent snapshot.
+
+If a file changes externally between the time you opened it and when you click Save, the editor surfaces a **File changed externally — Reload** banner instead of silently overwriting.
+
+### Path-safety guarantees
+
+The editor refuses to write to anything outside the allowlist (user CLAUDE.md, a scanned project's CLAUDE.md, or an `*.md` file directly inside an auto-memory directory). Attempts to PUT a fabricated id resolve to **400 PATH_NOT_ALLOWED**. The 2 MB content cap returns **413 TOO_LARGE**. mtime conflicts return **409 MTIME_CONFLICT**.
+
+---
+
+## Per-project Memory tab
+
 The **Memory** tab on each project detail page lets you browse Claude Code's auto-memory files for that project without leaving Project Minder.
 
 ## What are memory files?

--- a/public/help/memory.md
+++ b/public/help/memory.md
@@ -1,5 +1,34 @@
 # Memory Browser
 
+Project Minder ships two complementary memory views:
+
+- **`/memory`** — cross-tier browser that lists every CLAUDE.md and auto-memory file across all scopes in one place. Edit any of them inline.
+- **Project detail → Memory tab** — per-project view scoped to one project's auto-memory directory.
+
+This page documents both.
+
+## Cross-tier `/memory` page
+
+The `/memory` page unifies three scopes:
+
+- **User** — `~/.claude/CLAUDE.md`
+- **Project** — `<project>/CLAUDE.md` for every scanned project
+- **Auto-memory** — every `.md` file inside `~/.claude/projects/<encoded>/memory/` for every scanned project
+
+Each row shows the display name, owning project (where applicable), preview text, modification time, and a `STALE` badge when the file is over 30 days old or contains broken `@import` references. Filter by scope or stale status with the chips above the list.
+
+Click any row to open it in the right pane. **Edit** switches into a textarea; **Save** writes back atomically. The editor takes a snapshot via `~/.minder/config-history/` before every save so you can roll back from the Config History page. **Diff** compares your draft against the most recent snapshot.
+
+If a file changes externally between the time you opened it and when you click Save, the editor surfaces a **File changed externally — Reload** banner instead of silently overwriting.
+
+### Path-safety guarantees
+
+The editor refuses to write to anything outside the allowlist (user CLAUDE.md, a scanned project's CLAUDE.md, or an `*.md` file directly inside an auto-memory directory). Attempts to PUT a fabricated id resolve to **400 PATH_NOT_ALLOWED**. The 2 MB content cap returns **413 TOO_LARGE**. mtime conflicts return **409 MTIME_CONFLICT**.
+
+---
+
+## Per-project Memory tab
+
 The **Memory** tab on each project detail page lets you browse Claude Code's auto-memory files for that project without leaving Project Minder.
 
 ## What are memory files?

--- a/src/app/api/memory/by-id/[id]/route.ts
+++ b/src/app/api/memory/by-id/[id]/route.ts
@@ -35,7 +35,7 @@ export async function GET(
   if (!absPath) return errorResponse("INVALID_ID", 400, "Could not decode id.");
 
   const projects = await getProjects();
-  const allowed = classifyMemoryPath(absPath, projects);
+  const allowed = await classifyMemoryPath(absPath, projects);
   if (!allowed) {
     return errorResponse(
       "PATH_NOT_ALLOWED",
@@ -77,7 +77,7 @@ export async function PUT(
   if (!absPath) return errorResponse("INVALID_ID", 400, "Could not decode id.");
 
   const projects = await getProjects();
-  const allowed = classifyMemoryPath(absPath, projects);
+  const allowed = await classifyMemoryPath(absPath, projects);
   if (!allowed) {
     return errorResponse(
       "PATH_NOT_ALLOWED",

--- a/src/app/api/memory/by-id/[id]/route.ts
+++ b/src/app/api/memory/by-id/[id]/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import { getCachedScan, setCachedScan } from "@/lib/cache";
+import { scanAllProjects } from "@/lib/scanner";
+import { writeFileAtomic, withFileLock } from "@/lib/atomicWrite";
+import { recordPreWrite } from "@/lib/configHistory";
+import {
+  classifyMemoryPath,
+  decodeMemoryId,
+} from "@/lib/memory/safety";
+import { invalidateMemoryInventoryCache } from "@/lib/memory";
+import { invalidateMemoryCache } from "@/lib/scanner/memory";
+
+const MAX_BYTES = 2 * 1024 * 1024;
+
+function errorResponse(code: string, status: number, message?: string) {
+  return NextResponse.json({ error: { code, message } }, { status });
+}
+
+async function getProjects() {
+  let scan = getCachedScan();
+  if (!scan) {
+    scan = await scanAllProjects();
+    setCachedScan(scan);
+  }
+  return scan.projects;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const absPath = decodeMemoryId(id);
+  if (!absPath) return errorResponse("INVALID_ID", 400, "Could not decode id.");
+
+  const projects = await getProjects();
+  const allowed = classifyMemoryPath(absPath, projects);
+  if (!allowed) {
+    return errorResponse(
+      "PATH_NOT_ALLOWED",
+      400,
+      "Path is not a known memory file.",
+    );
+  }
+
+  try {
+    const [stat, content] = await Promise.all([
+      fs.stat(absPath),
+      fs.readFile(absPath, "utf-8"),
+    ]);
+    return NextResponse.json({
+      id,
+      absPath,
+      scope: allowed.scope,
+      projectSlug: allowed.projectSlug,
+      content,
+      mtimeMs: stat.mtimeMs,
+      sizeBytes: stat.size,
+    });
+  } catch {
+    return errorResponse("FILE_NOT_FOUND", 404, "Memory file is missing.");
+  }
+}
+
+interface PutBody {
+  content?: unknown;
+  mtimeMs?: unknown;
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const absPath = decodeMemoryId(id);
+  if (!absPath) return errorResponse("INVALID_ID", 400, "Could not decode id.");
+
+  const projects = await getProjects();
+  const allowed = classifyMemoryPath(absPath, projects);
+  if (!allowed) {
+    return errorResponse(
+      "PATH_NOT_ALLOWED",
+      400,
+      "Path is not a known memory file.",
+    );
+  }
+
+  let body: PutBody;
+  try {
+    body = (await request.json()) as PutBody;
+  } catch {
+    return errorResponse("INVALID_JSON", 400, "Body is not valid JSON.");
+  }
+
+  if (typeof body.content !== "string" || typeof body.mtimeMs !== "number") {
+    return errorResponse(
+      "INVALID_BODY",
+      400,
+      "Body must include `content: string` and `mtimeMs: number`.",
+    );
+  }
+  const content: string = body.content;
+  const requestMtime: number = body.mtimeMs;
+
+  if (Buffer.byteLength(content, "utf-8") > MAX_BYTES) {
+    return errorResponse(
+      "TOO_LARGE",
+      413,
+      `Content exceeds ${MAX_BYTES} bytes.`,
+    );
+  }
+
+  // Conflict check + write under one lock so a sibling writer can't slip a
+  // change in between the stat and the rename.
+  return withFileLock(absPath, async () => {
+    let currentMtime: number | null = null;
+    try {
+      const stat = await fs.stat(absPath);
+      currentMtime = stat.mtimeMs;
+    } catch {
+      // File may have been deleted out from under us; allow the write to
+      // create it as long as the caller acknowledges (mtimeMs === 0 means
+      // "no prior file"). Refuse otherwise so we don't silently resurrect.
+      if (requestMtime !== 0) {
+        return errorResponse(
+          "MTIME_CONFLICT",
+          409,
+          "File no longer exists; refresh and retry.",
+        );
+      }
+    }
+
+    if (currentMtime !== null && Math.abs(currentMtime - requestMtime) > 1) {
+      // Sub-millisecond drift on some filesystems — allow ±1 ms slack.
+      return errorResponse(
+        "MTIME_CONFLICT",
+        409,
+        "File changed externally. Reload to see latest content.",
+      );
+    }
+
+    const backupId = await recordPreWrite(absPath, {
+      label: "memoryEditor",
+      projectSlug: allowed.projectSlug,
+    });
+
+    await writeFileAtomic(absPath, content);
+
+    // Invalidate caches so the dashboard sees the new content immediately.
+    invalidateMemoryInventoryCache();
+    if (allowed.scope === "auto" && allowed.projectPath) {
+      invalidateMemoryCache(allowed.projectPath);
+    }
+
+    const newStat = await fs.stat(absPath);
+    return NextResponse.json({
+      ok: true,
+      mtimeMs: newStat.mtimeMs,
+      sizeBytes: newStat.size,
+      backupId,
+    });
+  });
+}

--- a/src/app/api/memory/by-id/[id]/snapshot/route.ts
+++ b/src/app/api/memory/by-id/[id]/snapshot/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { getCachedScan, setCachedScan } from "@/lib/cache";
+import { scanAllProjects } from "@/lib/scanner";
+import { list as listHistory } from "@/lib/configHistory";
+import { classifyMemoryPath, decodeMemoryId } from "@/lib/memory/safety";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const absPath = decodeMemoryId(id);
+  if (!absPath) {
+    return NextResponse.json({ error: { code: "INVALID_ID" } }, { status: 400 });
+  }
+
+  let scan = getCachedScan();
+  if (!scan) {
+    scan = await scanAllProjects();
+    setCachedScan(scan);
+  }
+  const allowed = classifyMemoryPath(absPath, scan.projects);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: { code: "PATH_NOT_ALLOWED" } },
+      { status: 400 },
+    );
+  }
+
+  const entries = await listHistory();
+  const resolved = path.resolve(absPath);
+  // listHistory() returns newest-first, so the first match is the latest.
+  const latest = entries.find(
+    (e) => path.resolve(e.targetPath) === resolved && !e.wasMissing && e.snapshotPath,
+  );
+  if (!latest || !latest.snapshotPath) {
+    return NextResponse.json({ snapshot: null });
+  }
+
+  try {
+    const encoded = await fs.readFile(latest.snapshotPath, "utf-8");
+    const content = Buffer.from(encoded, "base64").toString("utf-8");
+    return NextResponse.json({
+      snapshot: { content, timestamp: latest.timestamp },
+    });
+  } catch {
+    return NextResponse.json({ snapshot: null });
+  }
+}

--- a/src/app/api/memory/by-id/[id]/snapshot/route.ts
+++ b/src/app/api/memory/by-id/[id]/snapshot/route.ts
@@ -21,7 +21,7 @@ export async function GET(
     scan = await scanAllProjects();
     setCachedScan(scan);
   }
-  const allowed = classifyMemoryPath(absPath, scan.projects);
+  const allowed = await classifyMemoryPath(absPath, scan.projects);
   if (!allowed) {
     return NextResponse.json(
       { error: { code: "PATH_NOT_ALLOWED" } },

--- a/src/app/api/memory/route.ts
+++ b/src/app/api/memory/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getCachedScan, setCachedScan } from "@/lib/cache";
+import { scanAllProjects } from "@/lib/scanner";
+import { listMemoryFiles } from "@/lib/memory";
+
+export async function GET() {
+  let scan = getCachedScan();
+  if (!scan) {
+    scan = await scanAllProjects();
+    setCachedScan(scan);
+  }
+  const entries = await listMemoryFiles({ projects: scan.projects });
+  return NextResponse.json({ entries });
+}

--- a/src/app/memory/page.tsx
+++ b/src/app/memory/page.tsx
@@ -1,16 +1,21 @@
-import { ComingSoon } from "@/components/ComingSoon";
+"use client";
+
+import { Brain } from "lucide-react";
+import { MemoryBrowser } from "@/components/MemoryBrowser";
 
 export default function MemoryPage() {
   return (
-    <ComingSoon
-      title="Memory"
-      blurb="A cross-project view of every memory file Claude is reading and writing — your CLAUDE.md hierarchy, .memory/ entries, and per-session memory state. Designed to make it obvious when context is missing or when an update never propagated to the project files Claude actually loads."
-      features={[
-        "All CLAUDE.md files across project, user, and plugin scopes",
-        "Stale-memory detection: entries that contradict current code",
-        "Quick edits without leaving the dashboard",
-        "Diff view for memory changes between sessions",
-      ]}
-    />
+    <div style={{ padding: "20px 24px 40px", display: "flex", flexDirection: "column", gap: "20px" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+        <Brain size={20} style={{ color: "var(--accent)" }} />
+        <div>
+          <h1 style={{ margin: 0, fontSize: "1.05rem", color: "var(--text-primary)" }}>Memory</h1>
+          <p style={{ margin: "2px 0 0", fontSize: "0.74rem", color: "var(--text-muted)" }}>
+            Cross-tier inventory of every CLAUDE.md and auto-memory file Claude reads.
+          </p>
+        </div>
+      </header>
+      <MemoryBrowser />
+    </div>
   );
 }

--- a/src/app/memory/page.tsx
+++ b/src/app/memory/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Brain } from "lucide-react";
 import { MemoryBrowser } from "@/components/MemoryBrowser";
 

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -67,7 +67,7 @@ const GROUPS: NavGroup[] = [
     hint: "What Claude Code is doing right now",
     children: [
       { id: "sessions", label: "Sessions", href: "/sessions", icon: ico(Layers), badge: "live" },
-      { id: "memory",   label: "Memory",   href: "/memory",   icon: ico(Brain),   comingSoon: true },
+      { id: "memory",   label: "Memory",   href: "/memory",   icon: ico(Brain) },
       { id: "timeline", label: "Timeline", href: "/timeline", icon: ico(Clock),   comingSoon: true },
     ],
   },

--- a/src/components/MemoryBrowser.tsx
+++ b/src/components/MemoryBrowser.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import type { MemoryFileEntry, MemoryScope } from "@/lib/types";
+import { MemoryEditor } from "./MemoryEditor";
+
+const SCOPE_LABEL: Record<MemoryScope, string> = {
+  user: "User",
+  project: "Project CLAUDE.md",
+  auto: "Auto-memory",
+};
+
+const SCOPE_ORDER: MemoryScope[] = ["user", "project", "auto"];
+
+type ScopeFilter = MemoryScope | "all";
+
+export function MemoryBrowser() {
+  const [entries, setEntries] = useState<MemoryFileEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>("all");
+  const [showStaleOnly, setShowStaleOnly] = useState(false);
+
+  async function reload(signal?: AbortSignal) {
+    try {
+      const r = await fetch("/api/memory", { signal });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const json = (await r.json()) as { entries: MemoryFileEntry[] };
+      setEntries(json.entries);
+      setError(null);
+    } catch (e) {
+      if (e instanceof Error && e.name === "AbortError") return;
+      setError(e instanceof Error ? e.message : "Failed to load memory files");
+    }
+  }
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    reload(ctrl.signal);
+    return () => ctrl.abort();
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!entries) return [];
+    const q = search.trim().toLowerCase();
+    return entries.filter((e) => {
+      if (scopeFilter !== "all" && e.scope !== scopeFilter) return false;
+      if (showStaleOnly && !isStale(e)) return false;
+      if (!q) return true;
+      return (
+        e.displayName.toLowerCase().includes(q) ||
+        e.preview.toLowerCase().includes(q) ||
+        (e.projectSlug ?? "").toLowerCase().includes(q) ||
+        (e.projectName ?? "").toLowerCase().includes(q)
+      );
+    });
+  }, [entries, search, scopeFilter, showStaleOnly]);
+
+  const grouped = useMemo(() => {
+    const out: Record<MemoryScope, MemoryFileEntry[]> = { user: [], project: [], auto: [] };
+    for (const e of filtered) out[e.scope].push(e);
+    return out;
+  }, [filtered]);
+
+  const { scopeCounts, staleCount } = useMemo(() => {
+    const counts: Record<MemoryScope, number> = { user: 0, project: 0, auto: 0 };
+    let stale = 0;
+    if (entries) {
+      for (const e of entries) {
+        counts[e.scope]++;
+        if (isStale(e)) stale++;
+      }
+    }
+    return { scopeCounts: counts, staleCount: stale };
+  }, [entries]);
+
+  const selected = entries?.find((e) => e.id === selectedId) ?? null;
+
+  if (error) {
+    return <p style={{ padding: "40px 0", color: "var(--status-error-text, var(--accent))" }}>{error}</p>;
+  }
+  if (!entries) {
+    return <p style={{ padding: "40px 0", color: "var(--text-muted)" }}>Loading</p>;
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "10px", alignItems: "center" }}>
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search memory files…"
+          style={{
+            flex: "1 1 240px",
+            padding: "8px 12px",
+            fontSize: "0.78rem",
+            background: "var(--bg-surface)",
+            border: "1px solid var(--border-default)",
+            borderRadius: "var(--radius)",
+            color: "var(--text-primary)",
+          }}
+        />
+        <ScopeChip
+          label={`All (${entries.length})`}
+          active={scopeFilter === "all"}
+          onClick={() => setScopeFilter("all")}
+        />
+        {SCOPE_ORDER.map((s) => (
+          <ScopeChip
+            key={s}
+            label={`${SCOPE_LABEL[s]} (${scopeCounts[s]})`}
+            active={scopeFilter === s}
+            onClick={() => setScopeFilter(s)}
+          />
+        ))}
+        <ScopeChip
+          label={`Stale (${staleCount})`}
+          active={showStaleOnly}
+          onClick={() => setShowStaleOnly((v) => !v)}
+          variant="warn"
+        />
+      </div>
+
+      <div style={{ display: "flex", gap: "16px", alignItems: "flex-start" }}>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+            width: "320px",
+            flexShrink: 0,
+          }}
+        >
+          {SCOPE_ORDER.map((scope) => {
+            const list = grouped[scope];
+            if (list.length === 0) return null;
+            return (
+              <div key={scope} style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+                <SectionHeader label={`${SCOPE_LABEL[scope]} · ${list.length}`} />
+                {list.map((entry) => (
+                  <MemoryRow
+                    key={entry.id}
+                    entry={entry}
+                    active={selectedId === entry.id}
+                    onClick={() => setSelectedId(entry.id)}
+                  />
+                ))}
+              </div>
+            );
+          })}
+          {filtered.length === 0 && (
+            <p style={{ color: "var(--text-muted)", fontSize: "0.75rem" }}>No matches.</p>
+          )}
+        </div>
+        {selected ? (
+          <MemoryEditor entry={selected} onSaved={reload} />
+        ) : (
+          <div
+            style={{
+              flex: 1,
+              padding: "60px 20px",
+              textAlign: "center",
+              border: "1px dashed var(--border-subtle)",
+              borderRadius: "var(--radius)",
+              color: "var(--text-muted)",
+              fontSize: "0.78rem",
+            }}
+          >
+            Select a memory file on the left to view or edit it.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ScopeChip({
+  label,
+  active,
+  onClick,
+  variant,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  variant?: "warn";
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        padding: "6px 12px",
+        fontSize: "0.7rem",
+        fontFamily: "var(--font-body)",
+        background: active ? "var(--accent-bg)" : "var(--bg-surface)",
+        color: active ? "var(--accent)" : variant === "warn" ? "var(--accent)" : "var(--text-secondary)",
+        border: `1px solid ${active ? "var(--accent-border)" : "var(--border-subtle)"}`,
+        borderRadius: "var(--radius)",
+        cursor: "pointer",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function SectionHeader({ label }: { label: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+      <span
+        style={{
+          fontSize: "0.6rem",
+          fontWeight: 700,
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-body)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </span>
+      <div style={{ flex: 1, height: "1px", background: "var(--border-subtle)" }} />
+    </div>
+  );
+}
+
+function MemoryRow({
+  entry,
+  active,
+  onClick,
+}: {
+  entry: MemoryFileEntry;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const stale = isStale(entry);
+  const rel = formatDistanceToNow(new Date(entry.mtimeMs), { addSuffix: true });
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+        padding: "10px 12px",
+        textAlign: "left",
+        background: active ? "var(--accent-bg)" : "var(--bg-elevated)",
+        border: `1px solid ${active ? "var(--accent-border)" : "var(--border-subtle)"}`,
+        borderRadius: "var(--radius)",
+        cursor: "pointer",
+        transition: "background 0.1s, border-color 0.1s",
+        width: "100%",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+        <span
+          style={{
+            fontSize: "0.78rem",
+            fontFamily: "var(--font-mono)",
+            color: active ? "var(--accent)" : "var(--text-primary)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            flex: 1,
+            minWidth: 0,
+          }}
+        >
+          {entry.displayName}
+        </span>
+        {stale && <StaleChip entry={entry} />}
+      </div>
+      {entry.projectName && (
+        <span
+          style={{
+            fontSize: "0.66rem",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {entry.projectName}
+        </span>
+      )}
+      {entry.preview && (
+        <span
+          style={{
+            fontSize: "0.68rem",
+            color: "var(--text-secondary)",
+            fontFamily: "var(--font-body)",
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {entry.preview}
+        </span>
+      )}
+      <span
+        style={{
+          fontSize: "0.62rem",
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+        }}
+      >
+        {rel} · {(entry.sizeBytes / 1024).toFixed(1)} KB
+      </span>
+    </button>
+  );
+}
+
+function StaleChip({ entry }: { entry: MemoryFileEntry }) {
+  const reasons: string[] = [];
+  if (entry.stale.ageOver30d) reasons.push("age > 30d");
+  if (entry.stale.brokenImports.length > 0) {
+    reasons.push(`${entry.stale.brokenImports.length} broken @import`);
+  }
+  return (
+    <span
+      title={reasons.join(" · ")}
+      style={{
+        marginLeft: "auto",
+        fontSize: "0.58rem",
+        fontFamily: "var(--font-mono)",
+        color: "var(--accent)",
+        background: "var(--accent-bg)",
+        border: "1px solid var(--accent-border)",
+        borderRadius: "3px",
+        padding: "1px 5px",
+        letterSpacing: "0.04em",
+        textTransform: "uppercase",
+        whiteSpace: "nowrap",
+      }}
+    >
+      stale
+    </span>
+  );
+}
+
+function isStale(entry: MemoryFileEntry): boolean {
+  return entry.stale.ageOver30d || entry.stale.brokenImports.length > 0;
+}

--- a/src/components/MemoryEditor.tsx
+++ b/src/components/MemoryEditor.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { MarkdownContent } from "./MarkdownContent";
+import { lineDiff } from "@/lib/usage/diff";
+import type { MemoryFileEntry } from "@/lib/types";
+
+interface FileResponse {
+  id: string;
+  absPath: string;
+  scope: string;
+  projectSlug?: string;
+  content: string;
+  mtimeMs: number;
+  sizeBytes: number;
+}
+
+interface SaveResponse {
+  ok: boolean;
+  mtimeMs: number;
+  sizeBytes: number;
+  backupId?: string | null;
+}
+
+interface DiffResponse {
+  snapshot: { content: string | null; timestamp: string } | null;
+}
+
+type EditorMode = "view" | "edit" | "diff";
+
+const DIFF_MAX_LINES = 3000;
+
+const DIFF_MARKER: Record<"added" | "removed" | "context", string> = {
+  added: "+",
+  removed: "-",
+  context: " ",
+};
+
+function diffLineStyle(kind: "added" | "removed" | "context"): React.CSSProperties {
+  if (kind === "added") return { padding: "0 6px", background: "rgba(76, 222, 128, 0.08)", color: "#86efac" };
+  if (kind === "removed") return { padding: "0 6px", background: "rgba(248, 113, 113, 0.08)", color: "#fca5a5" };
+  return { padding: "0 6px", color: "var(--text-secondary)" };
+}
+
+interface MemoryEditorProps {
+  entry: MemoryFileEntry;
+  onSaved?: () => void;
+}
+
+export function MemoryEditor({ entry, onSaved }: MemoryEditorProps) {
+  const [data, setData] = useState<FileResponse | null>(null);
+  const [draft, setDraft] = useState<string>("");
+  const [mode, setMode] = useState<EditorMode>("view");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [conflict, setConflict] = useState(false);
+
+  async function loadFile(signal?: AbortSignal): Promise<FileResponse> {
+    const r = await fetch(`/api/memory/by-id/${encodeURIComponent(entry.id)}`, { signal });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return (await r.json()) as FileResponse;
+  }
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setData(null);
+    setError(null);
+    setMode("view");
+    setConflict(false);
+    loadFile(ctrl.signal)
+      .then((res) => {
+        setData(res);
+        setDraft(res.content);
+      })
+      .catch((e: Error) => {
+        if (e.name === "AbortError") return;
+        setError(e.message);
+      });
+    return () => ctrl.abort();
+  }, [entry.id]);
+
+  async function handleSave() {
+    if (!data) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/memory/by-id/${encodeURIComponent(entry.id)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: draft, mtimeMs: data.mtimeMs }),
+      });
+      const body: { ok?: boolean; mtimeMs?: number; sizeBytes?: number; error?: { code: string; message?: string } } =
+        await res.json().catch(() => ({}));
+      if (res.status === 409) {
+        setConflict(true);
+        return;
+      }
+      if (!res.ok || !body.ok) {
+        const code = body.error?.code ?? `HTTP ${res.status}`;
+        throw new Error(body.error?.message ?? code);
+      }
+      const saved = body as SaveResponse;
+      setData({ ...data, content: draft, mtimeMs: saved.mtimeMs, sizeBytes: saved.sizeBytes });
+      setMode("view");
+      setSavedFlash(true);
+      setTimeout(() => setSavedFlash(false), 1500);
+      onSaved?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleReload() {
+    setConflict(false);
+    setError(null);
+    try {
+      const res = await loadFile();
+      setData(res);
+      setDraft(res.content);
+      setMode("view");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Reload failed");
+    }
+  }
+
+  if (error && !data) {
+    return <p style={{ ...errorTextStyle, padding: "20px 0" }}>{error}</p>;
+  }
+  if (!data) {
+    return <p style={{ ...mutedStyle, padding: "20px 0" }}>Loading</p>;
+  }
+
+  const dirty = draft !== data.content;
+
+  return (
+    <div style={paneStyle}>
+      <div style={toolbarStyle}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "2px", flex: 1, minWidth: 0 }}>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.78rem", color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {entry.displayName}
+          </span>
+          <span style={{ fontFamily: "var(--font-mono)", fontSize: "0.65rem", color: "var(--text-muted)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {data.absPath}
+          </span>
+        </div>
+        {mode === "view" && (
+          <>
+            <button onClick={() => setMode("edit")} style={btnStyle}>Edit</button>
+            <button onClick={() => setMode("diff")} style={btnStyle} title="Compare against last config-history snapshot">Diff</button>
+          </>
+        )}
+        {mode === "diff" && (
+          <button onClick={() => setMode("view")} style={btnStyle}>Close diff</button>
+        )}
+        {mode === "edit" && (
+          <>
+            <button
+              onClick={() => { setDraft(data.content); setMode("view"); setError(null); }}
+              style={btnStyle}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              style={{ ...btnStyle, color: "var(--text-primary)", borderColor: "var(--border-default)" }}
+              disabled={saving || !dirty}
+            >
+              {saving ? "Saving" : "Save"}
+            </button>
+          </>
+        )}
+        {savedFlash && (
+          <span style={{ fontSize: "0.68rem", color: "var(--status-active-text, var(--accent))" }}>Saved</span>
+        )}
+      </div>
+
+      {conflict && (
+        <div style={conflictBannerStyle}>
+          <span style={{ flex: 1 }}>File changed externally. Reload to see latest content.</span>
+          <button onClick={handleReload} style={btnStyle}>Reload</button>
+        </div>
+      )}
+
+      {error && <p style={errorTextStyle}>{error}</p>}
+
+      {mode === "diff" && <DiffView entry={entry} draftContent={data.content} />}
+      {mode === "edit" && (
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          readOnly={saving}
+          style={textareaStyle}
+        />
+      )}
+      {mode === "view" && <MarkdownContent content={data.content} />}
+
+      <div style={footerStyle}>
+        <span>{(data.sizeBytes / 1024).toFixed(1)} KB</span>
+        <span style={{ flex: 1 }} />
+        <span>mtime {new Date(data.mtimeMs).toLocaleString()}</span>
+      </div>
+    </div>
+  );
+}
+
+function DiffView({ entry, draftContent }: { entry: MemoryFileEntry; draftContent: string }) {
+  const [snapshot, setSnapshot] = useState<DiffResponse["snapshot"]>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    setLoading(true);
+    fetch(`/api/memory/by-id/${encodeURIComponent(entry.id)}/snapshot`, { signal: ctrl.signal })
+      .then(async (r) => (r.ok ? ((await r.json()) as DiffResponse) : { snapshot: null }))
+      .then((res) => setSnapshot(res.snapshot))
+      .catch((e: Error) => {
+        if (e.name !== "AbortError") setSnapshot(null);
+      })
+      .finally(() => setLoading(false));
+    return () => ctrl.abort();
+  }, [entry.id]);
+
+  const diffLines = useMemo(
+    () => (snapshot?.content != null ? lineDiff(snapshot.content, draftContent, DIFF_MAX_LINES) : []),
+    [snapshot, draftContent],
+  );
+
+  if (loading) return <p style={mutedStyle}>Loading snapshot</p>;
+  if (!snapshot || snapshot.content === null) {
+    return (
+      <p style={{ ...mutedStyle, padding: "12px 0" }}>
+        No prior config-history snapshot for this file. The next save will record one.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      <span style={{ fontSize: "0.65rem", color: "var(--text-muted)", fontFamily: "var(--font-mono)" }}>
+        snapshot {new Date(snapshot.timestamp).toLocaleString()}
+      </span>
+      <pre style={diffPreStyle}>
+        {diffLines.map((line, i) => (
+          <div key={i} style={diffLineStyle(line.kind)}>
+            <span style={{ display: "inline-block", width: "1.2em" }}>{DIFF_MARKER[line.kind]}</span>
+            {line.text || " "}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+const paneStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  padding: "12px 16px",
+  background: "var(--bg-elevated)",
+  border: "1px solid var(--border-subtle)",
+  borderRadius: "var(--radius)",
+  minHeight: "240px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "12px",
+};
+
+const toolbarStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  paddingBottom: "8px",
+  borderBottom: "1px solid var(--border-subtle)",
+};
+
+const btnStyle: React.CSSProperties = {
+  padding: "4px 10px",
+  fontSize: "0.7rem",
+  fontFamily: "var(--font-body)",
+  color: "var(--text-secondary)",
+  background: "var(--bg-surface)",
+  border: "1px solid var(--border-subtle)",
+  borderRadius: "var(--radius)",
+  cursor: "pointer",
+};
+
+const textareaStyle: React.CSSProperties = {
+  width: "100%",
+  minHeight: "60vh",
+  padding: "10px 12px",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.78rem",
+  color: "var(--text-primary)",
+  background: "var(--bg-surface)",
+  border: "1px solid var(--border-default)",
+  borderRadius: "var(--radius)",
+  resize: "vertical",
+};
+
+const conflictBannerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "10px",
+  padding: "8px 12px",
+  fontSize: "0.72rem",
+  color: "var(--text-primary)",
+  background: "var(--accent-bg)",
+  border: "1px solid var(--accent-border)",
+  borderRadius: "var(--radius)",
+};
+
+const errorTextStyle: React.CSSProperties = {
+  fontSize: "0.72rem",
+  color: "var(--status-error-text, var(--accent))",
+  margin: 0,
+};
+
+const mutedStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "var(--text-muted)",
+  margin: 0,
+};
+
+const footerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "12px",
+  paddingTop: "8px",
+  borderTop: "1px solid var(--border-subtle)",
+  fontSize: "0.65rem",
+  color: "var(--text-muted)",
+  fontFamily: "var(--font-mono)",
+};
+
+const diffPreStyle: React.CSSProperties = {
+  margin: 0,
+  padding: "8px 0",
+  background: "var(--bg-surface)",
+  border: "1px solid var(--border-subtle)",
+  borderRadius: "var(--radius)",
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.74rem",
+  lineHeight: 1.55,
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  maxHeight: "65vh",
+  overflow: "auto",
+};

--- a/src/components/MemoryEditor.tsx
+++ b/src/components/MemoryEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { MarkdownContent } from "./MarkdownContent";
 import { lineDiff } from "@/lib/usage/diff";
 import type { MemoryFileEntry } from "@/lib/types";
@@ -55,6 +55,7 @@ export function MemoryEditor({ entry, onSaved }: MemoryEditorProps) {
   const [error, setError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
   const [conflict, setConflict] = useState(false);
+  const saveCtrl = useRef<AbortController | null>(null);
 
   async function loadFile(signal?: AbortSignal): Promise<FileResponse> {
     const r = await fetch(`/api/memory/by-id/${encodeURIComponent(entry.id)}`, { signal });
@@ -77,11 +78,17 @@ export function MemoryEditor({ entry, onSaved }: MemoryEditorProps) {
         if (e.name === "AbortError") return;
         setError(e.message);
       });
-    return () => ctrl.abort();
+    return () => {
+      ctrl.abort();
+      saveCtrl.current?.abort();
+    };
   }, [entry.id]);
 
   async function handleSave() {
     if (!data) return;
+    saveCtrl.current?.abort();
+    const ctrl = new AbortController();
+    saveCtrl.current = ctrl;
     setSaving(true);
     setError(null);
     try {
@@ -89,6 +96,7 @@ export function MemoryEditor({ entry, onSaved }: MemoryEditorProps) {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ content: draft, mtimeMs: data.mtimeMs }),
+        signal: ctrl.signal,
       });
       const body: { ok?: boolean; mtimeMs?: number; sizeBytes?: number; error?: { code: string; message?: string } } =
         await res.json().catch(() => ({}));
@@ -107,8 +115,10 @@ export function MemoryEditor({ entry, onSaved }: MemoryEditorProps) {
       setTimeout(() => setSavedFlash(false), 1500);
       onSaved?.();
     } catch (e) {
+      if (e instanceof Error && e.name === "AbortError") return;
       setError(e instanceof Error ? e.message : "Save failed");
     } finally {
+      if (saveCtrl.current === ctrl) saveCtrl.current = null;
       setSaving(false);
     }
   }
@@ -153,10 +163,11 @@ export function MemoryEditor({ entry, onSaved }: MemoryEditorProps) {
           </>
         )}
         {mode === "diff" && (
-          <button onClick={() => setMode("view")} style={btnStyle}>Close diff</button>
+          <button onClick={() => setMode(dirty ? "edit" : "view")} style={btnStyle}>Close diff</button>
         )}
         {mode === "edit" && (
           <>
+            <button onClick={() => setMode("diff")} style={btnStyle} title="Compare draft against last config-history snapshot">Diff</button>
             <button
               onClick={() => { setDraft(data.content); setMode("view"); setError(null); }}
               style={btnStyle}
@@ -187,7 +198,7 @@ export function MemoryEditor({ entry, onSaved }: MemoryEditorProps) {
 
       {error && <p style={errorTextStyle}>{error}</p>}
 
-      {mode === "diff" && <DiffView entry={entry} draftContent={data.content} />}
+      {mode === "diff" && <DiffView entry={entry} draftContent={draft} />}
       {mode === "edit" && (
         <textarea
           value={draft}

--- a/src/lib/help-mapping.ts
+++ b/src/lib/help-mapping.ts
@@ -36,6 +36,7 @@ export const helpMapping: Record<string, string> = {
   '/library': 'library',
   '/new-project': 'new-project',
   '/insights-report': 'insights-report',
+  '/memory': 'memory',
 }
 
 /**

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "fs";
+import { createHash } from "crypto";
 import path from "path";
 import type { MemoryFileEntry, MemoryStaleness, ProjectData } from "../types";
 import { expandImports } from "../scanner/expandImports";
@@ -7,12 +8,11 @@ import { encodeMemoryId, userMemoryPath } from "./safety";
 
 const STALE_AGE_MS = 30 * 24 * 60 * 60_000;
 const PREVIEW_CHARS = 200;
-// Reads first N bytes for preview + broken-import detection. Imports must
-// resolve from disk anyway, so over-reading the entry file just wastes I/O.
-const PARTIAL_READ_BYTES = 8 * 1024;
 const CACHE_TTL = 60_000;
+const IMPORT_CACHE_MAX = 500;
 
 interface InventoryCache {
+  key: string;
   entries: MemoryFileEntry[];
   cachedAt: number;
 }
@@ -36,9 +36,22 @@ interface DiscoveryInput {
   projects: ProjectData[];
 }
 
+// Hash the project set so cache hits require both freshness AND a matching
+// project list. Without this, a list call after a rescan could return entries
+// for projects that are no longer present (which would then 400 on PUT
+// because /api/memory/by-id/[id] revalidates against the fresh list).
+function projectsKey(projects: ProjectData[]): string {
+  const h = createHash("sha256");
+  for (const p of projects) h.update(`${p.slug}\0${p.path}\n`);
+  return h.digest("hex").slice(0, 16);
+}
+
 export async function listMemoryFiles(input: DiscoveryInput): Promise<MemoryFileEntry[]> {
+  const key = projectsKey(input.projects);
   const cached = g.__memoryInventoryCache;
-  if (cached && Date.now() - cached.cachedAt < CACHE_TTL) return cached.entries;
+  if (cached && cached.key === key && Date.now() - cached.cachedAt < CACHE_TTL) {
+    return cached.entries;
+  }
 
   const entries: MemoryFileEntry[] = [];
   const userEntry = await tryUser();
@@ -60,7 +73,7 @@ export async function listMemoryFiles(input: DiscoveryInput): Promise<MemoryFile
     return a.displayName.localeCompare(b.displayName);
   });
 
-  g.__memoryInventoryCache = { entries, cachedAt: Date.now() };
+  g.__memoryInventoryCache = { key, entries, cachedAt: Date.now() };
   return entries;
 }
 
@@ -124,8 +137,17 @@ async function readEntry(
   }
   if (!stat.isFile()) return null;
 
-  const partial = await readHead(absPath, PARTIAL_READ_BYTES);
-  const stale = await computeStaleness(absPath, partial, stat.mtimeMs);
+  // Read full file: expandImports needs the whole entry so late `@import`
+  // directives aren't missed. The mtime-keyed import cache below ensures
+  // repeat list calls don't re-read or re-recurse when nothing changed.
+  let raw: string;
+  try {
+    raw = await fs.readFile(absPath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const stale = await computeStaleness(absPath, raw, stat.mtimeMs);
 
   return {
     id: encodeMemoryId(absPath),
@@ -136,23 +158,9 @@ async function readEntry(
     displayName: meta.displayName,
     mtimeMs: stat.mtimeMs,
     sizeBytes: stat.size,
-    preview: makePreview(partial),
+    preview: makePreview(raw),
     stale,
   };
-}
-
-async function readHead(absPath: string, maxBytes: number): Promise<string> {
-  let handle: import("fs").promises.FileHandle | null = null;
-  try {
-    handle = await fs.open(absPath, "r");
-    const buf = Buffer.alloc(maxBytes);
-    const { bytesRead } = await handle.read(buf, 0, maxBytes, 0);
-    return buf.subarray(0, bytesRead).toString("utf-8");
-  } catch {
-    return "";
-  } finally {
-    if (handle) await handle.close().catch(() => {});
-  }
 }
 
 async function computeStaleness(
@@ -165,6 +173,9 @@ async function computeStaleness(
   const importCache = g.__memoryImportCache!;
   const cached = importCache.get(absPath);
   if (cached && cached.mtimeMs === mtimeMs) {
+    // LRU touch: re-insert to move to most-recently-used end of Map iteration order.
+    importCache.delete(absPath);
+    importCache.set(absPath, cached);
     return { ageOver30d, brokenImports: cached.brokenImports };
   }
 
@@ -176,6 +187,12 @@ async function computeStaleness(
       .map((i) => i.spec);
   } catch {
     // best-effort; leave brokenImports empty
+  }
+
+  if (importCache.size >= IMPORT_CACHE_MAX) {
+    // Evict oldest entry (Map preserves insertion order).
+    const oldest = importCache.keys().next().value;
+    if (oldest !== undefined) importCache.delete(oldest);
   }
   importCache.set(absPath, { mtimeMs, brokenImports });
   return { ageOver30d, brokenImports };

--- a/src/lib/memory/index.ts
+++ b/src/lib/memory/index.ts
@@ -1,0 +1,187 @@
+import { promises as fs } from "fs";
+import path from "path";
+import type { MemoryFileEntry, MemoryStaleness, ProjectData } from "../types";
+import { expandImports } from "../scanner/expandImports";
+import { memoryDirFor } from "../scanner/memoryWriter";
+import { encodeMemoryId, userMemoryPath } from "./safety";
+
+const STALE_AGE_MS = 30 * 24 * 60 * 60_000;
+const PREVIEW_CHARS = 200;
+// Reads first N bytes for preview + broken-import detection. Imports must
+// resolve from disk anyway, so over-reading the entry file just wastes I/O.
+const PARTIAL_READ_BYTES = 8 * 1024;
+const CACHE_TTL = 60_000;
+
+interface InventoryCache {
+  entries: MemoryFileEntry[];
+  cachedAt: number;
+}
+
+interface ImportCacheEntry {
+  mtimeMs: number;
+  brokenImports: string[];
+}
+
+const g = globalThis as unknown as {
+  __memoryInventoryCache?: InventoryCache | null;
+  __memoryImportCache?: Map<string, ImportCacheEntry>;
+};
+g.__memoryImportCache ??= new Map();
+
+export function invalidateMemoryInventoryCache(): void {
+  g.__memoryInventoryCache = null;
+}
+
+interface DiscoveryInput {
+  projects: ProjectData[];
+}
+
+export async function listMemoryFiles(input: DiscoveryInput): Promise<MemoryFileEntry[]> {
+  const cached = g.__memoryInventoryCache;
+  if (cached && Date.now() - cached.cachedAt < CACHE_TTL) return cached.entries;
+
+  const entries: MemoryFileEntry[] = [];
+  const userEntry = await tryUser();
+  if (userEntry) entries.push(userEntry);
+
+  await Promise.all(
+    input.projects.map(async (p) => {
+      const proj = await tryProject(p);
+      if (proj) entries.push(proj);
+      const auto = await tryAuto(p);
+      entries.push(...auto);
+    }),
+  );
+
+  entries.sort((a, b) => {
+    const scoreA = scopeOrder(a.scope);
+    const scoreB = scopeOrder(b.scope);
+    if (scoreA !== scoreB) return scoreA - scoreB;
+    return a.displayName.localeCompare(b.displayName);
+  });
+
+  g.__memoryInventoryCache = { entries, cachedAt: Date.now() };
+  return entries;
+}
+
+function scopeOrder(scope: MemoryFileEntry["scope"]): number {
+  return scope === "user" ? 0 : scope === "project" ? 1 : 2;
+}
+
+async function tryUser(): Promise<MemoryFileEntry | null> {
+  return readEntry(userMemoryPath(), { scope: "user", displayName: "User CLAUDE.md" });
+}
+
+async function tryProject(p: ProjectData): Promise<MemoryFileEntry | null> {
+  return readEntry(path.resolve(path.join(p.path, "CLAUDE.md")), {
+    scope: "project",
+    projectSlug: p.slug,
+    projectName: p.name,
+    displayName: "CLAUDE.md",
+  });
+}
+
+async function tryAuto(p: ProjectData): Promise<MemoryFileEntry[]> {
+  const memDir = memoryDirFor(p.path);
+  let names: string[];
+  try {
+    names = await fs.readdir(memDir);
+  } catch {
+    return [];
+  }
+  const mdNames = names.filter(
+    (n) => n.toLowerCase().endsWith(".md") && !n.startsWith("."),
+  );
+  const out = await Promise.all(
+    mdNames.map((name) =>
+      readEntry(path.resolve(path.join(memDir, name)), {
+        scope: "auto",
+        projectSlug: p.slug,
+        projectName: p.name,
+        displayName: name,
+      }),
+    ),
+  );
+  return out.filter((e): e is MemoryFileEntry => e !== null);
+}
+
+interface PartialEntry {
+  scope: MemoryFileEntry["scope"];
+  projectSlug?: string;
+  projectName?: string;
+  displayName: string;
+}
+
+async function readEntry(
+  absPath: string,
+  meta: PartialEntry,
+): Promise<MemoryFileEntry | null> {
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(absPath);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile()) return null;
+
+  const partial = await readHead(absPath, PARTIAL_READ_BYTES);
+  const stale = await computeStaleness(absPath, partial, stat.mtimeMs);
+
+  return {
+    id: encodeMemoryId(absPath),
+    scope: meta.scope,
+    projectSlug: meta.projectSlug,
+    projectName: meta.projectName,
+    absPath,
+    displayName: meta.displayName,
+    mtimeMs: stat.mtimeMs,
+    sizeBytes: stat.size,
+    preview: makePreview(partial),
+    stale,
+  };
+}
+
+async function readHead(absPath: string, maxBytes: number): Promise<string> {
+  let handle: import("fs").promises.FileHandle | null = null;
+  try {
+    handle = await fs.open(absPath, "r");
+    const buf = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buf, 0, maxBytes, 0);
+    return buf.subarray(0, bytesRead).toString("utf-8");
+  } catch {
+    return "";
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+}
+
+async function computeStaleness(
+  absPath: string,
+  raw: string,
+  mtimeMs: number,
+): Promise<MemoryStaleness> {
+  const ageOver30d = Date.now() - mtimeMs > STALE_AGE_MS;
+
+  const importCache = g.__memoryImportCache!;
+  const cached = importCache.get(absPath);
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return { ageOver30d, brokenImports: cached.brokenImports };
+  }
+
+  let brokenImports: string[] = [];
+  try {
+    const expanded = await expandImports(absPath, raw);
+    brokenImports = expanded.imports
+      .filter((i) => i.error !== undefined)
+      .map((i) => i.spec);
+  } catch {
+    // best-effort; leave brokenImports empty
+  }
+  importCache.set(absPath, { mtimeMs, brokenImports });
+  return { ageOver30d, brokenImports };
+}
+
+function makePreview(raw: string): string {
+  const stripped = raw.replace(/^---\n[\s\S]*?\n---\n?/, "").trimStart();
+  return stripped.slice(0, PREVIEW_CHARS).replace(/\s+/g, " ").trim();
+}

--- a/src/lib/memory/safety.ts
+++ b/src/lib/memory/safety.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from "fs";
 import path from "path";
 import os from "os";
 import type { ProjectData } from "../types";
@@ -6,11 +7,13 @@ import { memoryDirFor } from "../scanner/memoryWriter";
 // PUT to /api/memory/by-id/[id] decodes its `id` into an absolute path. Without
 // an allowlist, that becomes a write-anywhere primitive. We constrain accepted
 // targets to exactly three shapes:
-//   1. The user-scope CLAUDE.md (`~/.claude/CLAUDE.md`)
-//   2. A scanned project's CLAUDE.md (`<project.path>/CLAUDE.md`)
-//   3. An auto-memory file inside `~/.claude/projects/<encoded>/memory/*.md`
-// Anything else — including ".." escapes that resolve back into the tree —
-// gets a 400 PATH_NOT_ALLOWED before any snapshot or write happens.
+//   1. The user-scope CLAUDE.md (~/.claude/CLAUDE.md)
+//   2. A scanned project's CLAUDE.md (<project.path>/CLAUDE.md)
+//   3. An auto-memory file inside ~/.claude/projects/<encoded>/memory/*.md
+// Both candidate and allowlist entries are realpath-resolved so a symlink
+// in the home dir or project root cannot fool the comparison. Anything else
+// (including ".." escapes that resolve back into the tree) gets a 400
+// PATH_NOT_ALLOWED before any snapshot or write happens.
 
 export function userMemoryPath(): string {
   return path.resolve(path.join(os.homedir(), ".claude", "CLAUDE.md"));
@@ -41,32 +44,48 @@ export interface AllowedPathInfo {
   projectPath?: string;
 }
 
-/** Validate `absPath` against the three allowed shapes and return scope info,
- *  or null if disallowed. Pure: caller passes the project list it already has
- *  (from `scanAllProjects()`), so we don't introduce a scan dependency here. */
-export function classifyMemoryPath(
+// Realpath the candidate. If the file doesn't exist (allowed for the
+// mtimeMs=0 create-via-PUT escape hatch), realpath the parent directory and
+// re-attach the basename, so we still resolve any symlinks in the parent
+// chain. Returns null only on truly missing parent dirs.
+async function safeRealpath(p: string): Promise<string | null> {
+  try {
+    return await fs.realpath(p);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") return null;
+    try {
+      const parentReal = await fs.realpath(path.dirname(p));
+      return path.join(parentReal, path.basename(p));
+    } catch {
+      return null;
+    }
+  }
+}
+
+export async function classifyMemoryPath(
   absPath: string,
   projects: ProjectData[],
-): AllowedPathInfo | null {
-  const resolved = path.resolve(absPath);
+): Promise<AllowedPathInfo | null> {
+  const realCandidate = await safeRealpath(absPath);
+  if (!realCandidate) return null;
 
-  // 1. User scope
-  if (resolved === userMemoryPath()) {
+  const realUser = await safeRealpath(userMemoryPath());
+  if (realUser && realCandidate === realUser) {
     return { scope: "user" };
   }
 
   for (const p of projects) {
-    // 2. Project CLAUDE.md
-    if (resolved === projectMemoryPath(p.path)) {
+    const realProjectMd = await safeRealpath(projectMemoryPath(p.path));
+    if (realProjectMd && realCandidate === realProjectMd) {
       return { scope: "project", projectSlug: p.slug, projectPath: p.path };
     }
 
-    // 3. Auto-memory inside this project's memory dir
-    const memDir = path.resolve(memoryDirFor(p.path));
+    const realMemDir = await safeRealpath(memoryDirFor(p.path));
     if (
-      path.dirname(resolved) === memDir &&
-      resolved.toLowerCase().endsWith(".md") &&
-      !path.basename(resolved).startsWith(".")
+      realMemDir &&
+      path.dirname(realCandidate) === realMemDir &&
+      realCandidate.toLowerCase().endsWith(".md") &&
+      !path.basename(realCandidate).startsWith(".")
     ) {
       return { scope: "auto", projectSlug: p.slug, projectPath: p.path };
     }

--- a/src/lib/memory/safety.ts
+++ b/src/lib/memory/safety.ts
@@ -1,0 +1,76 @@
+import path from "path";
+import os from "os";
+import type { ProjectData } from "../types";
+import { memoryDirFor } from "../scanner/memoryWriter";
+
+// PUT to /api/memory/by-id/[id] decodes its `id` into an absolute path. Without
+// an allowlist, that becomes a write-anywhere primitive. We constrain accepted
+// targets to exactly three shapes:
+//   1. The user-scope CLAUDE.md (`~/.claude/CLAUDE.md`)
+//   2. A scanned project's CLAUDE.md (`<project.path>/CLAUDE.md`)
+//   3. An auto-memory file inside `~/.claude/projects/<encoded>/memory/*.md`
+// Anything else — including ".." escapes that resolve back into the tree —
+// gets a 400 PATH_NOT_ALLOWED before any snapshot or write happens.
+
+export function userMemoryPath(): string {
+  return path.resolve(path.join(os.homedir(), ".claude", "CLAUDE.md"));
+}
+
+export function projectMemoryPath(projectPath: string): string {
+  return path.resolve(path.join(projectPath, "CLAUDE.md"));
+}
+
+export function decodeMemoryId(id: string): string | null {
+  try {
+    const decoded = Buffer.from(id, "base64url").toString("utf-8");
+    if (!decoded || decoded.includes("\0")) return null;
+    if (!path.isAbsolute(decoded)) return null;
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+export function encodeMemoryId(absPath: string): string {
+  return Buffer.from(absPath, "utf-8").toString("base64url");
+}
+
+export interface AllowedPathInfo {
+  scope: "user" | "project" | "auto";
+  projectSlug?: string;
+  projectPath?: string;
+}
+
+/** Validate `absPath` against the three allowed shapes and return scope info,
+ *  or null if disallowed. Pure: caller passes the project list it already has
+ *  (from `scanAllProjects()`), so we don't introduce a scan dependency here. */
+export function classifyMemoryPath(
+  absPath: string,
+  projects: ProjectData[],
+): AllowedPathInfo | null {
+  const resolved = path.resolve(absPath);
+
+  // 1. User scope
+  if (resolved === userMemoryPath()) {
+    return { scope: "user" };
+  }
+
+  for (const p of projects) {
+    // 2. Project CLAUDE.md
+    if (resolved === projectMemoryPath(p.path)) {
+      return { scope: "project", projectSlug: p.slug, projectPath: p.path };
+    }
+
+    // 3. Auto-memory inside this project's memory dir
+    const memDir = path.resolve(memoryDirFor(p.path));
+    if (
+      path.dirname(resolved) === memDir &&
+      resolved.toLowerCase().endsWith(".md") &&
+      !path.basename(resolved).startsWith(".")
+    ) {
+      return { scope: "auto", projectSlug: p.slug, projectPath: p.path };
+    }
+  }
+
+  return null;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,6 +142,31 @@ export interface MemoryData {
   files: MemoryFile[];
 }
 
+export type MemoryScope = "user" | "project" | "auto";
+
+export interface MemoryStaleness {
+  ageOver30d: boolean;
+  brokenImports: string[]; // unresolved @import specs (from expandImports)
+}
+
+export interface MemoryFileEntry {
+  /** base64url(absPath) — opaque, path-traversal safe identifier. */
+  id: string;
+  scope: MemoryScope;
+  /** Project slug for `project` + `auto` scopes; undefined for `user`. */
+  projectSlug?: string;
+  /** Project name for display alongside slug; undefined for `user`. */
+  projectName?: string;
+  absPath: string;
+  /** Display name — basename for project/auto, "User CLAUDE.md" for user. */
+  displayName: string;
+  mtimeMs: number;
+  sizeBytes: number;
+  /** First ~200 chars of body, frontmatter stripped. */
+  preview: string;
+  stale: MemoryStaleness;
+}
+
 export interface PortMapping {
   service: string;
   host: number;

--- a/tests/memoryByIdRoute.test.ts
+++ b/tests/memoryByIdRoute.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import { NextRequest } from "next/server";
+
+// PUT /api/memory/by-id/[id] — allowlist gating, 2 MB cap, mtime conflict,
+// configHistory snapshot, atomic write. We use a real tmpdir so the
+// configHistory snapshot trail is exercised end-to-end (the same atomic-
+// write path used in production).
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+
+interface ProjectStub {
+  slug: string;
+  name: string;
+  path: string;
+  status: string;
+  dependencies: string[];
+  dockerPorts: never[];
+  externalServices: never[];
+  scannedAt: string;
+}
+
+function mkProject(slug: string, p: string): ProjectStub {
+  return {
+    slug,
+    name: slug,
+    path: p,
+    status: "active",
+    dependencies: [],
+    dockerPorts: [],
+    externalServices: [],
+    scannedAt: new Date().toISOString(),
+  };
+}
+
+async function reload() {
+  vi.resetModules();
+  vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  return await import("@/app/api/memory/by-id/[id]/route");
+}
+
+beforeEach(async () => {
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "minder-mem-route-"));
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  await fs.mkdir(path.join(tmpHome, ".claude"), { recursive: true });
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = originalUserProfile;
+  vi.restoreAllMocks();
+  try {
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+function makeRequest(id: string, method: "GET" | "PUT", body?: unknown): NextRequest {
+  if (body === undefined) {
+    return new NextRequest(`http://localhost:4100/api/memory/by-id/${id}`, { method });
+  }
+  return new NextRequest(`http://localhost:4100/api/memory/by-id/${id}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function stubScan(projects: ProjectStub[]) {
+  vi.doMock("@/lib/cache", () => ({
+    getCachedScan: () => ({ projects, ports: [], devRoots: [] }),
+    setCachedScan: () => {},
+    invalidateCache: () => {},
+  }));
+  vi.doMock("@/lib/scanner", () => ({
+    scanAllProjects: async () => ({ projects, ports: [], devRoots: [] }),
+  }));
+}
+
+function encodeId(p: string): string {
+  return Buffer.from(p, "utf-8").toString("base64url");
+}
+
+describe("PUT /api/memory/by-id/[id] — allowlist", () => {
+  it("rejects path outside the allowlist with 400 PATH_NOT_ALLOWED", async () => {
+    await stubScan([]);
+    const { PUT } = await reload();
+    const stray = path.join(tmpHome, "stray.md");
+    await fs.writeFile(stray, "x");
+    const id = encodeId(stray);
+    const res = await PUT(makeRequest(id, "PUT", { content: "new", mtimeMs: 0 }), paramsFor(id));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("PATH_NOT_ALLOWED");
+  });
+
+  it("accepts user CLAUDE.md", async () => {
+    await stubScan([]);
+    const userPath = path.join(tmpHome, ".claude", "CLAUDE.md");
+    await fs.writeFile(userPath, "old\n");
+    const stat = await fs.stat(userPath);
+    const { PUT } = await reload();
+    const id = encodeId(userPath);
+    const res = await PUT(
+      makeRequest(id, "PUT", { content: "new\n", mtimeMs: stat.mtimeMs }),
+      paramsFor(id),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.mtimeMs).toBe("number");
+    const after = await fs.readFile(userPath, "utf-8");
+    expect(after).toBe("new\n");
+  });
+});
+
+describe("PUT /api/memory/by-id/[id] — validation", () => {
+  it("returns 413 when content exceeds 2 MB", async () => {
+    const userPath = path.join(tmpHome, ".claude", "CLAUDE.md");
+    await fs.writeFile(userPath, "x");
+    await stubScan([]);
+    const { PUT } = await reload();
+    const id = encodeId(userPath);
+    const huge = "a".repeat(2 * 1024 * 1024 + 1);
+    const stat = await fs.stat(userPath);
+    const res = await PUT(
+      makeRequest(id, "PUT", { content: huge, mtimeMs: stat.mtimeMs }),
+      paramsFor(id),
+    );
+    expect(res.status).toBe(413);
+    expect((await res.json()).error.code).toBe("TOO_LARGE");
+  });
+
+  it("returns 400 INVALID_BODY when mtimeMs is missing", async () => {
+    const userPath = path.join(tmpHome, ".claude", "CLAUDE.md");
+    await fs.writeFile(userPath, "x");
+    await stubScan([]);
+    const { PUT } = await reload();
+    const id = encodeId(userPath);
+    const res = await PUT(makeRequest(id, "PUT", { content: "new" }), paramsFor(id));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe("INVALID_BODY");
+  });
+
+  it("returns 400 INVALID_ID for an undecodable id", async () => {
+    await stubScan([]);
+    const { PUT } = await reload();
+    const id = "not%a%valid%id%@@@";
+    const res = await PUT(
+      makeRequest(id, "PUT", { content: "x", mtimeMs: 0 }),
+      paramsFor(id),
+    );
+    // Accept either 400 INVALID_ID (decode succeeded but produced garbage that
+    // fails allowlist) or PATH_NOT_ALLOWED — both are correct rejections.
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(["INVALID_ID", "PATH_NOT_ALLOWED"]).toContain(body.error.code);
+  });
+});
+
+describe("PUT /api/memory/by-id/[id] — mtime conflict", () => {
+  it("returns 409 when caller's mtimeMs doesn't match current", async () => {
+    const userPath = path.join(tmpHome, ".claude", "CLAUDE.md");
+    await fs.writeFile(userPath, "old");
+    await stubScan([]);
+    const { PUT } = await reload();
+    const id = encodeId(userPath);
+    const res = await PUT(
+      makeRequest(id, "PUT", { content: "new", mtimeMs: 12345 }),
+      paramsFor(id),
+    );
+    expect(res.status).toBe(409);
+    expect((await res.json()).error.code).toBe("MTIME_CONFLICT");
+  });
+});
+
+describe("PUT /api/memory/by-id/[id] — auto tier", () => {
+  it("accepts an auto-memory file path inside a project's memory dir", async () => {
+    const proj = path.join(tmpHome, "projA");
+    await fs.mkdir(proj);
+    const { encodePath } = await import("@/lib/scanner/claudeConversations");
+    const memDir = path.join(tmpHome, ".claude", "projects", encodePath(proj), "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    const file = path.join(memDir, "user_role.md");
+    await fs.writeFile(file, "old");
+    const stat = await fs.stat(file);
+    await stubScan([mkProject("projA", proj)]);
+    const { PUT } = await reload();
+    const id = encodeId(file);
+    const res = await PUT(
+      makeRequest(id, "PUT", { content: "new content", mtimeMs: stat.mtimeMs }),
+      paramsFor(id),
+    );
+    expect(res.status).toBe(200);
+    expect(await fs.readFile(file, "utf-8")).toBe("new content");
+  });
+});

--- a/tests/memoryDiscovery.test.ts
+++ b/tests/memoryDiscovery.test.ts
@@ -169,18 +169,27 @@ describe("listMemoryFiles — preview + sorting", () => {
 });
 
 describe("encodeMemoryId / decodeMemoryId", () => {
-  it("round-trips absolute paths through base64url", async () => {
+  it("round-trips POSIX absolute paths through base64url", async () => {
     await reloadModule();
     const { encodeMemoryId, decodeMemoryId } = await import("@/lib/memory/safety");
-    const inputs = [
-      "C:\\dev\\project-minder\\CLAUDE.md",
-      "/Users/joshu/.claude/CLAUDE.md",
-      "/tmp/spaces in path/file.md",
-    ];
+    const inputs = ["/Users/joshu/.claude/CLAUDE.md", "/tmp/spaces in path/file.md"];
     for (const p of inputs) {
       expect(decodeMemoryId(encodeMemoryId(p))).toBe(p);
     }
   });
+
+  // path.isAbsolute is platform-aware: Windows-style paths only count as
+  // absolute on win32. Skip on POSIX CI to keep the round-trip semantic
+  // honest rather than swallowing the platform difference.
+  it.skipIf(process.platform !== "win32")(
+    "round-trips Windows absolute paths through base64url",
+    async () => {
+      await reloadModule();
+      const { encodeMemoryId, decodeMemoryId } = await import("@/lib/memory/safety");
+      const p = "C:\\dev\\project-minder\\CLAUDE.md";
+      expect(decodeMemoryId(encodeMemoryId(p))).toBe(p);
+    },
+  );
 
   it("rejects malformed ids", async () => {
     await reloadModule();

--- a/tests/memoryDiscovery.test.ts
+++ b/tests/memoryDiscovery.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import type { ProjectData } from "@/lib/types";
+
+// `listMemoryFiles` discovery + stale heuristic. Uses a real tmpdir because
+// the broken-import detection delegates to `expandImports`, which itself
+// reads files; mocking `fs` would force us to mirror that contract here and
+// silently drift. The tmpdir is small (a handful of CLAUDE.md files) so the
+// test stays fast.
+
+let tmpHome: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+
+async function reloadModule() {
+  vi.resetModules();
+  delete (globalThis as { __memoryInventoryCache?: unknown }).__memoryInventoryCache;
+  delete (globalThis as { __memoryImportCache?: unknown }).__memoryImportCache;
+  vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+  return await import("@/lib/memory");
+}
+
+function project(slug: string, projectPath: string): ProjectData {
+  return {
+    slug,
+    name: slug,
+    path: projectPath,
+    status: "active",
+    dependencies: [],
+    dockerPorts: [],
+    externalServices: [],
+    scannedAt: new Date().toISOString(),
+  };
+}
+
+beforeEach(async () => {
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "minder-mem-"));
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  await fs.mkdir(path.join(tmpHome, ".claude"), { recursive: true });
+  await fs.mkdir(path.join(tmpHome, ".claude", "projects"), { recursive: true });
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = originalUserProfile;
+  vi.restoreAllMocks();
+  try {
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe("listMemoryFiles — discovery", () => {
+  it("includes user CLAUDE.md when present", async () => {
+    await fs.writeFile(path.join(tmpHome, ".claude", "CLAUDE.md"), "# user\n");
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [] });
+    expect(entries.filter((e) => e.scope === "user")).toHaveLength(1);
+    expect(entries[0].displayName).toBe("User CLAUDE.md");
+  });
+
+  it("skips user scope when ~/.claude/CLAUDE.md is missing", async () => {
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [] });
+    expect(entries.filter((e) => e.scope === "user")).toHaveLength(0);
+  });
+
+  it("includes one project entry per scanned project that has a CLAUDE.md", async () => {
+    const a = path.join(tmpHome, "projA");
+    const b = path.join(tmpHome, "projB");
+    await fs.mkdir(a); await fs.mkdir(b);
+    await fs.writeFile(path.join(a, "CLAUDE.md"), "# A\n");
+    // B has no CLAUDE.md
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [project("a", a), project("b", b)] });
+    const proj = entries.filter((e) => e.scope === "project");
+    expect(proj).toHaveLength(1);
+    expect(proj[0].projectSlug).toBe("a");
+  });
+
+  it("includes auto-memory .md files and skips non-md or dotfiles", async () => {
+    const a = path.join(tmpHome, "projA");
+    await fs.mkdir(a);
+    // Match the encodePath shape: `C:\dev\projA` → `c--dev-projA`-style; we
+    // use the actual encoder by importing memoryWriter through the module.
+    const { encodePath } = await import("@/lib/scanner/claudeConversations");
+    const memDir = path.join(tmpHome, ".claude", "projects", encodePath(a), "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "user_role.md"), "user info");
+    await fs.writeFile(path.join(memDir, "feedback.md"), "feedback info");
+    await fs.writeFile(path.join(memDir, "ignored.json"), "{}");
+    await fs.writeFile(path.join(memDir, ".hidden.md"), "hidden");
+
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [project("a", a)] });
+    const auto = entries.filter((e) => e.scope === "auto");
+    expect(auto.map((e) => e.displayName).sort()).toEqual(["feedback.md", "user_role.md"]);
+    for (const e of auto) expect(e.projectSlug).toBe("a");
+  });
+});
+
+describe("listMemoryFiles — staleness", () => {
+  it("flags files mtime > 30d as ageOver30d", async () => {
+    const userMd = path.join(tmpHome, ".claude", "CLAUDE.md");
+    await fs.writeFile(userMd, "# old\n");
+    const old = (Date.now() - 31 * 24 * 60 * 60_000) / 1000;
+    await fs.utimes(userMd, old, old);
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [] });
+    expect(entries[0].stale.ageOver30d).toBe(true);
+  });
+
+  it("reports broken @import refs", async () => {
+    const a = path.join(tmpHome, "projA");
+    await fs.mkdir(a);
+    await fs.writeFile(
+      path.join(a, "CLAUDE.md"),
+      "# project\n\n@import ./missing-target.md\n",
+    );
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [project("a", a)] });
+    const proj = entries.find((e) => e.scope === "project");
+    expect(proj?.stale.brokenImports).toEqual(["./missing-target.md"]);
+  });
+
+  it("does not flag working @import refs", async () => {
+    const a = path.join(tmpHome, "projA");
+    await fs.mkdir(a);
+    await fs.writeFile(path.join(a, "rules.md"), "# rules\n");
+    await fs.writeFile(
+      path.join(a, "CLAUDE.md"),
+      "# project\n\n@import ./rules.md\n",
+    );
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [project("a", a)] });
+    const proj = entries.find((e) => e.scope === "project");
+    expect(proj?.stale.brokenImports).toEqual([]);
+  });
+});
+
+describe("listMemoryFiles — preview + sorting", () => {
+  it("strips frontmatter from preview", async () => {
+    await fs.writeFile(
+      path.join(tmpHome, ".claude", "CLAUDE.md"),
+      "---\nname: x\n---\nThe real content starts here.\n",
+    );
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [] });
+    expect(entries[0].preview).toMatch(/^The real content/);
+  });
+
+  it("sorts user → project → auto", async () => {
+    const a = path.join(tmpHome, "projA");
+    await fs.mkdir(a);
+    await fs.writeFile(path.join(tmpHome, ".claude", "CLAUDE.md"), "u");
+    await fs.writeFile(path.join(a, "CLAUDE.md"), "p");
+    const { encodePath } = await import("@/lib/scanner/claudeConversations");
+    const memDir = path.join(tmpHome, ".claude", "projects", encodePath(a), "memory");
+    await fs.mkdir(memDir, { recursive: true });
+    await fs.writeFile(path.join(memDir, "x.md"), "auto");
+    const { listMemoryFiles } = await reloadModule();
+    const entries = await listMemoryFiles({ projects: [project("a", a)] });
+    expect(entries.map((e) => e.scope)).toEqual(["user", "project", "auto"]);
+  });
+});
+
+describe("encodeMemoryId / decodeMemoryId", () => {
+  it("round-trips absolute paths through base64url", async () => {
+    await reloadModule();
+    const { encodeMemoryId, decodeMemoryId } = await import("@/lib/memory/safety");
+    const inputs = [
+      "C:\\dev\\project-minder\\CLAUDE.md",
+      "/Users/joshu/.claude/CLAUDE.md",
+      "/tmp/spaces in path/file.md",
+    ];
+    for (const p of inputs) {
+      expect(decodeMemoryId(encodeMemoryId(p))).toBe(p);
+    }
+  });
+
+  it("rejects malformed ids", async () => {
+    await reloadModule();
+    const { decodeMemoryId } = await import("@/lib/memory/safety");
+    const id = Buffer.from("foo\0bar", "utf-8").toString("base64url");
+    expect(decodeMemoryId(id)).toBeNull();
+  });
+
+  it("rejects relative paths even when base64url decodes cleanly", async () => {
+    await reloadModule();
+    const { decodeMemoryId } = await import("@/lib/memory/safety");
+    const id = Buffer.from("relative/path.md", "utf-8").toString("base64url");
+    expect(decodeMemoryId(id)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the ComingSoon stub at `/memory` with a real cross-tier inventory + inline editor unifying three scopes:
- **User** — `~/.claude/CLAUDE.md`
- **Project** — `<project>/CLAUDE.md` for every scanned project
- **Auto** — `~/.claude/projects/<encoded>/memory/*.md`

Per-project auto-memory is still served by the existing `/api/memory/[slug]` route used by `MemoryTab`; this phase adds a portfolio-wide browser without disturbing it.

## Changes

**New endpoints**

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/memory` | cross-tier list |
| GET | `/api/memory/by-id/[id]` | content + mtimeMs (allowlist-gated) |
| PUT | `/api/memory/by-id/[id]` | 2 MB cap, 409 on mtime drift, configHistory snapshot, atomic write |
| GET | `/api/memory/by-id/[id]/snapshot` | latest configHistory snapshot for the diff view |

Routing nests under `by-id/` so the existing `[slug]` per-project sibling stays untouched (Next.js dynamic params at the same directory level can only have one name).

**Path-safety allowlist** (`src/lib/memory/safety.ts`)
- `decodeMemoryId` rejects non-absolute paths and embedded nulls
- `classifyMemoryPath` returns scope info only when the resolved path is exactly user CLAUDE.md, a scanned-project CLAUDE.md, or an `*.md` directly inside an auto-memory dir
- PUT returns 400 PATH_NOT_ALLOWED before any snapshot or write

**Discovery** (`src/lib/memory/index.ts`)
- Stat first → skip directories → read first 8 KB only (preview + import detection)
- Per-`(absPath, mtimeMs)` cache for broken-import detection so repeat refreshes don't re-walk import trees
- Inventory + import caches on `globalThis` to survive Next.js HMR (matches `src/lib/cache.ts` pattern)
- Broken-import detection delegates to `expandImports` from the audit pipeline so staleness semantics agree with `ClaudeMdAuditPanel`

**UI** (`src/components/MemoryBrowser.tsx`, `MemoryEditor.tsx`)
- Left rail grouped by scope with search, scope chips, stale filter
- View → Edit → Save flow with inline error + 409 \"Reload\" banner
- Diff toggle reuses `lineDiff` from `src/lib/usage/diff.ts` (LCS with `maxLines` guard); `useMemo`-wrapped so re-renders don't re-run the algorithm
- AbortController on all client fetches

**Help docs**
- `docs/help/memory.md` extended with cross-tier section, mirrored to `public/help/`
- `/memory` mapped in `src/lib/help-mapping.ts`
- `comingSoon` flag dropped from the AppSidebar `/memory` row

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 1941 passed | 1 skipped (was 1922 before Phase 2; +19)
- [x] `npm run build` — clean; all four memory routes built
- [x] Manual: edit user CLAUDE.md via `/memory`, reload, see new content; verify config-history snapshot recorded
- [x] Manual: PUT a fabricated id outside allowlist → 400 PATH_NOT_ALLOWED
- [x] Manual: PUT with stale mtimeMs → 409 + Reload banner

**Test coverage** (19 new tests):
- Discovery: user / project / auto tier discovery, missing user file, mixed projects with/without CLAUDE.md, dotfile + non-md exclusion
- Staleness: age > 30d, broken `@import`, working `@import`
- Preview: frontmatter strip, scope sort
- Codec: base64url round-trip, null-byte rejection, relative-path rejection
- Route: PATH_NOT_ALLOWED 400, user CLAUDE.md round-trip, 413 TOO_LARGE, 400 INVALID_BODY, 400 INVALID_ID, 409 MTIME_CONFLICT, auto-tier round-trip

## Reference plan

Phase 2 of `~/.claude/plans/reference-plan-claude-plans-our-to-do-li-polymorphic-wreath.md`. Verification note appended to the plan with this commit's pass counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)