### PR TITLE
fix(agent-view): drop stale end_turn sessions from Needs Input column

### DIFF
--- a/src/lib/scanner/liveSessionStatus.ts
+++ b/src/lib/scanner/liveSessionStatus.ts
@@ -54,7 +54,13 @@ export function inferLiveSessionStatus(
   const ageMs = Date.now() - mtime.getTime();
 
   if (pendingIds.size === 0) {
-    if (stopReason === "end_turn") return { status: "waiting", lastToolName };
+    if (stopReason === "end_turn") {
+      // Session ended cleanly waiting for the user. After STALE_MS with no new
+      // user turn, treat as "other" so the aggregate drops it as a stale-idle
+      // entry instead of pinning it to "Needs Input" for 3 hours.
+      if (ageMs > STALE_MS) return { status: "other", lastToolName };
+      return { status: "waiting", lastToolName };
+    }
     // stop_reason was tool_use but results all returned — Claude is computing next response
     if (ageMs < WORKING_MS) return { status: "working", lastToolName };
     return { status: "other", lastToolName };

--- a/tests/liveSessionStatus.test.ts
+++ b/tests/liveSessionStatus.test.ts
@@ -139,6 +139,17 @@ describe("inferLiveSessionStatus", () => {
     ).toBe("working");
   });
 
+  it("returns other for stale end_turn sessions (> 10 min) — phantom-session fix", () => {
+    const entries = [assistantEntry({ stopReason: "end_turn" })];
+    // 11 minutes old — past STALE_MS, should not pin to "Needs Input"
+    expect(inferLiveSessionStatus(entries, makeMtime(11 * 60_000), undefined).status).toBe("other");
+  });
+
+  it("still returns waiting for end_turn sessions within the 10-min window", () => {
+    const entries = [assistantEntry({ stopReason: "end_turn" })];
+    expect(inferLiveSessionStatus(entries, makeMtime(5 * 60_000), undefined).status).toBe("waiting");
+  });
+
   it("ignores sidechain entries when finding last assistant turn", () => {
     const entries: ConversationEntry[] = [
       assistantEntry({ stopReason: "end_turn" }),


### PR DESCRIPTION
## Problem

Sessions that ended cleanly with `stop_reason=end_turn` (Claude gave a final response and was waiting for the next user message) were pinned to the **Needs Input** column indefinitely — up to the 180-minute abandon threshold. When a user started a new Claude Code session on the same project, the old session's card stayed visible alongside the new one.

Confirmed via `22b0f49a.jsonl`: previous project-minder session, last assistant turn has `stop_reason=end_turn`, file written 21 minutes before the screenshot was taken, but it still showed as a live "Needs Input" card.

## Root cause

`inferLiveSessionStatus` returns `{ status: "waiting" }` for `end_turn` unconditionally — no age check. The stale-idle filter in `aggregate.ts` (`secondsSinceChange > 300`) only applies to sessions already classified as `"idle"` (mapped from `"other"`). Sessions classified as `"waiting"` bypass that filter entirely.

## Fix

Apply the existing `STALE_MS = 10min` threshold to `end_turn` sessions too. After 10 minutes with no user response the session returns `"other"` instead of `"waiting"`, which `aggregate.ts` drops as stale-idle after a further 5 minutes:

- **Total phantom lifespan**: ~15 min (down from ~180 min)
- **Active sessions unaffected**: a user who responds within 10 min still sees their session correctly; the card reappears immediately when the JSONL file updates
- **No change to hook-confirmed or daemon-roster sessions**: fix only applies to the pure-JSONL fallback path

## Test plan

- [ ] `npm run typecheck` ✅ · `npm test` ✅ (2295 passing, 207 files, 0 failures)
- [ ] Two new regression tests added: stale end_turn → "other", fresh end_turn → "waiting"
- [ ] Start a Claude Code session, let it end cleanly, start a new one — confirm old card disappears within ~15 min rather than persisting for 3 hours

🤖 Generated with [Claude Code](https://claude.ai/claude-code)