### PR TITLE
chore: add .mcp.json.example for project-minder MCP server

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "project-minder": {
+      "type": "http",
+      "url": "http://localhost:4100/api/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The real `.mcp.json` is gitignored — it's per-developer config and may contain credentials (the existing local copy in this repo has a postgresql block with placeholder creds, for instance). This commit adds a `.mcp.json.example` template that **is** tracked, so a fresh clone has a copy-pasteable starting point to wire Claude Code to the local Project Minder MCP endpoint.

Block matches the example in the README and `docs/help/mcp-server.md` — single source of truth, just available as a file users can `cp .mcp.json.example .mcp.json` from.

## Test plan
- [x] Pre-commit hook: `npm run typecheck` (0 errors) + `npm test` (2352 pass)
- [x] Confirmed `.mcp.json` pattern in `.gitignore:40` does not match `.mcp.json.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)