### PR TITLE
feat(claude-status): surface status.claude.com incidents in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Claude status alerts.** Project Minder now polls `status.claude.com/api/v2/summary.json` and surfaces active Claude incidents in a sticky banner below the topbar on every route, plus toast notifications when an incident appears, transitions status, or resolves. Gated behind a new `claudeStatusAlerts` feature flag (default-on). New library at `src/lib/claudeStatus/` (types, parser, diff, cache singleton) mirrors the file-cache + promise-singleton pattern from `costCalculator.ts` and the change-feed pattern from `manualStepsWatcher.ts`. New REST endpoints `GET /api/claude-status` and `GET /api/claude-status/changes?since=ISO8601`. New `<ClaudeStatusBanner />` in `AppShell.tsx` and `<ClaudeStatusListener />` in `layout.tsx`. New MCP tool `get-claude-status` (read-only, openWorld) so a connected Claude agent can self-diagnose whether an API error is upstream. Disk cache at `.cache/claude-status.json`; 30s memory TTL; backoff on consecutive failures up to 8 minutes. 33 new tests across `tests/claudeStatusParser.test.ts`, `tests/claudeStatusChanges.test.ts`, `tests/claudeStatusCache.test.ts` with four fixture payloads. Documented in `docs/help/claude-status.md`.
+
 ### Changed
 - **Settings page** — "W7" / "W8" / "W10" developer-only wave badges replaced with "Soon" labels; placeholder sections now say "Coming soon." instead of "Coming in wave N."
 - **Schedule page** — removed developer-only wave version reference from the coming-soon blurb.

--- a/docs/help/claude-status.md
+++ b/docs/help/claude-status.md
@@ -1,0 +1,50 @@
+# Claude Status Alerts
+
+Project Minder polls [status.claude.com](https://status.claude.com) and surfaces active Claude incidents inside the dashboard so you know whether an API failure you're debugging is local or upstream.
+
+## Where It Appears
+
+- **Sticky banner** — A colored banner appears below the topbar on every route whenever any Claude service is in `degraded_performance`, `partial_outage`, or `major_outage`, or whenever an active incident exists on the public status page. The banner stays visible until the underlying state clears.
+- **Toast notifications** — When a new incident appears, when an incident's status changes (e.g. `investigating` → `monitoring`), or when an incident resolves, you get a short toast.
+
+## Banner Colors
+
+| Color | Meaning |
+|---|---|
+| **Amber** (`degraded`) | One or more components are reporting `degraded_performance`, **or** there's an active incident with `minor` impact |
+| **Red** (`incident`) | An active incident has `critical` impact, **or** any component is in `major_outage` |
+| (hidden) | All components operational and no active incidents |
+
+Click "View incident" on the banner to open the incident page on status.claude.com in a new tab.
+
+## How It Works
+
+Project Minder calls Statuspage's public JSON summary API every 60 seconds while the dashboard is open. There's no background polling when no browser tab is open — the server-side cache is request-driven.
+
+- **Source URL**: `https://status.claude.com/api/v2/summary.json` (no auth, no rate limits, CORS-enabled)
+- **Cache**: `process.cwd()/.cache/claude-status.json` (30-second memory TTL, 30-minute stale tolerance)
+- **Failure mode**: If the upstream fetch fails, the banner keeps showing the last good snapshot with a subtle "Last checked Xm ago" footnote and retries with exponential backoff (60s → 8m cap).
+
+## Disabling the Feature
+
+Settings → Active Features → **Claude status alerts** toggles the entire feature. With the flag off:
+
+- `/api/claude-status` returns `{"disabled": true}`.
+- The banner is hidden everywhere.
+- No upstream polling happens.
+- The MCP tool `get-claude-status` returns `{"disabled": true}` to MCP clients.
+
+## MCP Access
+
+A Claude agent connected to the Project Minder MCP server can call `get-claude-status` to self-diagnose whether an API issue is upstream:
+
+```
+mcp__project-minder__get-claude-status
+  inputs: { includeOperationalComponents?: boolean }
+```
+
+Returns the same snapshot the banner reads from, plus a `source` field (`live` / `disk-cache` / `stale` / `empty`) so the agent knows how fresh the data is.
+
+## Privacy
+
+Only outbound calls go to `status.claude.com`. No telemetry about your usage is sent. The disk cache contains nothing but the raw Statuspage payload.

--- a/public/help/claude-status.md
+++ b/public/help/claude-status.md
@@ -1,0 +1,50 @@
+# Claude Status Alerts
+
+Project Minder polls [status.claude.com](https://status.claude.com) and surfaces active Claude incidents inside the dashboard so you know whether an API failure you're debugging is local or upstream.
+
+## Where It Appears
+
+- **Sticky banner** — A colored banner appears below the topbar on every route whenever any Claude service is in `degraded_performance`, `partial_outage`, or `major_outage`, or whenever an active incident exists on the public status page. The banner stays visible until the underlying state clears.
+- **Toast notifications** — When a new incident appears, when an incident's status changes (e.g. `investigating` → `monitoring`), or when an incident resolves, you get a short toast.
+
+## Banner Colors
+
+| Color | Meaning |
+|---|---|
+| **Amber** (`degraded`) | One or more components are reporting `degraded_performance`, **or** there's an active incident with `minor` impact |
+| **Red** (`incident`) | An active incident has `critical` impact, **or** any component is in `major_outage` |
+| (hidden) | All components operational and no active incidents |
+
+Click "View incident" on the banner to open the incident page on status.claude.com in a new tab.
+
+## How It Works
+
+Project Minder calls Statuspage's public JSON summary API every 60 seconds while the dashboard is open. There's no background polling when no browser tab is open — the server-side cache is request-driven.
+
+- **Source URL**: `https://status.claude.com/api/v2/summary.json` (no auth, no rate limits, CORS-enabled)
+- **Cache**: `process.cwd()/.cache/claude-status.json` (30-second memory TTL, 30-minute stale tolerance)
+- **Failure mode**: If the upstream fetch fails, the banner keeps showing the last good snapshot with a subtle "Last checked Xm ago" footnote and retries with exponential backoff (60s → 8m cap).
+
+## Disabling the Feature
+
+Settings → Active Features → **Claude status alerts** toggles the entire feature. With the flag off:
+
+- `/api/claude-status` returns `{"disabled": true}`.
+- The banner is hidden everywhere.
+- No upstream polling happens.
+- The MCP tool `get-claude-status` returns `{"disabled": true}` to MCP clients.
+
+## MCP Access
+
+A Claude agent connected to the Project Minder MCP server can call `get-claude-status` to self-diagnose whether an API issue is upstream:
+
+```
+mcp__project-minder__get-claude-status
+  inputs: { includeOperationalComponents?: boolean }
+```
+
+Returns the same snapshot the banner reads from, plus a `source` field (`live` / `disk-cache` / `stale` / `empty`) so the agent knows how fresh the data is.
+
+## Privacy
+
+Only outbound calls go to `status.claude.com`. No telemetry about your usage is sent. The disk cache contains nothing but the raw Statuspage payload.

--- a/src/app/api/claude-status/changes/route.ts
+++ b/src/app/api/claude-status/changes/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { readConfig } from "@/lib/config";
+import { getFlag } from "@/lib/featureFlags";
+import { getChanges, getCurrentStatus } from "@/lib/claudeStatus/cache";
+
+export async function GET(request: NextRequest) {
+  const since = request.nextUrl.searchParams.get("since");
+  if (!since) {
+    return NextResponse.json({ error: "since parameter required" }, { status: 400 });
+  }
+  const config = await readConfig();
+  if (!getFlag(config.featureFlags, "claudeStatusAlerts")) {
+    return NextResponse.json([]);
+  }
+  // Ensure the singleton has at least once snapshot so a poll arriving
+  // before the first fetch doesn't return an empty diff window forever.
+  await getCurrentStatus();
+  return NextResponse.json(getChanges(since));
+}

--- a/src/app/api/claude-status/route.ts
+++ b/src/app/api/claude-status/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { readConfig } from "@/lib/config";
+import { getFlag } from "@/lib/featureFlags";
+import { getCurrentStatus } from "@/lib/claudeStatus/cache";
+
+export async function GET() {
+  const config = await readConfig();
+  if (!getFlag(config.featureFlags, "claudeStatusAlerts")) {
+    return NextResponse.json({ disabled: true });
+  }
+  const snapshot = await getCurrentStatus();
+  return NextResponse.json(snapshot);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { HelpProvider } from "@/components/HelpProvider";
 import { HelpPanel } from "@/components/HelpPanel";
 import { ToastProvider } from "@/components/ToastProvider";
 import { NotificationListener } from "@/components/NotificationListener";
+import { ClaudeStatusListener } from "@/components/ClaudeStatusListener";
 import { PulseProvider } from "@/components/PulseProvider";
 import { EmergencyStopButton } from "@/components/EmergencyStopButton";
 import { readConfig, getDevRoots } from "@/lib/config";
@@ -80,6 +81,7 @@ export default async function RootLayout({
 
                   <HelpPanel />
                   <NotificationListener />
+                  <ClaudeStatusListener />
                 </HelpProvider>
               </CommandPaletteProvider>
             </PulseProvider>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { AppSidebar } from "./AppSidebar";
 import { AppTopbar } from "./AppTopbar";
+import { ClaudeStatusBanner } from "./ClaudeStatusBanner";
 import { ProjectScopeMenu } from "./ProjectScopeMenu";
 import { useScope } from "./ScopeProvider";
 import type { ProjectData } from "@/lib/types";
@@ -98,6 +99,7 @@ export function AppShell({ children, devRootLabel }: AppShellProps) {
           onOpenScopePicker={() => setScopeOpen(true)}
           devRootLabel={devRootLabel}
         />
+        <ClaudeStatusBanner />
         {children}
       </div>
       <ProjectScopeMenu open={scopeOpen} onClose={() => setScopeOpen(false)} projects={projects} />

--- a/src/components/ClaudeStatusBanner.tsx
+++ b/src/components/ClaudeStatusBanner.tsx
@@ -6,7 +6,8 @@
  *
  * Renders nothing when:
  *   - The feature flag is off (server replies `{disabled: true}`)
- *   - Overall status is `operational` with a fresh `live` source
+ *   - Overall status is `operational` (regardless of source — once we know
+ *     things are fine, the banner is hidden even if the snapshot is stale)
  *   - The first poll hasn't completed within the initial 600ms suppress window
  *
  * Polls `/api/claude-status` every 60s. State only updates on successful

--- a/src/components/ClaudeStatusBanner.tsx
+++ b/src/components/ClaudeStatusBanner.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * ClaudeStatusBanner — sticky cross-route banner that surfaces active
+ * incidents from status.claude.com.
+ *
+ * Renders nothing when:
+ *   - The feature flag is off (server replies `{disabled: true}`)
+ *   - Overall status is `operational` with a fresh `live` source
+ *   - The first poll hasn't completed within the initial 600ms suppress window
+ *
+ * Polls `/api/claude-status` every 60s. State only updates on successful
+ * fetches — a transient network blip leaves the last good banner in place.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import type { ClaudeStatusSnapshot, OverallStatus } from "@/lib/claudeStatus/types";
+
+const POLL_INTERVAL_MS = 60_000;
+const SUPPRESS_FIRST_RENDER_MS = 600;
+
+type ApiResponse = ClaudeStatusSnapshot | { disabled: true };
+
+function isDisabled(r: ApiResponse): r is { disabled: true } {
+  return (r as { disabled?: boolean }).disabled === true;
+}
+
+function bannerTone(overall: OverallStatus): "warn" | "danger" | null {
+  if (overall === "incident") return "danger";
+  if (overall === "degraded") return "warn";
+  return null;
+}
+
+function ageLabel(fetchedAt: number): string {
+  if (!fetchedAt) return "never";
+  const seconds = Math.max(0, Math.floor((Date.now() - fetchedAt) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}
+
+export function ClaudeStatusBanner() {
+  const [snapshot, setSnapshot] = useState<ClaudeStatusSnapshot | null>(null);
+  const [disabled, setDisabled] = useState(false);
+  const [allowRender, setAllowRender] = useState(false);
+
+  // Suppress any UI for the first 600ms so the banner doesn't flash on
+  // every page nav before the poll resolves.
+  useEffect(() => {
+    const t = setTimeout(() => setAllowRender(true), SUPPRESS_FIRST_RENDER_MS);
+    return () => clearTimeout(t);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const ctrl = new AbortController();
+
+    async function pull() {
+      try {
+        const res = await fetch("/api/claude-status", { signal: ctrl.signal });
+        if (!res.ok) return;
+        const data = (await res.json()) as ApiResponse;
+        if (cancelled) return;
+        if (isDisabled(data)) {
+          setDisabled(true);
+          setSnapshot(null);
+          return;
+        }
+        setDisabled(false);
+        setSnapshot(data);
+      } catch {
+        // Keep the last good snapshot; transient errors shouldn't unmount the banner.
+      }
+    }
+
+    pull();
+    const id = setInterval(pull, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      ctrl.abort();
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!allowRender || disabled || !snapshot) return null;
+  const tone = bannerTone(snapshot.overall);
+  if (!tone) return null;
+
+  const isStale = snapshot.source === "stale";
+  const color = tone === "danger" ? "var(--danger)" : "var(--warn)";
+
+  const incident = snapshot.incidents[0];
+  const degradedComponents = snapshot.components.filter((c) => c.status !== "operational");
+
+  // Headline + detail line are derived once so server logic stays out
+  // of the JSX tree.
+  const headline = incident
+    ? `Claude incident: ${incident.name}`
+    : degradedComponents.length === 1
+    ? `${degradedComponents[0].name}: ${degradedComponents[0].status.replace(/_/g, " ")}`
+    : `${degradedComponents.length} Claude services degraded`;
+
+  const detail = incident?.latestUpdateBody
+    ?? (degradedComponents.length > 1
+      ? degradedComponents.map((c) => c.name).join(", ")
+      : null);
+
+  const linkHref = incident?.shortlink ?? snapshot.page.url;
+  const linkLabel = incident ? "View incident" : "Status page";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-claude-status={tone}
+      style={{
+        margin: "8px 14px 0",
+        padding: "8px 12px",
+        borderRadius: 8,
+        borderWidth: 1,
+        borderStyle: "solid",
+        borderColor: `color-mix(in oklch, ${color} 55%, transparent)`,
+        background: `linear-gradient(90deg, color-mix(in oklch, ${color} 12%, transparent), transparent 65%)`,
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        fontSize: 12,
+      }}
+    >
+      <div
+        style={{
+          width: 24,
+          height: 24,
+          borderRadius: 6,
+          background: `color-mix(in oklch, ${color} 22%, transparent)`,
+          color,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <AlertTriangle width={14} height={14} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontWeight: 600 }}>{headline}</div>
+        {detail && (
+          <div
+            style={{
+              color: "var(--text-3)",
+              marginTop: 2,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {detail}
+          </div>
+        )}
+      </div>
+      {isStale && (
+        <span style={{ color: "var(--text-4)", fontSize: 11, whiteSpace: "nowrap" }}>
+          Last checked {ageLabel(snapshot.fetchedAt)}
+        </span>
+      )}
+      <Link
+        href={linkHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          color: "var(--text-2)",
+          textDecoration: "none",
+          padding: "4px 10px",
+          borderRadius: 6,
+          borderWidth: 1,
+          borderStyle: "solid",
+          borderColor: "var(--border)",
+          whiteSpace: "nowrap",
+          fontWeight: 500,
+        }}
+      >
+        {linkLabel}
+      </Link>
+    </div>
+  );
+}

--- a/src/components/ClaudeStatusListener.tsx
+++ b/src/components/ClaudeStatusListener.tsx
@@ -36,8 +36,11 @@ function describeTransition(c: ClaudeStatusChange): { title: string; body: strin
 export function ClaudeStatusListener() {
   const { showToast } = useToast();
   const lastCheckedRef = useRef<string>(new Date().toISOString());
-  // Track (incidentId, status) we've already toasted so an overlapping
-  // poll/refresh can't fire a duplicate notification.
+  // Track (incidentId, status, impact, transition) we've already toasted so an
+  // overlapping poll/refresh can't fire a duplicate notification. Including
+  // impact catches severity escalations (e.g. minor→major while status stays
+  // `investigating`); including transition lets a resolve-then-reopen of the
+  // same incident still notify.
   const seenRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -53,19 +56,22 @@ export function ClaudeStatusListener() {
         if (cancelled) return;
         if (!Array.isArray(data)) return;
 
+        let maxChangedAt = lastCheckedRef.current;
         for (const change of data) {
-          const key = `${change.incidentId}:${change.status}`;
-          if (seenRef.current.has(key)) continue;
-          seenRef.current.add(key);
-          const { title, body } = describeTransition(change);
-          showToast(title, body);
+          const key = `${change.incidentId}:${change.status}:${change.impact}:${change.transition}`;
+          if (!seenRef.current.has(key)) {
+            seenRef.current.add(key);
+            const { title, body } = describeTransition(change);
+            showToast(title, body);
+          }
+          if (change.changedAt > maxChangedAt) maxChangedAt = change.changedAt;
         }
-        // Advance the cursor to "just now" so the next poll only fetches
-        // events newer than this call. We deliberately don't use the
-        // server-supplied timestamp on each change because we want a
-        // single monotonic cursor; `getChanges(since)` is filter-only,
-        // so over-fetching is the worst that can happen on clock skew.
-        lastCheckedRef.current = new Date().toISOString();
+        // Advance the cursor to the latest server-stamped `changedAt` we
+        // observed. Falls back to the previous cursor if the response was
+        // empty (preserving since= so the same window is rechecked). This
+        // avoids the "client clock ahead of server" skip where setting
+        // `Date.now()` would jump past unconsumed transitions.
+        lastCheckedRef.current = maxChangedAt;
       } catch {
         // Transient errors are non-fatal — try again next tick.
       }

--- a/src/components/ClaudeStatusListener.tsx
+++ b/src/components/ClaudeStatusListener.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * ClaudeStatusListener — polls `/api/claude-status/changes?since=…` every
+ * 60s and surfaces transitions as toasts.
+ *
+ * Lives alongside `NotificationListener` and uses the same `useToast()`
+ * hook. The cursor (`lastChecked`) advances to the polling timestamp on
+ * each successful pull, mirroring the pattern in `PulseProvider`.
+ *
+ * Renders nothing — purely side-effectful.
+ */
+
+import { useEffect, useRef } from "react";
+import { useToast } from "./ToastProvider";
+import type { ClaudeStatusChange } from "@/lib/claudeStatus/types";
+
+const POLL_INTERVAL_MS = 60_000;
+
+function describeTransition(c: ClaudeStatusChange): { title: string; body: string } {
+  if (c.transition === "new") {
+    return {
+      title: `Claude incident: ${c.name}`,
+      body: `${c.impact.toUpperCase()} impact — ${c.status}`,
+    };
+  }
+  if (c.transition === "resolved") {
+    return { title: `Claude incident resolved`, body: c.name };
+  }
+  return {
+    title: `Claude incident updated`,
+    body: `${c.name} — now ${c.status} (${c.impact} impact)`,
+  };
+}
+
+export function ClaudeStatusListener() {
+  const { showToast } = useToast();
+  const lastCheckedRef = useRef<string>(new Date().toISOString());
+  // Track (incidentId, status) we've already toasted so an overlapping
+  // poll/refresh can't fire a duplicate notification.
+  const seenRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    const ctrl = new AbortController();
+
+    async function pull() {
+      try {
+        const url = `/api/claude-status/changes?since=${encodeURIComponent(lastCheckedRef.current)}`;
+        const res = await fetch(url, { signal: ctrl.signal });
+        if (!res.ok) return;
+        const data = (await res.json()) as ClaudeStatusChange[] | { error?: string };
+        if (cancelled) return;
+        if (!Array.isArray(data)) return;
+
+        for (const change of data) {
+          const key = `${change.incidentId}:${change.status}`;
+          if (seenRef.current.has(key)) continue;
+          seenRef.current.add(key);
+          const { title, body } = describeTransition(change);
+          showToast(title, body);
+        }
+        // Advance the cursor to "just now" so the next poll only fetches
+        // events newer than this call. We deliberately don't use the
+        // server-supplied timestamp on each change because we want a
+        // single monotonic cursor; `getChanges(since)` is filter-only,
+        // so over-fetching is the worst that can happen on clock skew.
+        lastCheckedRef.current = new Date().toISOString();
+      } catch {
+        // Transient errors are non-fatal — try again next tick.
+      }
+    }
+
+    pull();
+    const id = setInterval(pull, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      ctrl.abort();
+      clearInterval(id);
+    };
+  }, [showToast]);
+
+  return null;
+}

--- a/src/lib/claudeStatus/cache.ts
+++ b/src/lib/claudeStatus/cache.ts
@@ -1,0 +1,234 @@
+/**
+ * Cache singleton for the Claude Status snapshot.
+ *
+ * Pattern combines two existing in-repo idioms:
+ *   - `src/lib/usage/costCalculator.ts`: file cache + promise singleton +
+ *     fallback to a safe default when fetch fails.
+ *   - `src/lib/manualStepsWatcher.ts`: `globalThis`-pinned instance so
+ *     hot reload in dev doesn't spawn a second copy, plus a 5-minute
+ *     ring buffer of change events exposed via `getChanges(since)`.
+ *
+ * Lifecycle: lazy. `getCurrentStatus()` triggers a fetch only when the
+ * in-memory snapshot is older than `FRESH_TTL_MS`. There is no
+ * `setInterval` loop; the dashboard's own 60s client poll is what kicks
+ * the cycle. This means an idle/unmounted dashboard makes zero network
+ * calls — matching the spirit of `gitStatusCache`'s "enqueued by the
+ * request" model.
+ *
+ * On fetch failure we serve the last good snapshot (memory or disk) and
+ * mark `source: "stale"`. Backoff doubles up to 8 minutes on consecutive
+ * failures so a 4xx/5xx upstream doesn't trigger a hot retry storm.
+ */
+
+import { promises as fs } from "fs";
+import path from "path";
+
+import { parseSummary } from "./parser";
+import { diffIncidents } from "./changes";
+import { emptySnapshot } from "./types";
+import type { ClaudeStatusChange, ClaudeStatusSnapshot } from "./types";
+
+const SUMMARY_URL = "https://status.claude.com/api/v2/summary.json";
+const CACHE_DIR = path.join(process.cwd(), ".cache");
+const CACHE_FILE = path.join(CACHE_DIR, "claude-status.json");
+
+const FRESH_TTL_MS = 30_000;            // memory considered fresh under 30s
+const STALE_MAX_MS = 30 * 60_000;       // serve stale up to 30min after last good
+const FETCH_TIMEOUT_MS = 5_000;         // upstream fetch deadline
+const CHANGE_RETENTION_MS = 30 * 60_000; // 30min ring of change events
+const BACKOFF_BASE_MS = 60_000;
+const BACKOFF_MAX_MS = 8 * 60_000;
+
+interface CacheState {
+  snapshot: ClaudeStatusSnapshot | null;
+  inflight: Promise<ClaudeStatusSnapshot> | null;
+  changes: ClaudeStatusChange[];
+  consecutiveFailures: number;
+  nextRetryAt: number;
+  diskHydrationAttempted: boolean;
+}
+
+function freshState(): CacheState {
+  return {
+    snapshot: null,
+    inflight: null,
+    changes: [],
+    consecutiveFailures: 0,
+    nextRetryAt: 0,
+    diskHydrationAttempted: false,
+  };
+}
+
+// `globalThis` singleton so Next.js dev's HMR doesn't spawn duplicates.
+const g = globalThis as unknown as { __claudeStatusCache?: CacheState };
+function state(): CacheState {
+  if (!g.__claudeStatusCache) g.__claudeStatusCache = freshState();
+  return g.__claudeStatusCache;
+}
+
+function backoffDelay(failures: number): number {
+  if (failures <= 0) return 0;
+  const ms = BACKOFF_BASE_MS * 2 ** (failures - 1);
+  return Math.min(ms, BACKOFF_MAX_MS);
+}
+
+async function readDiskCache(): Promise<ClaudeStatusSnapshot | null> {
+  try {
+    const raw = await fs.readFile(CACHE_FILE, "utf-8");
+    const data = JSON.parse(raw) as unknown;
+    const parsed = parseSummary(data);
+    const stat = await fs.stat(CACHE_FILE).catch(() => null);
+    return {
+      ...parsed,
+      source: "disk-cache",
+      fetchedAt: stat?.mtimeMs ?? Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function writeDiskCache(raw: unknown): Promise<void> {
+  try {
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+    await fs.writeFile(CACHE_FILE, JSON.stringify(raw), "utf-8");
+  } catch {
+    // Non-critical — the in-memory snapshot still works.
+  }
+}
+
+async function fetchSummary(): Promise<{ raw: unknown; parsed: ClaudeStatusSnapshot }> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(SUMMARY_URL, { signal: ctrl.signal });
+    if (!res.ok) throw new Error(`status.claude.com fetch failed: HTTP ${res.status}`);
+    const raw = (await res.json()) as unknown;
+    const parsed = parseSummary(raw);
+    return { raw, parsed };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function pruneChanges(s: CacheState, now: number): void {
+  const cutoff = now - CHANGE_RETENTION_MS;
+  s.changes = s.changes.filter((c) => new Date(c.changedAt).getTime() > cutoff);
+}
+
+async function refreshSnapshot(): Promise<ClaudeStatusSnapshot> {
+  const s = state();
+  const now = Date.now();
+
+  // If we're inside the backoff window, don't even try the network —
+  // just return whatever we have (or empty) marked as stale.
+  if (s.consecutiveFailures > 0 && now < s.nextRetryAt) {
+    if (s.snapshot) return { ...s.snapshot, source: "stale" };
+    const empty = emptySnapshot(`Backoff: skipping fetch until ${new Date(s.nextRetryAt).toISOString()}`);
+    return empty;
+  }
+
+  try {
+    const { raw, parsed } = await fetchSummary();
+    const stamped: ClaudeStatusSnapshot = {
+      ...parsed,
+      source: "live",
+      fetchedAt: now,
+      lastError: null,
+    };
+    const newChanges = diffIncidents(s.snapshot, stamped, new Date(now));
+    if (newChanges.length > 0) {
+      s.changes.push(...newChanges);
+      pruneChanges(s, now);
+    }
+    s.snapshot = stamped;
+    s.consecutiveFailures = 0;
+    s.nextRetryAt = 0;
+    // Fire-and-forget — caller doesn't wait on disk I/O.
+    void writeDiskCache(raw);
+    return stamped;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+
+    // First-failure-of-streak log; spare the logs on repeated failures.
+    if (s.consecutiveFailures === 0) {
+      console.warn("[claudeStatus] fetch failed:", msg);
+    }
+    s.consecutiveFailures += 1;
+    s.nextRetryAt = now + backoffDelay(s.consecutiveFailures);
+
+    if (s.snapshot && now - s.snapshot.fetchedAt < STALE_MAX_MS) {
+      return { ...s.snapshot, source: "stale", lastError: msg };
+    }
+
+    // Try disk cache once if we haven't already (cold boot path).
+    if (!s.diskHydrationAttempted) {
+      s.diskHydrationAttempted = true;
+      const disk = await readDiskCache();
+      if (disk) {
+        s.snapshot = disk;
+        return { ...disk, source: "stale", lastError: msg };
+      }
+    }
+
+    return emptySnapshot(msg);
+  }
+}
+
+/**
+ * Returns the current snapshot. Triggers an upstream fetch only when
+ * in-memory state is older than {@link FRESH_TTL_MS}. Concurrent calls
+ * share a single in-flight promise.
+ */
+export async function getCurrentStatus(): Promise<ClaudeStatusSnapshot> {
+  const s = state();
+  const now = Date.now();
+
+  if (s.snapshot && now - s.snapshot.fetchedAt < FRESH_TTL_MS) {
+    return s.snapshot;
+  }
+
+  // Cold boot: prefer a disk seed to a 5-second wait on first request.
+  if (!s.snapshot && !s.diskHydrationAttempted) {
+    s.diskHydrationAttempted = true;
+    const disk = await readDiskCache();
+    if (disk) {
+      s.snapshot = disk;
+      // Kick a background refresh — the caller already has data to render.
+      if (!s.inflight) {
+        s.inflight = refreshSnapshot().finally(() => { s.inflight = null; });
+      }
+      return disk;
+    }
+  }
+
+  if (s.inflight) return s.inflight;
+  s.inflight = refreshSnapshot().finally(() => { s.inflight = null; });
+  return s.inflight;
+}
+
+/**
+ * Force an immediate fetch, bypassing TTL. Used by tests and admin actions.
+ */
+export async function forceRefresh(): Promise<ClaudeStatusSnapshot> {
+  const s = state();
+  if (s.inflight) return s.inflight;
+  s.inflight = refreshSnapshot().finally(() => { s.inflight = null; });
+  return s.inflight;
+}
+
+/**
+ * Return change events since the given ISO timestamp. Mirrors the
+ * contract of {@link manualStepsWatcher}.getChanges(since).
+ */
+export function getChanges(since: string): ClaudeStatusChange[] {
+  const s = state();
+  const sinceTime = new Date(since).getTime();
+  if (Number.isNaN(sinceTime)) return [];
+  return s.changes.filter((c) => new Date(c.changedAt).getTime() > sinceTime);
+}
+
+/** Test-only reset hook. */
+export function _resetForTesting(): void {
+  delete g.__claudeStatusCache;
+}

--- a/src/lib/claudeStatus/cache.ts
+++ b/src/lib/claudeStatus/cache.ts
@@ -5,8 +5,11 @@
  *   - `src/lib/usage/costCalculator.ts`: file cache + promise singleton +
  *     fallback to a safe default when fetch fails.
  *   - `src/lib/manualStepsWatcher.ts`: `globalThis`-pinned instance so
- *     hot reload in dev doesn't spawn a second copy, plus a 5-minute
- *     ring buffer of change events exposed via `getChanges(since)`.
+ *     hot reload in dev doesn't spawn a second copy, plus a ring buffer
+ *     of change events exposed via `getChanges(since)`. We use a 30-min
+ *     window (see `CHANGE_RETENTION_MS`); manualStepsWatcher uses 5 min
+ *     because it polls every few seconds, while this module polls at
+ *     60 s so listeners need a wider catch-up window.
  *
  * Lifecycle: lazy. `getCurrentStatus()` triggers a fetch only when the
  * in-memory snapshot is older than `FRESH_TTL_MS`. There is no
@@ -121,11 +124,16 @@ async function refreshSnapshot(): Promise<ClaudeStatusSnapshot> {
   const now = Date.now();
 
   // If we're inside the backoff window, don't even try the network —
-  // just return whatever we have (or empty) marked as stale.
+  // just return whatever we have (or empty) marked as stale. Apply the
+  // same STALE_MAX_MS guard the catch branch uses so a string of failures
+  // can't keep serving 30min+ old data indefinitely.
   if (s.consecutiveFailures > 0 && now < s.nextRetryAt) {
-    if (s.snapshot) return { ...s.snapshot, source: "stale" };
-    const empty = emptySnapshot(`Backoff: skipping fetch until ${new Date(s.nextRetryAt).toISOString()}`);
-    return empty;
+    if (s.snapshot && now - s.snapshot.fetchedAt < STALE_MAX_MS) {
+      return { ...s.snapshot, source: "stale" };
+    }
+    return emptySnapshot(
+      `Backoff: skipping fetch until ${new Date(s.nextRetryAt).toISOString()}`,
+    );
   }
 
   try {
@@ -158,7 +166,11 @@ async function refreshSnapshot(): Promise<ClaudeStatusSnapshot> {
     s.nextRetryAt = now + backoffDelay(s.consecutiveFailures);
 
     if (s.snapshot && now - s.snapshot.fetchedAt < STALE_MAX_MS) {
-      return { ...s.snapshot, source: "stale", lastError: msg };
+      // Persist the failure context onto the cached snapshot so a memory
+      // hit during the backoff window still surfaces `lastError` to the
+      // UI/MCP. Cleared on the next successful refresh (above).
+      s.snapshot = { ...s.snapshot, lastError: msg };
+      return { ...s.snapshot, source: "stale" };
     }
 
     // Try disk cache once if we haven't already (cold boot path).
@@ -166,8 +178,8 @@ async function refreshSnapshot(): Promise<ClaudeStatusSnapshot> {
       s.diskHydrationAttempted = true;
       const disk = await readDiskCache();
       if (disk) {
-        s.snapshot = disk;
-        return { ...disk, source: "stale", lastError: msg };
+        s.snapshot = { ...disk, lastError: msg };
+        return { ...s.snapshot, source: "stale" };
       }
     }
 

--- a/src/lib/claudeStatus/changes.ts
+++ b/src/lib/claudeStatus/changes.ts
@@ -1,0 +1,82 @@
+/**
+ * Diff two {@link ClaudeStatusSnapshot}s and emit a list of
+ * {@link ClaudeStatusChange}s describing every transition relevant to
+ * the UI listener (new incidents, status changes, resolutions).
+ *
+ * Pure function: deterministic on the inputs, no side effects. The
+ * caller owns the ring buffer and the `changedAt` timestamp source.
+ */
+
+import type {
+  ClaudeStatusChange,
+  ClaudeStatusSnapshot,
+  StatusIncident,
+} from "./types";
+
+/**
+ * Compare two snapshots and return the per-incident transitions.
+ * `now` is injected for testability; defaults to `new Date()`.
+ */
+export function diffIncidents(
+  previous: ClaudeStatusSnapshot | null,
+  next: ClaudeStatusSnapshot,
+  now: Date = new Date(),
+): ClaudeStatusChange[] {
+  const changes: ClaudeStatusChange[] = [];
+  const changedAt = now.toISOString();
+
+  const prevById = new Map<string, StatusIncident>();
+  for (const inc of previous?.incidents ?? []) prevById.set(inc.id, inc);
+
+  const nextById = new Map<string, StatusIncident>();
+  for (const inc of next.incidents) nextById.set(inc.id, inc);
+
+  // 1. Incidents that appear in next but not previous — new active incident.
+  // 2. Incidents in both — emit only if status OR impact changed.
+  for (const inc of next.incidents) {
+    const prev = prevById.get(inc.id);
+    if (!prev) {
+      changes.push({
+        incidentId: inc.id,
+        name: inc.name,
+        impact: inc.impact,
+        status: inc.status,
+        transition: "new",
+        shortlink: inc.shortlink,
+        changedAt,
+      });
+      continue;
+    }
+    if (prev.status !== inc.status || prev.impact !== inc.impact) {
+      changes.push({
+        incidentId: inc.id,
+        name: inc.name,
+        impact: inc.impact,
+        status: inc.status,
+        transition: "status-change",
+        shortlink: inc.shortlink,
+        changedAt,
+      });
+    }
+  }
+
+  // 3. Incidents in previous but not next — resolved (Statuspage drops
+  //    resolved incidents from summary.json's `incidents` array). If a
+  //    payload ever does include a resolved incident, parser.ts already
+  //    filters it from next.incidents, so this branch fires uniformly.
+  for (const inc of previous?.incidents ?? []) {
+    if (!nextById.has(inc.id)) {
+      changes.push({
+        incidentId: inc.id,
+        name: inc.name,
+        impact: inc.impact,
+        status: "resolved",
+        transition: "resolved",
+        shortlink: inc.shortlink,
+        changedAt,
+      });
+    }
+  }
+
+  return changes;
+}

--- a/src/lib/claudeStatus/parser.ts
+++ b/src/lib/claudeStatus/parser.ts
@@ -47,10 +47,18 @@ function stripHtml(html: string): string {
   // the atom feed's `content`). We still strip defensively so any
   // sanitization on Statuspage's side that injects tags can't bleed
   // through to a toast.
-  return html
-    .replace(/<\/?[^>]+>/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  //
+  // Iterate until idempotent so nested/malformed payloads like
+  // `<scr<script>ipt>` collapse correctly (a single pass would leave a
+  // stray `ipt>` behind). Then drop any lingering angle brackets so a
+  // partial fragment can't be misread as a tag downstream.
+  let s = html;
+  for (let i = 0; i < 5; i++) {
+    const next = s.replace(/<\/?[^>]+>/g, "");
+    if (next === s) break;
+    s = next;
+  }
+  return s.replace(/[<>]/g, "").replace(/\s+/g, " ").trim();
 }
 
 function truncate(s: string, max: number): string {

--- a/src/lib/claudeStatus/parser.ts
+++ b/src/lib/claudeStatus/parser.ts
@@ -1,0 +1,182 @@
+/**
+ * Pure transform from a raw Statuspage `summary.json` payload to the
+ * trimmed {@link ClaudeStatusSnapshot} the UI renders.
+ *
+ * The function tolerates schema drift: missing optional fields default
+ * to safe values, unknown enum values pass through verbatim (the UI has
+ * a `default` branch), extra fields are ignored. It never throws.
+ */
+
+import type {
+  ClaudeStatusSnapshot,
+  ComponentStatus,
+  IncidentImpact,
+  IncidentStatus,
+  OverallStatus,
+  StatusComponent,
+  StatusIncident,
+} from "./types";
+
+const LATEST_UPDATE_MAX_CHARS = 280;
+
+type RawSummary = {
+  page?: { url?: unknown; updated_at?: unknown };
+  components?: unknown;
+  incidents?: unknown;
+};
+
+type RawComponent = Record<string, unknown>;
+type RawIncident = Record<string, unknown>;
+type RawIncidentUpdate = Record<string, unknown>;
+type RawAffectedComponent = Record<string, unknown>;
+
+function asString(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function asNullableString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+function asArray<T = unknown>(v: unknown): T[] {
+  return Array.isArray(v) ? (v as T[]) : [];
+}
+
+function stripHtml(html: string): string {
+  // Statuspage update bodies are plain text in `body` (HTML is only in
+  // the atom feed's `content`). We still strip defensively so any
+  // sanitization on Statuspage's side that injects tags can't bleed
+  // through to a toast.
+  return html
+    .replace(/<\/?[^>]+>/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + "…";
+}
+
+function parseComponent(raw: RawComponent): StatusComponent | null {
+  const id = asString(raw["id"]);
+  if (!id) return null;
+  return {
+    id,
+    name: asString(raw["name"], id),
+    // Unknown statuses pass through — UI default branch handles them.
+    status: asString(raw["status"], "operational") as ComponentStatus,
+    updatedAt: asString(raw["updated_at"], new Date(0).toISOString()),
+  };
+}
+
+function parseIncident(raw: RawIncident): StatusIncident | null {
+  const id = asString(raw["id"]);
+  if (!id) return null;
+
+  // Collect affected component ids from incident_updates[].affected_components[]
+  // since the top-level `components` array on an incident isn't always
+  // present. Dedup while preserving first-seen order.
+  const seen = new Set<string>();
+  const affected: string[] = [];
+  const updates = asArray<RawIncidentUpdate>(raw["incident_updates"]);
+  for (const u of updates) {
+    const ac = asArray<RawAffectedComponent>(u["affected_components"]);
+    for (const c of ac) {
+      const code = asString(c["code"]);
+      if (code && !seen.has(code)) {
+        seen.add(code);
+        affected.push(code);
+      }
+    }
+  }
+  // Fallback: some payloads include `components` on the incident itself.
+  for (const c of asArray<RawComponent>(raw["components"])) {
+    const cid = asString(c["id"]);
+    if (cid && !seen.has(cid)) {
+      seen.add(cid);
+      affected.push(cid);
+    }
+  }
+
+  // Latest update body — Statuspage orders incident_updates newest-first.
+  let latestUpdateBody: string | null = null;
+  if (updates.length > 0) {
+    const body = asString(updates[0]["body"]);
+    if (body) latestUpdateBody = truncate(stripHtml(body), LATEST_UPDATE_MAX_CHARS);
+  }
+
+  const fallbackTime = new Date(0).toISOString();
+  return {
+    id,
+    name: asString(raw["name"], "Untitled incident"),
+    status: asString(raw["status"], "investigating") as IncidentStatus,
+    impact: asString(raw["impact"], "none") as IncidentImpact,
+    shortlink: asString(raw["shortlink"], "https://status.claude.com"),
+    startedAt: asString(raw["started_at"], fallbackTime),
+    updatedAt: asString(raw["updated_at"], fallbackTime),
+    resolvedAt: asNullableString(raw["resolved_at"]),
+    affectedComponentIds: affected,
+    latestUpdateBody,
+  };
+}
+
+/**
+ * Derive the coarse overall status from incidents and component states.
+ *
+ * Severity priority:
+ *  - `incident`   = any active critical incident OR any component in major_outage
+ *  - `degraded`   = any active incident (any impact) OR any non-operational component
+ *  - `operational`= otherwise
+ */
+function deriveOverall(
+  components: StatusComponent[],
+  activeIncidents: StatusIncident[],
+): OverallStatus {
+  const hasCritical = activeIncidents.some((i) => i.impact === "critical");
+  const hasMajorOutage = components.some((c) => c.status === "major_outage");
+  if (hasCritical || hasMajorOutage) return "incident";
+
+  if (activeIncidents.length > 0) return "degraded";
+  if (components.some((c) => c.status !== "operational")) return "degraded";
+
+  return "operational";
+}
+
+/**
+ * Parse the Statuspage `summary.json` payload into a {@link ClaudeStatusSnapshot}.
+ * Resolved incidents are filtered out so the UI/MCP only see currently-active ones.
+ *
+ * `source` and `fetchedAt` are stamped by the caller (the cache layer);
+ * this function fills them with placeholders so the result is still a
+ * valid `ClaudeStatusSnapshot`.
+ */
+export function parseSummary(payload: unknown): ClaudeStatusSnapshot {
+  const raw: RawSummary = (payload && typeof payload === "object" ? (payload as RawSummary) : {});
+
+  const components: StatusComponent[] = [];
+  for (const c of asArray<RawComponent>(raw.components)) {
+    const parsed = parseComponent(c);
+    if (parsed) components.push(parsed);
+  }
+
+  const allIncidents: StatusIncident[] = [];
+  for (const i of asArray<RawIncident>(raw.incidents)) {
+    const parsed = parseIncident(i);
+    if (parsed) allIncidents.push(parsed);
+  }
+  const activeIncidents = allIncidents.filter((i) => i.status !== "resolved");
+
+  const pageUrl = asString(raw.page?.url, "https://status.claude.com");
+  const pageUpdated = asString(raw.page?.updated_at, new Date(0).toISOString());
+
+  return {
+    page: { url: pageUrl, updatedAt: pageUpdated },
+    components,
+    incidents: activeIncidents,
+    overall: deriveOverall(components, activeIncidents),
+    fetchedAt: 0,
+    source: "live",
+    lastError: null,
+  };
+}

--- a/src/lib/claudeStatus/types.ts
+++ b/src/lib/claudeStatus/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Types for the Claude Status integration. Mirrors the fields of
+ * status.claude.com's Statuspage `summary.json`, trimmed to what the
+ * UI/MCP surfaces actually render.
+ */
+
+export type ComponentStatus =
+  | "operational"
+  | "degraded_performance"
+  | "partial_outage"
+  | "major_outage";
+
+export type IncidentStatus =
+  | "investigating"
+  | "identified"
+  | "monitoring"
+  | "resolved";
+
+export type IncidentImpact = "none" | "minor" | "major" | "critical";
+
+export interface StatusComponent {
+  id: string;
+  name: string;
+  status: ComponentStatus;
+  updatedAt: string;
+}
+
+export interface StatusIncident {
+  id: string;
+  name: string;
+  status: IncidentStatus;
+  impact: IncidentImpact;
+  shortlink: string;
+  startedAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+  affectedComponentIds: string[];
+  /** Most recent `incident_updates[].body` (HTML stripped to plain text), trimmed to ~280 chars. */
+  latestUpdateBody: string | null;
+}
+
+/**
+ * Cache-state hint. `live` = freshly fetched. `disk-cache` = loaded from
+ * disk on cold boot. `stale` = upstream fetch failed and we're serving the
+ * last good snapshot. `empty` = no live data and no cache (safe default).
+ */
+export type SnapshotSource = "live" | "disk-cache" | "stale" | "empty";
+
+export type OverallStatus = "operational" | "degraded" | "incident";
+
+export interface ClaudeStatusSnapshot {
+  page: { url: string; updatedAt: string };
+  components: StatusComponent[];
+  incidents: StatusIncident[];
+  overall: OverallStatus;
+  fetchedAt: number;
+  source: SnapshotSource;
+  lastError: string | null;
+}
+
+export interface ClaudeStatusChange {
+  incidentId: string;
+  name: string;
+  impact: IncidentImpact;
+  status: IncidentStatus;
+  transition: "new" | "status-change" | "resolved";
+  shortlink: string;
+  changedAt: string;
+}
+
+/**
+ * Safe empty snapshot. Used when no live or cached data is available so
+ * the banner can render "operational" instead of crashing.
+ */
+export function emptySnapshot(lastError: string | null = null): ClaudeStatusSnapshot {
+  return {
+    page: { url: "https://status.claude.com", updatedAt: new Date(0).toISOString() },
+    components: [],
+    incidents: [],
+    overall: "operational",
+    fetchedAt: 0,
+    source: "empty",
+    lastError,
+  };
+}

--- a/src/lib/claudeStatus/types.ts
+++ b/src/lib/claudeStatus/types.ts
@@ -4,12 +4,25 @@
  * UI/MCP surfaces actually render.
  */
 
+/**
+ * Component statuses Statuspage currently emits. The parser is intentionally
+ * lenient: it casts any string value from `summary.json` into this type so
+ * a Statuspage-side rename or new value doesn't crash the dashboard. Treat
+ * a `ComponentStatus` from the snapshot as an opaque string when branching —
+ * always provide a `default` arm. UI severity decisions go through
+ * `OverallStatus` (a derived 3-value enum), so this leniency is contained.
+ */
 export type ComponentStatus =
   | "operational"
   | "degraded_performance"
   | "partial_outage"
   | "major_outage";
 
+/**
+ * Incident statuses Statuspage currently emits. Same lenient-cast policy
+ * as {@link ComponentStatus} — values from the snapshot may be strings
+ * outside this union if Statuspage adds new states.
+ */
 export type IncidentStatus =
   | "investigating"
   | "identified"

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -20,6 +20,7 @@ export const FEATURE_FLAG_KEYS: readonly FeatureFlagKey[] = [
   "mcpSecurityScan",
   "gsdPlanning",
   "agentView",
+  "claudeStatusAlerts",
 ] as const;
 
 /** Human-readable metadata for the Settings UI. Empty groups are fine —
@@ -166,6 +167,14 @@ export const FEATURE_FLAG_META: readonly FeatureFlagMeta[] = [
     description: "Reads the Claude daemon roster + JSONL appends to power the /agent-view live session Kanban. Defaults on.",
     group: "active",
     appliesAt: "watcher",
+    wired: true,
+  },
+  {
+    key: "claudeStatusAlerts",
+    label: "Claude status alerts",
+    description: "Polls status.claude.com for incidents and shows a banner + toast when Claude services are degraded. Defaults on.",
+    group: "active",
+    appliesAt: "ui",
     wired: true,
   },
 ];

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -12,6 +12,7 @@ import { registerGitTools } from "./tools/git";
 import { registerStatsTools } from "./tools/stats";
 import { registerOtelTools } from "./tools/otel";
 import { registerDevServerTools } from "./tools/devServers";
+import { registerClaudeStatusTools } from "./tools/claudeStatus";
 import { registerResources } from "./resources";
 
 // Bind the transport's DNS-rebinding protection to the dev-server's port.
@@ -57,6 +58,7 @@ export function buildMcpServer(): McpServer {
   registerStatsTools(server);
   registerOtelTools(server);
   registerDevServerTools(server);
+  registerClaudeStatusTools(server);
   registerResources(server);
 
   return server;

--- a/src/lib/mcp/tools/claudeStatus.ts
+++ b/src/lib/mcp/tools/claudeStatus.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { getCurrentStatus } from "@/lib/claudeStatus/cache";
+import { readConfig } from "@/lib/config";
+import { getFlag } from "@/lib/featureFlags";
+import { jsonResult } from "../result";
+
+export function registerClaudeStatusTools(server: McpServer): void {
+  server.registerTool(
+    "get-claude-status",
+    {
+      title: "Get current Claude service status",
+      description:
+        "Returns active Claude incidents and per-component health pulled from status.claude.com's " +
+        "Statuspage summary API. Use this to determine whether an API error or Claude.ai/Claude " +
+        "Code issue the user reports is caused by an upstream incident vs. a local problem. " +
+        "Includes overall severity, the affected components, the latest incident-update body, " +
+        "and a `source` field that flags stale-vs-live data. By default, components currently " +
+        "marked `operational` are omitted from the result to keep the payload focused on what's " +
+        "actionable.",
+      inputSchema: {
+        includeOperationalComponents: z
+          .boolean()
+          .default(false)
+          .describe("Include components currently in `operational` status. Default false — return only currently-degraded components."),
+      },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+    },
+    async ({ includeOperationalComponents }) => {
+      const config = await readConfig();
+      if (!getFlag(config.featureFlags, "claudeStatusAlerts")) {
+        return jsonResult({
+          disabled: true,
+          reason: "claudeStatusAlerts feature flag is off in this project's .minder.json. Enable it via the Project Minder Settings page.",
+        });
+      }
+
+      const snapshot = await getCurrentStatus();
+      const components = includeOperationalComponents
+        ? snapshot.components
+        : snapshot.components.filter((c) => c.status !== "operational");
+
+      return jsonResult({
+        overall: snapshot.overall,
+        source: snapshot.source,
+        fetchedAt: snapshot.fetchedAt ? new Date(snapshot.fetchedAt).toISOString() : null,
+        lastError: snapshot.lastError,
+        page: snapshot.page,
+        componentCount: snapshot.components.length,
+        components,
+        incidents: snapshot.incidents,
+      });
+    },
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -429,7 +429,8 @@ export type FeatureFlagKey =
   | "taskDispatcher"
   | "mcpSecurityScan"
   | "gsdPlanning"
-  | "agentView";
+  | "agentView"
+  | "claudeStatusAlerts";
 
 /** Claude Code lifecycle hook event names sent in the hook stdin payload. */
 export type HookEventName =

--- a/tests/claudeStatusCache.test.ts
+++ b/tests/claudeStatusCache.test.ts
@@ -8,9 +8,12 @@ vi.mock("fs", () => {
   const writeFile = vi.fn();
   const mkdir = vi.fn();
   return {
+    // Mock the promises surface used by cache.ts. `readFileSync` is also
+    // exported (as a stub) so any code path importing it from `fs` doesn't
+    // crash — but the stub does NOT proxy to the real implementation.
+    // The fixture loader below uses `require("node:fs").readFileSync`
+    // directly to bypass this mock when it needs real disk reads.
     promises: { stat, readFile, writeFile, mkdir },
-    // Some places (tests, vitest itself) import sync helpers from fs.
-    // Provide a no-op shim that delegates to real readFileSync via require.
     readFileSync: vi.fn(),
   };
 });
@@ -28,12 +31,11 @@ const mockReadFile = vi.mocked(fsP.readFile);
 const mockWriteFile = vi.mocked(fsP.writeFile);
 const mockMkdir = vi.mocked(fsP.mkdir);
 
-// We mocked the `fs` module so we can't use the real readFileSync to load
-// fixtures. Inline the payloads we need at module-load time, before mocks
-// were active, using a literal require. The fixtures are tiny.
+// Bypass the `vi.mock("fs", ...)` above by reaching for the unmocked
+// `node:fs` module via require(). Vitest only intercepts the bare "fs"
+// specifier, so "node:fs" gives us the real readFileSync we need to
+// hydrate the JSON fixtures off disk.
 function loadFixture(name: string): unknown {
-  // Use a path relative to the project root; readFileSync is mocked above,
-  // so we shell out to require() against a real path resolved by node.
   const real = require("node:fs").readFileSync as typeof readFileSync;
   const p = path.resolve(__dirname, "fixtures", "claudeStatus", `${name}.json`);
   return JSON.parse(real(p, "utf-8"));

--- a/tests/claudeStatusCache.test.ts
+++ b/tests/claudeStatusCache.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+
+vi.mock("fs", () => {
+  const stat = vi.fn();
+  const readFile = vi.fn();
+  const writeFile = vi.fn();
+  const mkdir = vi.fn();
+  return {
+    promises: { stat, readFile, writeFile, mkdir },
+    // Some places (tests, vitest itself) import sync helpers from fs.
+    // Provide a no-op shim that delegates to real readFileSync via require.
+    readFileSync: vi.fn(),
+  };
+});
+
+import { promises as fsP } from "fs";
+import {
+  _resetForTesting,
+  getChanges,
+  getCurrentStatus,
+  forceRefresh,
+} from "@/lib/claudeStatus/cache";
+
+const mockStat = vi.mocked(fsP.stat);
+const mockReadFile = vi.mocked(fsP.readFile);
+const mockWriteFile = vi.mocked(fsP.writeFile);
+const mockMkdir = vi.mocked(fsP.mkdir);
+
+// We mocked the `fs` module so we can't use the real readFileSync to load
+// fixtures. Inline the payloads we need at module-load time, before mocks
+// were active, using a literal require. The fixtures are tiny.
+function loadFixture(name: string): unknown {
+  // Use a path relative to the project root; readFileSync is mocked above,
+  // so we shell out to require() against a real path resolved by node.
+  const real = require("node:fs").readFileSync as typeof readFileSync;
+  const p = path.resolve(__dirname, "fixtures", "claudeStatus", `${name}.json`);
+  return JSON.parse(real(p, "utf-8"));
+}
+
+const clearPayload = loadFixture("summary-clear");
+const incidentPayload = loadFixture("summary-incident");
+
+function mockFetchOk(payload: unknown): void {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  }) as unknown as typeof fetch;
+}
+
+function mockFetchFail(message = "boom"): void {
+  global.fetch = vi.fn().mockRejectedValue(new Error(message)) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetForTesting();
+  // Default: no disk cache.
+  mockStat.mockRejectedValue(new Error("ENOENT"));
+  mockReadFile.mockRejectedValue(new Error("ENOENT"));
+  mockMkdir.mockResolvedValue(undefined);
+  mockWriteFile.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  (global as { fetch?: typeof fetch }).fetch = undefined;
+});
+
+describe("claudeStatus cache", () => {
+  it("fetches live data on first call, marks source=live, writes disk cache", async () => {
+    mockFetchOk(clearPayload);
+    const snap = await getCurrentStatus();
+    expect(snap.source).toBe("live");
+    expect(snap.overall).toBe("operational");
+    expect(snap.components).toHaveLength(6);
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns memory on a second call within the fresh TTL (no second fetch)", async () => {
+    mockFetchOk(clearPayload);
+    const a = await getCurrentStatus();
+    const b = await getCurrentStatus();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it("falls back to memory and marks source=stale when fetch fails", async () => {
+    // First call: success seeds the cache.
+    mockFetchOk(clearPayload);
+    await getCurrentStatus();
+    // Force a refresh that fails.
+    mockFetchFail("upstream 503");
+    const stale = await forceRefresh();
+    expect(stale.source).toBe("stale");
+    expect(stale.lastError).toContain("upstream 503");
+    expect(stale.overall).toBe("operational"); // last good
+  });
+
+  it("returns an empty snapshot when no memory + no disk + fetch fails", async () => {
+    mockFetchFail("offline");
+    const snap = await getCurrentStatus();
+    expect(snap.source).toBe("empty");
+    expect(snap.overall).toBe("operational");
+    expect(snap.lastError).toContain("offline");
+  });
+
+  it("hydrates from disk on cold boot before kicking a network refresh", async () => {
+    mockStat.mockResolvedValue({ mtimeMs: Date.now() - 10_000 } as Awaited<ReturnType<typeof fsP.stat>>);
+    mockReadFile.mockResolvedValue(JSON.stringify(clearPayload));
+    mockFetchOk(clearPayload);
+    const snap = await getCurrentStatus();
+    expect(snap.source).toBe("disk-cache");
+    expect(snap.components).toHaveLength(6);
+  });
+
+  it("dedupes concurrent callers to a single in-flight fetch", async () => {
+    let resolve: ((v: unknown) => void) | null = null;
+    global.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolve = (payload: unknown) =>
+            r({ ok: true, status: 200, json: async () => payload });
+        })
+    ) as unknown as typeof fetch;
+
+    const p1 = getCurrentStatus();
+    const p2 = getCurrentStatus();
+    await Promise.resolve();
+    expect(resolve).not.toBeNull();
+    resolve!(clearPayload);
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a).toBe(b);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("records change events on incident transitions and exposes them via getChanges(since)", async () => {
+    const since = new Date(Date.now() - 1000).toISOString();
+    // 1st fetch: no incidents
+    mockFetchOk(clearPayload);
+    await getCurrentStatus();
+    expect(getChanges(since)).toEqual([]);
+
+    // 2nd fetch (forced): an incident appears
+    mockFetchOk(incidentPayload);
+    await forceRefresh();
+    const changes = getChanges(since);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].transition).toBe("new");
+    expect(changes[0].incidentId).toBe("yn24rtdnf77b");
+  });
+
+  it("does not emit change events for unchanged refreshes", async () => {
+    mockFetchOk(incidentPayload);
+    await getCurrentStatus();
+    const since = new Date(Date.now() + 1000).toISOString(); // future cutoff
+    mockFetchOk(incidentPayload);
+    await forceRefresh();
+    expect(getChanges(new Date(0).toISOString()).length).toBe(1); // only the initial "new"
+    expect(getChanges(since)).toEqual([]); // no diff on the second refresh
+  });
+
+  it("getChanges returns [] for an invalid since timestamp", () => {
+    expect(getChanges("not-a-date")).toEqual([]);
+  });
+});

--- a/tests/claudeStatusChanges.test.ts
+++ b/tests/claudeStatusChanges.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { diffIncidents } from "@/lib/claudeStatus/changes";
+import { emptySnapshot } from "@/lib/claudeStatus/types";
+import type { ClaudeStatusSnapshot, StatusIncident } from "@/lib/claudeStatus/types";
+
+function snapshot(incidents: StatusIncident[]): ClaudeStatusSnapshot {
+  return {
+    ...emptySnapshot(),
+    incidents,
+    overall: incidents.length > 0 ? "incident" : "operational",
+  };
+}
+
+function incident(overrides: Partial<StatusIncident> = {}): StatusIncident {
+  return {
+    id: "i1",
+    name: "Test incident",
+    status: "investigating",
+    impact: "minor",
+    shortlink: "https://status.claude.com/incidents/i1",
+    startedAt: "2026-05-13T10:00:00.000Z",
+    updatedAt: "2026-05-13T10:00:00.000Z",
+    resolvedAt: null,
+    affectedComponentIds: [],
+    latestUpdateBody: null,
+    ...overrides,
+  };
+}
+
+const fixedNow = new Date("2026-05-13T12:00:00.000Z");
+
+describe("diffIncidents", () => {
+  it("returns empty when both snapshots are empty", () => {
+    expect(diffIncidents(snapshot([]), snapshot([]), fixedNow)).toEqual([]);
+  });
+
+  it("emits a 'new' change when an incident appears", () => {
+    const changes = diffIncidents(snapshot([]), snapshot([incident()]), fixedNow);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].transition).toBe("new");
+    expect(changes[0].incidentId).toBe("i1");
+    expect(changes[0].changedAt).toBe(fixedNow.toISOString());
+  });
+
+  it("emits 'status-change' when status flips", () => {
+    const prev = snapshot([incident({ status: "investigating" })]);
+    const next = snapshot([incident({ status: "monitoring" })]);
+    const changes = diffIncidents(prev, next, fixedNow);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].transition).toBe("status-change");
+    expect(changes[0].status).toBe("monitoring");
+  });
+
+  it("emits 'status-change' when impact escalates", () => {
+    const prev = snapshot([incident({ impact: "minor" })]);
+    const next = snapshot([incident({ impact: "critical" })]);
+    const changes = diffIncidents(prev, next, fixedNow);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].transition).toBe("status-change");
+    expect(changes[0].impact).toBe("critical");
+  });
+
+  it("emits 'resolved' when an incident disappears from the active list", () => {
+    const prev = snapshot([incident({ status: "monitoring" })]);
+    const next = snapshot([]);
+    const changes = diffIncidents(prev, next, fixedNow);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].transition).toBe("resolved");
+    expect(changes[0].status).toBe("resolved");
+  });
+
+  it("emits nothing when the same incident is unchanged", () => {
+    const prev = snapshot([incident()]);
+    const next = snapshot([incident()]);
+    expect(diffIncidents(prev, next, fixedNow)).toEqual([]);
+  });
+
+  it("treats a null previous snapshot as all-new (cold start)", () => {
+    const next = snapshot([incident(), incident({ id: "i2" })]);
+    const changes = diffIncidents(null, next, fixedNow);
+    expect(changes).toHaveLength(2);
+    expect(changes.every((c) => c.transition === "new")).toBe(true);
+  });
+
+  it("handles a mix of new + status-change + resolved in one diff", () => {
+    const prev = snapshot([
+      incident({ id: "a", status: "investigating" }),
+      incident({ id: "b", status: "monitoring" }),
+    ]);
+    const next = snapshot([
+      incident({ id: "a", status: "identified" }),         // status-change
+      incident({ id: "c", impact: "major" }),               // new
+      // b dropped → resolved
+    ]);
+    const changes = diffIncidents(prev, next, fixedNow);
+    expect(changes.map((c) => `${c.incidentId}:${c.transition}`).sort()).toEqual([
+      "a:status-change",
+      "b:resolved",
+      "c:new",
+    ]);
+  });
+
+  it("stamps changedAt from the injected `now`", () => {
+    const myNow = new Date("2030-01-01T00:00:00.000Z");
+    const changes = diffIncidents(snapshot([]), snapshot([incident()]), myNow);
+    expect(changes[0].changedAt).toBe(myNow.toISOString());
+  });
+});

--- a/tests/claudeStatusParser.test.ts
+++ b/tests/claudeStatusParser.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+import { parseSummary } from "@/lib/claudeStatus/parser";
+
+function fixture(name: string): unknown {
+  const p = path.resolve(__dirname, "fixtures", "claudeStatus", `${name}.json`);
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+describe("parseSummary", () => {
+  it("treats an all-operational payload as overall=operational with no incidents", () => {
+    const snap = parseSummary(fixture("summary-clear"));
+    expect(snap.overall).toBe("operational");
+    expect(snap.incidents).toHaveLength(0);
+    expect(snap.components).toHaveLength(6);
+    expect(snap.components.every((c) => c.status === "operational")).toBe(true);
+  });
+
+  it("treats a single degraded_performance component (no incident) as overall=degraded", () => {
+    const snap = parseSummary(fixture("summary-degraded"));
+    expect(snap.overall).toBe("degraded");
+    expect(snap.incidents).toHaveLength(0);
+    const claudeApi = snap.components.find((c) => c.name === "Claude API");
+    expect(claudeApi?.status).toBe("degraded_performance");
+  });
+
+  it("treats an active major incident with a major_outage component as overall=incident", () => {
+    const snap = parseSummary(fixture("summary-incident"));
+    expect(snap.overall).toBe("incident");
+    expect(snap.incidents).toHaveLength(1);
+    const inc = snap.incidents[0];
+    expect(inc.status).toBe("investigating");
+    expect(inc.impact).toBe("major");
+    expect(inc.resolvedAt).toBeNull();
+  });
+
+  it("picks the most-recent incident update for latestUpdateBody and truncates if needed", () => {
+    const snap = parseSummary(fixture("summary-incident"));
+    const inc = snap.incidents[0];
+    // Statuspage orders newest-first; first update mentions "elevated error rates affecting"
+    expect(inc.latestUpdateBody).toContain("elevated error rates");
+    expect(inc.latestUpdateBody).toContain("API and Claude Code");
+    expect((inc.latestUpdateBody ?? "").length).toBeLessThanOrEqual(280);
+  });
+
+  it("collects affectedComponentIds from incident_updates, deduped and preserving first-seen order", () => {
+    const snap = parseSummary(fixture("summary-incident"));
+    const inc = snap.incidents[0];
+    // Most-recent update lists API then Code; earlier update only lists API.
+    // Dedup must keep first-seen order.
+    expect(inc.affectedComponentIds).toEqual(["cmpapi00001", "cmpcode0001"]);
+  });
+
+  it("filters resolved incidents out of incidents[] and falls back to operational when components are clean", () => {
+    const snap = parseSummary(fixture("summary-resolved"));
+    expect(snap.incidents).toHaveLength(0);
+    expect(snap.overall).toBe("operational");
+  });
+
+  it("returns a safe empty result for malformed input (not an object)", () => {
+    const snap = parseSummary("not-an-object");
+    expect(snap.components).toEqual([]);
+    expect(snap.incidents).toEqual([]);
+    expect(snap.overall).toBe("operational");
+  });
+
+  it("returns a safe empty result when payload is null", () => {
+    const snap = parseSummary(null);
+    expect(snap.components).toEqual([]);
+    expect(snap.incidents).toEqual([]);
+    expect(snap.overall).toBe("operational");
+  });
+
+  it("tolerates missing components/incidents arrays", () => {
+    const snap = parseSummary({ page: { url: "x", updated_at: "y" } });
+    expect(snap.components).toEqual([]);
+    expect(snap.incidents).toEqual([]);
+    expect(snap.page.url).toBe("x");
+  });
+
+  it("tolerates an incident with no incident_updates array (latestUpdateBody is null)", () => {
+    const payload = {
+      page: { url: "u", updated_at: "t" },
+      components: [],
+      incidents: [
+        {
+          id: "i1",
+          name: "n",
+          status: "investigating",
+          impact: "minor",
+          shortlink: "s",
+          started_at: "a",
+          updated_at: "b",
+          resolved_at: null,
+        },
+      ],
+    };
+    const snap = parseSummary(payload);
+    expect(snap.incidents).toHaveLength(1);
+    expect(snap.incidents[0].latestUpdateBody).toBeNull();
+    expect(snap.incidents[0].affectedComponentIds).toEqual([]);
+  });
+
+  it("strips HTML from latestUpdateBody", () => {
+    const payload = {
+      page: { url: "u", updated_at: "t" },
+      components: [],
+      incidents: [
+        {
+          id: "i1",
+          name: "n",
+          status: "investigating",
+          impact: "minor",
+          shortlink: "s",
+          started_at: "a",
+          updated_at: "b",
+          resolved_at: null,
+          incident_updates: [
+            {
+              id: "u1",
+              status: "investigating",
+              body: "<p><strong>Update</strong> - things are <em>broken</em></p>",
+              display_at: "z",
+            },
+          ],
+        },
+      ],
+    };
+    const snap = parseSummary(payload);
+    expect(snap.incidents[0].latestUpdateBody).toBe("Update - things are broken");
+  });
+
+  it("treats components with unknown status verbatim (forward-compat)", () => {
+    const payload = {
+      page: { url: "u", updated_at: "t" },
+      components: [
+        { id: "c1", name: "Future", status: "under_review", updated_at: "z" },
+      ],
+      incidents: [],
+    };
+    const snap = parseSummary(payload);
+    expect(snap.components[0].status).toBe("under_review");
+    // Unknown status counts as non-operational → degraded.
+    expect(snap.overall).toBe("degraded");
+  });
+
+  it("treats a minor active incident as overall=degraded even with all components operational", () => {
+    const payload = {
+      page: { url: "u", updated_at: "t" },
+      components: [
+        { id: "c1", name: "Service", status: "operational", updated_at: "z" },
+      ],
+      incidents: [
+        {
+          id: "i1",
+          name: "Minor issue",
+          status: "monitoring",
+          impact: "minor",
+          shortlink: "s",
+          started_at: "a",
+          updated_at: "b",
+          resolved_at: null,
+        },
+      ],
+    };
+    const snap = parseSummary(payload);
+    expect(snap.overall).toBe("degraded");
+  });
+
+  it("treats a critical active incident as overall=incident", () => {
+    const payload = {
+      page: { url: "u", updated_at: "t" },
+      components: [
+        { id: "c1", name: "Service", status: "operational", updated_at: "z" },
+      ],
+      incidents: [
+        {
+          id: "i1",
+          name: "Total outage",
+          status: "investigating",
+          impact: "critical",
+          shortlink: "s",
+          started_at: "a",
+          updated_at: "b",
+          resolved_at: null,
+        },
+      ],
+    };
+    const snap = parseSummary(payload);
+    expect(snap.overall).toBe("incident");
+  });
+
+  it("skips components missing an id", () => {
+    const payload = {
+      page: { url: "u", updated_at: "t" },
+      components: [
+        { name: "no-id", status: "operational", updated_at: "z" },
+        { id: "c1", name: "ok", status: "operational", updated_at: "z" },
+      ],
+      incidents: [],
+    };
+    const snap = parseSummary(payload);
+    expect(snap.components.map((c) => c.id)).toEqual(["c1"]);
+  });
+});

--- a/tests/claudeStatusParser.test.ts
+++ b/tests/claudeStatusParser.test.ts
@@ -102,6 +102,40 @@ describe("parseSummary", () => {
     expect(snap.incidents[0].affectedComponentIds).toEqual([]);
   });
 
+  it("strips nested/malformed HTML from latestUpdateBody (defense against partial-sanitization escapes)", () => {
+    const payload = {
+      page: { url: "u", updated_at: "t" },
+      components: [],
+      incidents: [
+        {
+          id: "i1",
+          name: "n",
+          status: "investigating",
+          impact: "minor",
+          shortlink: "s",
+          started_at: "a",
+          updated_at: "b",
+          resolved_at: null,
+          incident_updates: [
+            {
+              id: "u1",
+              status: "investigating",
+              // Classic single-pass-strip bypass: removing `<script>` leaves
+              // the outer `<scr` + `ipt>` which look like a tag again.
+              body: "<scr<script>ipt>alert(1)</scr</script>ipt>fine",
+              display_at: "z",
+            },
+          ],
+        },
+      ],
+    };
+    const snap = parseSummary(payload);
+    const body = snap.incidents[0].latestUpdateBody ?? "";
+    expect(body).not.toContain("<");
+    expect(body).not.toContain(">");
+    expect(body).not.toContain("script");
+  });
+
   it("strips HTML from latestUpdateBody", () => {
     const payload = {
       page: { url: "u", updated_at: "t" },

--- a/tests/fixtures/claudeStatus/summary-clear.json
+++ b/tests/fixtures/claudeStatus/summary-clear.json
@@ -1,0 +1,55 @@
+{
+  "page": {
+    "id": "tymt9n04zgry",
+    "name": "Claude",
+    "url": "https://status.claude.com",
+    "updated_at": "2026-05-13T10:00:00.000Z"
+  },
+  "components": [
+    {
+      "id": "rwppv331jlwc",
+      "name": "claude.ai",
+      "status": "operational",
+      "position": 1,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpconsole01",
+      "name": "Claude Console",
+      "status": "operational",
+      "position": 2,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpapi00001",
+      "name": "Claude API",
+      "status": "operational",
+      "position": 3,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpcode0001",
+      "name": "Claude Code",
+      "status": "operational",
+      "position": 4,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpcowork01",
+      "name": "Cowork",
+      "status": "operational",
+      "position": 5,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpgov00001",
+      "name": "Government",
+      "status": "operational",
+      "position": 6,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    }
+  ],
+  "incidents": [],
+  "scheduled_maintenances": [],
+  "status": { "indicator": "none", "description": "All Systems Operational" }
+}

--- a/tests/fixtures/claudeStatus/summary-degraded.json
+++ b/tests/fixtures/claudeStatus/summary-degraded.json
@@ -1,0 +1,55 @@
+{
+  "page": {
+    "id": "tymt9n04zgry",
+    "name": "Claude",
+    "url": "https://status.claude.com",
+    "updated_at": "2026-05-13T11:30:00.000Z"
+  },
+  "components": [
+    {
+      "id": "rwppv331jlwc",
+      "name": "claude.ai",
+      "status": "operational",
+      "position": 1,
+      "updated_at": "2026-05-13T11:30:00.000Z"
+    },
+    {
+      "id": "cmpconsole01",
+      "name": "Claude Console",
+      "status": "operational",
+      "position": 2,
+      "updated_at": "2026-05-13T11:30:00.000Z"
+    },
+    {
+      "id": "cmpapi00001",
+      "name": "Claude API",
+      "status": "degraded_performance",
+      "position": 3,
+      "updated_at": "2026-05-13T11:30:00.000Z"
+    },
+    {
+      "id": "cmpcode0001",
+      "name": "Claude Code",
+      "status": "operational",
+      "position": 4,
+      "updated_at": "2026-05-13T11:30:00.000Z"
+    },
+    {
+      "id": "cmpcowork01",
+      "name": "Cowork",
+      "status": "operational",
+      "position": 5,
+      "updated_at": "2026-05-13T11:30:00.000Z"
+    },
+    {
+      "id": "cmpgov00001",
+      "name": "Government",
+      "status": "operational",
+      "position": 6,
+      "updated_at": "2026-05-13T11:30:00.000Z"
+    }
+  ],
+  "incidents": [],
+  "scheduled_maintenances": [],
+  "status": { "indicator": "minor", "description": "Partially Degraded Service" }
+}

--- a/tests/fixtures/claudeStatus/summary-incident.json
+++ b/tests/fixtures/claudeStatus/summary-incident.json
@@ -1,0 +1,88 @@
+{
+  "page": {
+    "id": "tymt9n04zgry",
+    "name": "Claude",
+    "url": "https://status.claude.com",
+    "updated_at": "2026-05-13T13:23:00.000Z"
+  },
+  "components": [
+    {
+      "id": "rwppv331jlwc",
+      "name": "claude.ai",
+      "status": "degraded_performance",
+      "position": 1,
+      "updated_at": "2026-05-13T12:59:41.000Z"
+    },
+    {
+      "id": "cmpconsole01",
+      "name": "Claude Console",
+      "status": "operational",
+      "position": 2,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpapi00001",
+      "name": "Claude API",
+      "status": "major_outage",
+      "position": 3,
+      "updated_at": "2026-05-13T12:59:41.000Z"
+    },
+    {
+      "id": "cmpcode0001",
+      "name": "Claude Code",
+      "status": "partial_outage",
+      "position": 4,
+      "updated_at": "2026-05-13T12:59:41.000Z"
+    },
+    {
+      "id": "cmpcowork01",
+      "name": "Cowork",
+      "status": "operational",
+      "position": 5,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpgov00001",
+      "name": "Government",
+      "status": "operational",
+      "position": 6,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    }
+  ],
+  "incidents": [
+    {
+      "id": "yn24rtdnf77b",
+      "name": "Claude.ai is experiencing elevated error rates",
+      "status": "investigating",
+      "impact": "major",
+      "shortlink": "https://status.claude.com/incidents/yn24rtdnf77b",
+      "started_at": "2026-05-13T12:21:57.626Z",
+      "created_at": "2026-05-13T12:21:57.633Z",
+      "updated_at": "2026-05-13T12:59:41.257Z",
+      "resolved_at": null,
+      "incident_updates": [
+        {
+          "id": "77js7v1drnwf",
+          "status": "investigating",
+          "body": "We are continuing to investigate this issue. Engineers are looking into elevated error rates affecting the API and Claude Code.",
+          "display_at": "2026-05-13T12:59:41.254Z",
+          "affected_components": [
+            { "code": "cmpapi00001", "name": "Claude API", "old_status": "operational", "new_status": "major_outage" },
+            { "code": "cmpcode0001", "name": "Claude Code", "old_status": "operational", "new_status": "partial_outage" }
+          ]
+        },
+        {
+          "id": "earlierupd0",
+          "status": "investigating",
+          "body": "We are investigating reports of elevated error rates on the Claude API.",
+          "display_at": "2026-05-13T12:21:57.633Z",
+          "affected_components": [
+            { "code": "cmpapi00001", "name": "Claude API", "old_status": "operational", "new_status": "major_outage" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scheduled_maintenances": [],
+  "status": { "indicator": "major", "description": "Major Service Outage" }
+}

--- a/tests/fixtures/claudeStatus/summary-resolved.json
+++ b/tests/fixtures/claudeStatus/summary-resolved.json
@@ -1,0 +1,79 @@
+{
+  "page": {
+    "id": "tymt9n04zgry",
+    "name": "Claude",
+    "url": "https://status.claude.com",
+    "updated_at": "2026-05-13T14:10:00.000Z"
+  },
+  "components": [
+    {
+      "id": "rwppv331jlwc",
+      "name": "claude.ai",
+      "status": "operational",
+      "position": 1,
+      "updated_at": "2026-05-13T14:05:00.000Z"
+    },
+    {
+      "id": "cmpconsole01",
+      "name": "Claude Console",
+      "status": "operational",
+      "position": 2,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpapi00001",
+      "name": "Claude API",
+      "status": "operational",
+      "position": 3,
+      "updated_at": "2026-05-13T14:05:00.000Z"
+    },
+    {
+      "id": "cmpcode0001",
+      "name": "Claude Code",
+      "status": "operational",
+      "position": 4,
+      "updated_at": "2026-05-13T14:05:00.000Z"
+    },
+    {
+      "id": "cmpcowork01",
+      "name": "Cowork",
+      "status": "operational",
+      "position": 5,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    },
+    {
+      "id": "cmpgov00001",
+      "name": "Government",
+      "status": "operational",
+      "position": 6,
+      "updated_at": "2026-05-13T10:00:00.000Z"
+    }
+  ],
+  "incidents": [
+    {
+      "id": "yn24rtdnf77b",
+      "name": "Claude.ai is experiencing elevated error rates",
+      "status": "resolved",
+      "impact": "major",
+      "shortlink": "https://status.claude.com/incidents/yn24rtdnf77b",
+      "started_at": "2026-05-13T12:21:57.626Z",
+      "created_at": "2026-05-13T12:21:57.633Z",
+      "updated_at": "2026-05-13T14:05:00.000Z",
+      "resolved_at": "2026-05-13T14:05:00.000Z",
+      "incident_updates": [
+        {
+          "id": "resolvedupd",
+          "status": "resolved",
+          "body": "This incident has been resolved. All systems are operating normally.",
+          "display_at": "2026-05-13T14:05:00.000Z",
+          "affected_components": [
+            { "code": "cmpapi00001", "name": "Claude API", "old_status": "major_outage", "new_status": "operational" },
+            { "code": "cmpcode0001", "name": "Claude Code", "old_status": "partial_outage", "new_status": "operational" }
+          ]
+        }
+      ]
+    }
+  ],
+  "scheduled_maintenances": [],
+  "status": { "indicator": "none", "description": "All Systems Operational" }
+}


### PR DESCRIPTION
## Summary

- Polls `status.claude.com/api/v2/summary.json` and surfaces active Claude incidents as a sticky banner below the topbar on every route, plus toast notifications on incident transitions (new / status change / resolved).
- New REST endpoints `GET /api/claude-status` and `GET /api/claude-status/changes?since=ISO8601`, plus MCP tool `get-claude-status` so a Claude agent connected to Project Minder's MCP server can self-diagnose whether an API failure is upstream.
- Gated behind a new `claudeStatusAlerts` feature flag (default-on). Cache singleton at `src/lib/claudeStatus/cache.ts` mirrors the file-cache + promise-singleton pattern from `costCalculator.ts`; 30s memory TTL, 30min stale tolerance, exponential backoff to 8min, disk cache at `.cache/claude-status.json`. 33 new tests across 3 test files; full suite 2385 passing.

## Test plan

- [ ] Flag on (default): `curl http://localhost:4100/api/claude-status` returns `overall: "operational"` and `incidents: []` on a clear day.
- [ ] Flag on: `curl 'http://localhost:4100/api/claude-status/changes?since=2026-01-01T00:00:00Z'` returns `[]` or recent transitions.
- [ ] Toggle Settings → Active Features → "Claude status alerts" off, reload dashboard, then `curl /api/claude-status` returns `{"disabled": true}` and banner is hidden everywhere.
- [ ] Simulate incident: stop dev server, copy `tests/fixtures/claudeStatus/summary-incident.json` over `.cache/claude-status.json`, block `status.claude.com` via hosts file, restart. Expect: red banner across all routes + one toast on first 60s poll cycle.
- [ ] Simulate transition: edit the cached fixture to flip `status` from `investigating` to `monitoring`, touch mtime, wait 60s. Expect: "Claude incident updated" toast.
- [ ] Stale path: kill internet, reload. Expect: banner persists with last good data + subtle "Last checked Xm ago" footnote; no toast loop.
- [ ] MCP: call `mcp__project-minder__get-claude-status` from Claude Desktop. Expect: trimmed snapshot matching `/api/claude-status` with `source` field.
- [ ] `npm run typecheck` clean; `npm test` reports 2385 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)