### PR TITLE
docs: correct stale "No database" claim; add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Project Minder — local runtime overrides.
+# Copy to .env.local (gitignored) and uncomment any you want to change.
+# All four are behavior toggles / paths — there are no secrets in this file.
+
+# Disable the SQLite index; session pages fall back to direct JSONL parsing.
+# Default: on. Set to 0 to disable.
+# MINDER_USE_DB=0
+
+# Suppress the chokidar watcher (no automatic index updates).
+# Default: on. Set to 0 to disable.
+# MINDER_INDEXER=0
+
+# Host the indexer watcher in a worker_thread for crash isolation.
+# Default: off. Set to 1 to enable.
+# MINDER_INDEXER_WORKER=1
+
+# Override the Gemini CLI data directory (default: ~/.gemini).
+# GEMINI_HOME=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ Project: **Project Minder** — local-only dashboard that auto-scans `C:\dev\*` 
 
 - **Next.js 16** (App Router) + TypeScript + React 19
 - **Tailwind CSS v4** + hand-rolled shadcn-style components (no shadcn CLI)
-- **No database** — filesystem is the database; user prefs in `.minder.json`
+- **SQLite index** (`better-sqlite3`, optional dep) at `~/.minder/index.db` — the
+  filesystem remains the source of truth; the DB is a derived, rebuildable index.
+  User prefs live in `.minder.json`. Set `MINDER_USE_DB=0` to disable the DB and fall
+  back to direct JSONL parsing.
 - **Dev port: 4100** — Turbopack is the default bundler in Next.js 16
 
 ## Commands
@@ -115,6 +118,16 @@ This project uses **pnpm** (pinned via the `packageManager` field; CI runs `pnpm
 - Skills: `SkillsBrowser` at `/skills` — same shape for skills. `ProjectSkillsTab` per-project. Supports bundled (`SKILL.md`-in-dir) and standalone `.md` layouts.
 - `DevServerControl` — compact mode on cards (start/stop badge), full mode on detail page (start/stop/restart, open in browser, output viewer)
 - Hand-rolled UI primitives in `src/components/ui/` (badge, button, input, tabs, skeleton, toast)
+
+### Database (`src/lib/db/`, `src/lib/data/`)
+- SQLite index at `~/.minder/index.db` via `better-sqlite3` (optional dependency;
+  `connection.ts` wraps the `require` in try/catch and degrades gracefully if absent).
+- `ingest.ts` writes sessions/turns/tool-uses; `migrations.ts` versions the schema;
+  `maintenance.ts` handles pruning/vacuum; `otelQueries.ts` serves OTEL telemetry reads.
+- FTS5 (`prompts_fts`) backs session prompt search.
+- `src/lib/data/*FromDb.ts` are the DB-backed query modules; routes should obtain init
+  status via `probeInitStatus()` from `@/lib/data` rather than calling `initDb()` directly.
+- Backend selection: `MINDER_USE_DB` (default on; `=0` forces the direct-JSONL path).
 
 ## Known Limitations / Technical Debt
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ All settings live in `.minder.json` at the repo root. The in-app **Config page**
 
 ### Environment overrides
 
+Copy `.env.example` to `.env.local` and uncomment what you need.
+
 Set in `.env.local` (gitignored) for persistent per-machine overrides:
 
 | Variable | Default | Effect |


### PR DESCRIPTION
## What

Implements **Plan 002** from the `/improve` audit (commit `2edf991`).

- **CLAUDE.md** — replaces the false `**No database** — filesystem is the database` Stack bullet with an accurate description of the SQLite index (`better-sqlite3`, optional dep, derived/rebuildable, `~/.minder/index.db`), and adds a `### Database` subsection under Architecture covering `src/lib/db/`, `src/lib/data/`, FTS5, and the `MINDER_USE_DB` backend toggle.
- **.env.example** — new file documenting all four runtime env vars (`MINDER_USE_DB`, `MINDER_INDEXER`, `MINDER_INDEXER_WORKER`, `GEMINI_HOME`) as commented defaults. No secrets.
- **README.md** — one-line pointer to copy `.env.example` → `.env.local`.

## Why

`CLAUDE.md` is the orientation file every agent/contributor session loads, and its "No database" claim was actively false — the project has a substantial SQLite layer (`src/lib/db/` ingest/migrations/FTS5/maintenance, `src/lib/data/*FromDb.ts`). Actively-wrong docs are worse than missing ones. Separately, four env vars were documented in the README with no `.env.example` template to copy.

## Scope

Docs + dotfile only — **zero** `src/` / `tests/` changes.

## Verification

- `grep "No database" CLAUDE.md` → no matches
- `.env.example` present, not gitignored, all four vars
- Pre-commit hook ran clean: typecheck + full suite (2,727 tests passed)

No CHANGELOG entry — docs-only change with no UI/API/process behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)