### PR TITLE
perf(scanner): reuse project catalog walk in runCatalogLint

### DIFF
--- a/src/lib/scanner/catalogLint.ts
+++ b/src/lib/scanner/catalogLint.ts
@@ -11,6 +11,7 @@ import {
 import type { ProvenanceContext } from "../indexer/types";
 import { getUserConfig } from "../userConfigCache";
 import { runGlobalLint } from "../lint/engine";
+import type { ProjectCatalogWalk } from "./index";
 
 /**
  * One-shot global catalog lint — runs once per scan after all projects resolve.
@@ -29,6 +30,7 @@ export async function runCatalogLint(
   projects: ProjectData[],
   flags: MinderConfig["featureFlags"],
   ctx: ProvenanceContext,
+  catalogWalkBySlug?: Map<string, ProjectCatalogWalk>,
 ): Promise<LintFinding[]> {
   if (!getFlag(flags, "configLint")) return [];
 
@@ -40,8 +42,12 @@ export async function runCatalogLint(
 
     // Walk project-scope agents/skills from the fresh scan instead of relying
     // on the stale getCachedScan() snapshot that loadCatalog(includeProjects:true) uses.
+    // When the side-channel map is present, reuse entries already computed by
+    // scanProject — avoids ~60 redundant traversals on a full scan.
     const projectEntryResults = await Promise.all(
       projects.map(async (p) => {
+        const pre = catalogWalkBySlug?.get(p.slug);
+        if (pre) return { skills: pre.skills, agents: pre.agents };
         const [pSkills, pAgents] = await Promise.all([
           walkProjectSkills(p.path, p.slug, ctx),
           walkProjectAgents(p.path, p.slug, ctx),
@@ -50,11 +56,17 @@ export async function runCatalogLint(
       })
     );
 
-    // Walk commands across all scopes (loadCatalog doesn't cover commands)
-    const [userCommands, pluginCommands, ...projectCommandSets] = await Promise.all([
+    // Walk commands across all scopes (loadCatalog doesn't cover commands).
+    // Project-scope commands also reuse the side-channel map when available.
+    const projectCommandSets = await Promise.all(
+      projects.map((p) => {
+        const pre = catalogWalkBySlug?.get(p.slug);
+        return pre ? Promise.resolve(pre.commands) : walkProjectCommands(p.path, p.slug, ctx);
+      })
+    );
+    const [userCommands, pluginCommands] = await Promise.all([
       walkUserCommands(ctx),
       walkPluginCommands(ctx.installedPlugins, ctx),
-      ...projects.map((p) => walkProjectCommands(p.path, p.slug, ctx)),
     ]);
     const allCommands = [userCommands, pluginCommands, ...projectCommandSets].flat();
 

--- a/src/lib/scanner/catalogLint.ts
+++ b/src/lib/scanner/catalogLint.ts
@@ -30,7 +30,7 @@ export async function runCatalogLint(
   projects: ProjectData[],
   flags: MinderConfig["featureFlags"],
   ctx: ProvenanceContext,
-  catalogWalkBySlug?: Map<string, ProjectCatalogWalk>,
+  catalogWalkByPath?: Map<string, ProjectCatalogWalk>,
 ): Promise<LintFinding[]> {
   if (!getFlag(flags, "configLint")) return [];
 
@@ -43,10 +43,10 @@ export async function runCatalogLint(
     // Walk project-scope agents/skills from the fresh scan instead of relying
     // on the stale getCachedScan() snapshot that loadCatalog(includeProjects:true) uses.
     // When the side-channel map is present, reuse entries already computed by
-    // scanProject — avoids ~60 redundant traversals on a full scan.
+    // scanProject — avoids ~180 redundant traversals (3 catalog subdirs × ~60 projects).
     const projectEntryResults = await Promise.all(
       projects.map(async (p) => {
-        const pre = catalogWalkBySlug?.get(p.slug);
+        const pre = catalogWalkByPath?.get(p.path);
         if (pre) return { skills: pre.skills, agents: pre.agents };
         const [pSkills, pAgents] = await Promise.all([
           walkProjectSkills(p.path, p.slug, ctx),
@@ -56,17 +56,15 @@ export async function runCatalogLint(
       })
     );
 
-    // Walk commands across all scopes (loadCatalog doesn't cover commands).
-    // Project-scope commands also reuse the side-channel map when available.
-    const projectCommandSets = await Promise.all(
-      projects.map((p) => {
-        const pre = catalogWalkBySlug?.get(p.slug);
-        return pre ? Promise.resolve(pre.commands) : walkProjectCommands(p.path, p.slug, ctx);
-      })
-    );
-    const [userCommands, pluginCommands] = await Promise.all([
+    // Walk user + plugin command scopes concurrently with project-scope commands.
+    // Project-scope commands reuse the side-channel map when available.
+    const [userCommands, pluginCommands, ...projectCommandSets] = await Promise.all([
       walkUserCommands(ctx),
       walkPluginCommands(ctx.installedPlugins, ctx),
+      ...projects.map((p) => {
+        const pre = catalogWalkByPath?.get(p.path);
+        return pre ? Promise.resolve(pre.commands) : walkProjectCommands(p.path, p.slug, ctx);
+      }),
     ]);
     const allCommands = [userCommands, pluginCommands, ...projectCommandSets].flat();
 

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -27,7 +27,17 @@ import { walkProjectAgents } from "../indexer/walkAgents";
 import { walkProjectSkills } from "../indexer/walkSkills";
 import { walkProjectCommands } from "../indexer/walkCommands";
 import { loadProvenanceContext } from "../indexer/provenance";
-import type { ProvenanceContext } from "../indexer/types";
+import type { ProvenanceContext, SkillEntry, AgentEntry } from "../indexer/types";
+import type { CommandEntry } from "../types";
+
+/** Side-channel payload carrying the entries walkProject* already computed
+ *  inside scanProject — threaded into runCatalogLint so it can skip the
+ *  redundant per-project re-walks (~60 traversals on a full scan). */
+export interface ProjectCatalogWalk {
+  skills: SkillEntry[];
+  agents: AgentEntry[];
+  commands: CommandEntry[];
+}
 
 // Neutral substitutes typed against the real scanner returns so downstream
 // code reads the same shape whether the scanner ran or was gated off.
@@ -68,7 +78,7 @@ async function scanProject(
   devRoot: string,
   flags: MinderConfig["featureFlags"],
   ctx: ProvenanceContext,
-): Promise<ProjectData | null> {
+): Promise<{ project: ProjectData; catalogWalk: ProjectCatalogWalk | null } | null> {
   const projectPath = path.join(devRoot, dirName);
 
   if (!(await isGitRepo(projectPath))) return null;
@@ -87,15 +97,27 @@ async function scanProject(
   // config-lint chain share the same promises (no double-scan).
   const mcpServersPromise = scanMcpServers(projectPath);
   const hooksPromise = scanClaudeHooks(projectPath);
+  // Hoist the three project catalog walks so both configLintPromise and the
+  // side-channel catalogWalk share the same promises (no double-scan in runCatalogLint).
+  const catalogLintEnabled = getFlag(flags, "configLint");
+  const skillsPromise = catalogLintEnabled
+    ? walkProjectSkills(projectPath, slug, ctx)
+    : Promise.resolve([] as SkillEntry[]);
+  const agentsPromise = catalogLintEnabled
+    ? walkProjectAgents(projectPath, slug, ctx)
+    : Promise.resolve([] as AgentEntry[]);
+  const commandsPromise = catalogLintEnabled
+    ? walkProjectCommands(projectPath, slug, ctx)
+    : Promise.resolve([] as CommandEntry[]);
   // Config lint chains off audit + mcpServers + hooks + project catalog.
-  const configLintPromise = getFlag(flags, "configLint")
+  const configLintPromise = catalogLintEnabled
     ? Promise.all([
         claudeMdAuditPromise,
         mcpServersPromise,
         hooksPromise,
-        walkProjectSkills(projectPath, slug, ctx),
-        walkProjectAgents(projectPath, slug, ctx),
-        walkProjectCommands(projectPath, slug, ctx),
+        skillsPromise,
+        agentsPromise,
+        commandsPromise,
       ]).then(([audit, mcp, hooksInfo, skills, agents, commands]) =>
         runConfigLint(projectPath, {
           claudeMdAudit: audit,
@@ -127,6 +149,9 @@ async function scanProject(
     catalogCounts,
     gsdPlanning,
     configLint,
+    skillsResult,
+    agentsResult,
+    commandsResult,
   ] = await Promise.all([
     scanPackageJson(projectPath),
     scanEnvFiles(projectPath),
@@ -158,6 +183,9 @@ async function scanProject(
       ? scanGsdPlanning(projectPath)
       : Promise.resolve(undefined),
     configLintPromise,
+    skillsPromise,
+    agentsPromise,
+    commandsPromise,
   ]);
 
   // Determine DB port from env or docker
@@ -180,7 +208,7 @@ async function scanProject(
     ? dates.sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0]
     : undefined;
 
-  return {
+  const project: ProjectData = {
     slug,
     name: pkgResult.name || dirName,
     path: projectPath,
@@ -221,6 +249,10 @@ async function scanProject(
     lastActivity,
     scannedAt: new Date().toISOString(),
   };
+  const catalogWalk: ProjectCatalogWalk | null = catalogLintEnabled
+    ? { skills: skillsResult, agents: agentsResult, commands: commandsResult }
+    : null;
+  return { project, catalogWalk };
 }
 
 function detectPortConflicts(projects: ProjectData[]): PortConflict[] {
@@ -265,6 +297,9 @@ export async function scanAllProjects(): Promise<ScanResult> {
     : ({} as Awaited<ReturnType<typeof loadProvenanceContext>>);
 
   const allProjects: ProjectData[] = [];
+  // Side-channel map: slug → catalog walk entries already computed by scanProject.
+  // Passed to runCatalogLint so it can skip redundant per-project re-walks.
+  const catalogWalkBySlug = new Map<string, ProjectCatalogWalk>();
   // Track slugs seen so far to handle collisions across roots (first root wins)
   const seenSlugs = new Set<string>();
 
@@ -301,8 +336,9 @@ export async function scanAllProjects(): Promise<ScanResult> {
       const results = await Promise.all(batch.map((d) => scanProject(d, devRoot, flags, ctx)));
       for (const r of results) {
         if (r) {
-          rootProjects.push(r);
-          seenSlugs.add(r.slug);
+          rootProjects.push(r.project);
+          seenSlugs.add(r.project.slug);
+          if (r.catalogWalk) catalogWalkBySlug.set(r.project.slug, r.catalogWalk);
         }
       }
     }
@@ -332,7 +368,7 @@ export async function scanAllProjects(): Promise<ScanResult> {
   });
 
   const portConflicts = detectPortConflicts(allProjects);
-  const catalogLintFindings = await runCatalogLint(allProjects, flags, ctx);
+  const catalogLintFindings = await runCatalogLint(allProjects, flags, ctx, catalogWalkBySlug);
 
   return {
     projects: allProjects,

--- a/src/lib/scanner/index.ts
+++ b/src/lib/scanner/index.ts
@@ -32,7 +32,7 @@ import type { CommandEntry } from "../types";
 
 /** Side-channel payload carrying the entries walkProject* already computed
  *  inside scanProject — threaded into runCatalogLint so it can skip the
- *  redundant per-project re-walks (~60 traversals on a full scan). */
+ *  redundant per-project re-walks (~180 traversals on a full scan: 3 catalog subdirs × ~60 projects). */
 export interface ProjectCatalogWalk {
   skills: SkillEntry[];
   agents: AgentEntry[];
@@ -297,9 +297,9 @@ export async function scanAllProjects(): Promise<ScanResult> {
     : ({} as Awaited<ReturnType<typeof loadProvenanceContext>>);
 
   const allProjects: ProjectData[] = [];
-  // Side-channel map: slug → catalog walk entries already computed by scanProject.
+  // Side-channel map: path → catalog walk entries already computed by scanProject.
   // Passed to runCatalogLint so it can skip redundant per-project re-walks.
-  const catalogWalkBySlug = new Map<string, ProjectCatalogWalk>();
+  const catalogWalkByPath = new Map<string, ProjectCatalogWalk>();
   // Track slugs seen so far to handle collisions across roots (first root wins)
   const seenSlugs = new Set<string>();
 
@@ -338,7 +338,7 @@ export async function scanAllProjects(): Promise<ScanResult> {
         if (r) {
           rootProjects.push(r.project);
           seenSlugs.add(r.project.slug);
-          if (r.catalogWalk) catalogWalkBySlug.set(r.project.slug, r.catalogWalk);
+          if (r.catalogWalk) catalogWalkByPath.set(r.project.path, r.catalogWalk);
         }
       }
     }
@@ -368,7 +368,7 @@ export async function scanAllProjects(): Promise<ScanResult> {
   });
 
   const portConflicts = detectPortConflicts(allProjects);
-  const catalogLintFindings = await runCatalogLint(allProjects, flags, ctx, catalogWalkBySlug);
+  const catalogLintFindings = await runCatalogLint(allProjects, flags, ctx, catalogWalkByPath);
 
   return {
     projects: allProjects,

--- a/tests/scannerCatalogLint.test.ts
+++ b/tests/scannerCatalogLint.test.ts
@@ -133,4 +133,31 @@ describe("runCatalogLint", () => {
     const findings = await runCatalogLint(PROJECTS, FLAGS_ON, EMPTY_CTX);
     expect(findings.some((f) => f.code === "agent/missing-description")).toBe(true);
   });
+
+  it("uses side-channel map — skips walkProjectSkills/Agents/Commands when slug is present", async () => {
+    stubMocks();
+    const walk = new Map([
+      ["a", { skills: [makeSkill()], agents: [makeAgent()], commands: [] }],
+    ]);
+    const project = { slug: "a", path: "/x/a" } as unknown as ProjectData;
+    await runCatalogLint([project], FLAGS_ON, EMPTY_CTX, walk);
+    expect(vi.mocked(walkProjectSkills)).not.toHaveBeenCalled();
+    expect(vi.mocked(walkProjectAgents)).not.toHaveBeenCalled();
+    expect(vi.mocked(walkProjectCommands)).not.toHaveBeenCalled();
+    // User/plugin command walks should still run
+    expect(vi.mocked(walkUserCommands)).toHaveBeenCalled();
+    expect(vi.mocked(walkPluginCommands)).toHaveBeenCalled();
+  });
+
+  it("falls back to walkProjectSkills/Agents/Commands when map is omitted", async () => {
+    stubMocks();
+    vi.mocked(walkProjectSkills).mockResolvedValue([]);
+    vi.mocked(walkProjectAgents).mockResolvedValue([]);
+    vi.mocked(walkProjectCommands).mockResolvedValue([]);
+    const project = { slug: "b", path: "/x/b" } as unknown as ProjectData;
+    await runCatalogLint([project], FLAGS_ON, EMPTY_CTX);
+    expect(vi.mocked(walkProjectSkills)).toHaveBeenCalledOnce();
+    expect(vi.mocked(walkProjectAgents)).toHaveBeenCalledOnce();
+    expect(vi.mocked(walkProjectCommands)).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/scannerCatalogLint.test.ts
+++ b/tests/scannerCatalogLint.test.ts
@@ -137,7 +137,7 @@ describe("runCatalogLint", () => {
   it("uses side-channel map — skips walkProjectSkills/Agents/Commands when slug is present", async () => {
     stubMocks();
     const walk = new Map([
-      ["a", { skills: [makeSkill()], agents: [makeAgent()], commands: [] }],
+      ["/x/a", { skills: [makeSkill()], agents: [makeAgent()], commands: [] }],
     ]);
     const project = { slug: "a", path: "/x/a" } as unknown as ProjectData;
     await runCatalogLint([project], FLAGS_ON, EMPTY_CTX, walk);


### PR DESCRIPTION
## What

Implements **Plan 001** from the `/improve` audit (commit `d6e14ac`).

Eliminates a redundant per-project filesystem walk on every scan. `scanProject` already walks each project's `.claude/{skills,agents,commands}` to feed per-project config-lint; `runCatalogLint` then walked all three **again** for every project to do cross-scope duplicate-name detection.

`scanProject` now surfaces those already-computed entries via a side-channel `Map<slug, ProjectCatalogWalk>`, which `scanAllProjects` passes to `runCatalogLint`. The lint reuses the map and falls back to walking only when a slug is absent (defensive, for any future caller that doesn't supply the map). The non-redundant `walkUserCommands` / `walkPluginCommands` calls are unchanged.

## Why

On a ~61-project scan this removes ~180 redundant directory traversals (3 subdirs × ~60 projects), serialized after the parallel batch — a contributor to pre-commit test-suite timeouts (tracked in `TODO.md`).

## Design note

The walk entries are threaded via a side-channel Map, **not** added to `ProjectData` — `ProjectData` is serialized wholesale to the client in `/api/projects`, so attaching the entries would bloat every dashboard response. `ProjectData`'s shape is unchanged (`git diff src/lib/types.ts` is empty).

## Scope

`src/lib/scanner/index.ts`, `src/lib/scanner/catalogLint.ts`, `tests/scannerCatalogLint.test.ts` (+88/−13).

## Verification

- `pnpm typecheck` → exit 0
- `pnpm lint` → exit 0 (0 errors)
- `pnpm test` → all pass; two new cases in `tests/scannerCatalogLint.test.ts` assert the project-scope walkers are called **0×** when the map is supplied (and once when it isn't), while user/plugin walks still run
- Pre-commit hook (typecheck + full suite) passed

No CHANGELOG entry — pure internal perf refactor; catalog-lint output is unchanged, only how it's computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)