### PR TITLE
docs: track INSIGHTS.md, convention handoff & PRODUCT.md; ignore local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,8 @@ workers/dist/
 # bundled MCP server artifact (built fresh via scripts/build-mcp-screenshot.mjs;
 # users run `npm run build:mcp-screenshot` once before `claude mcp add`)
 dist/
+
+# local agent/lint caches + throwaway session screenshots (not committed)
+.agents/
+.claudelint-cache/
+/t2.1-*.png

--- a/INSIGHTS.md
+++ b/INSIGHTS.md
@@ -1,5 +1,55 @@
 # Insights
 
+<!-- insight:e97bc79c0aae | session:6ecd3b9f-3e2f-48e6-aafa-7e0059bd3c9d | 2026-05-31T15:32:44.945Z -->
+## ★ Insight
+**ESLint flat config doesn't honor `.gitignore`.** All 23 errors live in `.design-fetch/claudoscope/*.jsx` and `agentlytics-repo/ui/src/**/*.jsx` — both confirmed **git-ignored** (`git check-ignore` matched them) and **untracked** (`git ls-files` empty). They're stray sibling-project directories sitting in my working tree that eslint happily lints locally but which **don't exist in CI's clean checkout**.
+
+---
+
+<!-- insight:edfe45c51a48 | session:6ecd3b9f-3e2f-48e6-aafa-7e0059bd3c9d | 2026-05-31T15:26:48.354Z -->
+## ★ Insight
+One deliberate inconsistency to flag: the README now says Diagnosis is **11-category** (stuck-loop added), but the landing site still reads "scored across **ten** quality dimensions." The site agent intentionally omitted stuck-loop (no standalone screenshot, and it judged the concept already implied by the existing compaction-loop/retry-cycle copy). The site's sentence stays internally consistent (it lists exactly ten and says "ten"). I'll leave it — a landing page saying "across N dimensions" loosely is fine, and the developer-facing README carries the precise count.
+
+---
+
+<!-- insight:6def342c0eb7 | session:6ecd3b9f-3e2f-48e6-aafa-7e0059bd3c9d | 2026-05-31T15:25:57.546Z -->
+## ★ Insight
+Note the diff stat includes `tsconfig.json | 3 +-` — that's the **pre-existing** unrelated modification from before this session (it was `M tsconfig.json` in the opening git status, and the CRLF warning confirms it). When I stage, I'll name the four release files explicitly and **never** `git add -A`, so that stray change (and the untracked PNGs/`.agents/`/`PRODUCT.md`) stay out of the release commit.
+
+---
+
+<!-- insight:b183d9856ee0 | session:6ecd3b9f-3e2f-48e6-aafa-7e0059bd3c9d | 2026-05-31T15:08:04.098Z -->
+## ★ Insight
+**Squash-merge creates a brand-new commit on `main`** that exists on neither the feature branch nor my local `main`. Tagging the branch tip would point `v1.1.0` at a tree that isn't in main's history — `release.yml` would then build the wrong commit. Correct order: merge → `git checkout main && git pull` → tag the pulled squash commit → verify tag SHA == merge SHA → push.
+
+---
+
+<!-- insight:cce1c406d9b3 | session:6ecd3b9f-3e2f-48e6-aafa-7e0059bd3c9d | 2026-05-31T15:01:27.170Z -->
+## ★ Insight
+**The release pipeline is fully automation-driven** — two GitHub Actions do the heavy lifting:
+- `release.yml` fires on any `v*` tag push: it runs lint → typecheck → test → build, then `gh release create --generate-notes`. So **tagging *is* releasing** — pushing the tag is the irreversible, outward-facing step.
+- `gh-pages-publish.yml` mirrors `site/**` from `main` into the `gh-pages` branch on every push. So "updating GitHub Pages" means **editing `site/index.html` and merging to main** — the publish is automatic.
+
+---
+
+<!-- insight:ed968bd0e3b2 | session:be527506-0f1f-4778-a194-67903a9373c5 | 2026-05-31T02:42:14.489Z -->
+## ★ Insight
+**1. Backup seam confirmed (not a guess):** `apply.ts:38` imports `recordPreWrite`/`removeBackup`. The real pattern is **snapshot-before-write** (line 80, `recordPreWrite(f, {projectSlug, label})`) + **cleanup-on-no-op** (line 123, `removeBackup` when the apply didn't actually touch disk). The TODO's "after each successful write" wording was imprecise. This is a clean, harness-generic seam I can mirror for Codex.
+
+---
+
+<!-- insight:0103adf35cb2 | session:be527506-0f1f-4778-a194-67903a9373c5 | 2026-05-31T02:39:10.761Z -->
+## ★ Insight
+**The sharp design tension I found:** The read path is deliberately *lossy for security* — `readConfig()` runs `redactConfig()` so the browser **never receives real secret values** (the Neon bearer token in `config.toml` comes back as `<redacted>`). That's a great property to preserve, but it makes naïve write/manage dangerous: if the UI edits the rendered tree and POSTs it back, we'd write `<redacted>` *over* the user's real secrets and destroy them. So whole-object write is off the table — writes must be **targeted key-path patches applied to the raw on-disk file**, never a round-trip of the redacted object.
+
+---
+
+<!-- insight:bfacd53e8e6e | session:be527506-0f1f-4778-a194-67903a9373c5 | 2026-05-31T02:34:17.376Z -->
+## ★ Insight
+**Why explore before planning here:** This wave extends three *existing* subsystems rather than building greenfield. The read-only Codex surface (#193) already established the redaction contract ("parse → redact the object → render"), the Claude side already has a Copy-on-Write backup layer (`configHistory.ts`) and an MCP security scanner. The design risk isn't "can we build it" — it's "do we reuse the Claude machinery generically, or fork it per-harness." That decision needs an accurate map of what's already abstracted vs. Claude-specific.
+
+---
+
 <!-- insight:addbc35b7b93 | session:a9419f83-ca4e-4c74-9e7a-ffed0b9e1de2 | 2026-05-30T15:16:19.891Z -->
 ## ★ Insight
 The version mechanism here is the **"schema.sql IS migration v1"** pattern: a fresh DB runs the complete current schema as migration 1, then migrations 2…N (idempotent `IF NOT EXISTS` / guarded `ALTER`) replay as no-ops above it. This means every new table must be added in **two** places that must stay byte-identical in intent — schema.sql (plain DDL, for fresh installs) and a versioned migration (`IF NOT EXISTS`, for existing installs) — or fresh and upgraded DBs silently diverge. The advisor's "delete a scratch index.db and confirm v16 applies on both fresh and existing" is precisely the test that catches a divergence unit tests can't.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,24 @@
+## Design Context
+
+### Users
+Solo developer (the tool's creator). Used throughout the workday and evening at a desktop, switching between 60+ active local projects. The primary job: instantly locate a project, assess its state, and act — start a dev server, check git status, jump to a session, review todos. Speed and scannability are the core product values.
+
+### Brand Personality
+**Fast, dense, surgical.** Like a well-designed flight management computer or a network operations center wallboard — not the flashy sci-fi movie version, but the real operational kind. Data-forward, no decorative noise. Every element either communicates something or gets cut.
+
+### Aesthetic Direction
+- **Dark mode** — confirmed, correct for a dev tool used at all hours
+- **NOT Tron** — no electric cyan, no neon glow, no laser-grid textures
+- **NOT AI aesthetic** — no purple-to-blue gradients, no frosted glass everywhere
+- **NOT boring** — not generic shadcn defaults, not another neutral starter kit
+- Closer to: aircraft glass cockpit, industrial NOC dashboard, well-organized mission briefing. The physical object: a thermal-printed operations status report, or the display face of a precision instrument.
+- Accent color: muted amber/gold (operational, not decorative) — reads as "system status" not "brand color"
+- Background: very dark steel (slightly blue-warm tinted, not pure black)
+- Typography: condensed grotesque for project names and labels (aerospace label energy), clean precise font for body/data
+
+### Design Principles
+1. **Scannable in one pass** — visual hierarchy must be immediately legible: name → status → key data. No hunting.
+2. **Density without noise** — pack information tightly but use spacing and typographic weight to separate signal from context.
+3. **Operational, not decorative** — every visual treatment should communicate state. Color means something. Size means something. Decoration means nothing.
+4. **Cards as data panels** — project cards are monitoring panels, not marketing tiles. No rounded-corner-icon-heading-text templates.
+5. **The grid is the layout** — consistent, tight grid. Asymmetry used sparingly and intentionally, not as a style reflex.

--- a/docs/manual-steps-todo-rules-handoff.md
+++ b/docs/manual-steps-todo-rules-handoff.md
@@ -1,0 +1,92 @@
+# Handoff for project-minder — MANUAL_STEPS.md / TODO.md rules + hooks
+
+Source repo: `C:\dev\patchmaven` (ContinuanceLabs/patchmaven). Captured 2026-06-26.
+Purpose: standardize the "manual steps / TODO are living checklists, completed work
+gets archived" convention across projects.
+
+---
+
+## 0. TL;DR of what was actually changed in this repo
+
+- **CLAUDE.md** — `## Manual Steps` section reworded from *append-only / never modify*
+  to *living checklist; editing & pruning expected*. (1 doc change.)
+- **No hook files were modified.** Both validators were only read, not edited.
+- **`MANUAL_STEPS.md` content** — 7 pre-existing column-0 descriptive bullets in old
+  migration entries were converted to `- [x]` (so the file became editable), then the
+  Vercel deployment checklist was appended. (Content only, not a rule/hook change.)
+- All committed in PR #170 (commits `a368685`, `8c18db4`) on branch
+  `chore/vercel-deploy-phase0`.
+
+---
+
+## 1. CLAUDE.md change (the only rule edit)
+
+Section: `## Manual Steps`.
+
+### Edit A — intro line
+- BEFORE: `…deploy trigger — append to ` + "`MANUAL_STEPS.md`:"
+- AFTER:  `…deploy trigger — record it in ` + "`MANUAL_STEPS.md`" + `, the living checklist of manual actions the developer still needs to take:`
+
+### Edit B — "Rules:" line replaced with a bulleted block
+BEFORE (single line):
+> Rules: **append only**, never modify existing entries, one header per session/feature, create the file if it doesn't exist, tell the developer what was logged after appending.
+
+AFTER:
+> Rules:
+> - **Add** a dated entry (one header per session/feature) for new manual work; create the file if it doesn't exist.
+> - **Keep it current.** Once a step is done, or a newer plan/action makes it obsolete, either check it off (`- [x]`) if it's worth keeping as a record or remove it — so the list shows only what's still outstanding. The file is a to-do list, not an append-only log; editing and pruning prior entries is expected.
+> - Don't remove a step you can't confirm is done or obsolete — surface the uncertainty to the developer instead.
+> - Format (enforced by `.claude/hooks/validate-manual-steps.mjs`): every list item is a `- [ ]` / `- [x]` checkbox, and every dated entry ends with a `---` separator.
+> - After changing the file, tell the developer what you added, checked off, or removed.
+
+NOT changed: the `## TODO List` section of CLAUDE.md still says only "append it to
+`TODO.md`." For a consistent living-checklist philosophy, TODO needs a parallel edit.
+
+---
+
+## 2. Hooks — UNCHANGED. Current behavior (for cross-project replication)
+
+Both are PreToolUse hooks that fire on the **Write and Edit tools only** (not Bash).
+Both key on the **exact filename** → archive files with any other name are exempt.
+
+### `.claude/hooks/validate-manual-steps.mjs`
+Acts only when `tool_input.file_path` is `MANUAL_STEPS.md` (or `*/MANUAL_STEPS.md`).
+For Edit, it reconstructs the full file (`current.replace(old_string, new_string)`)
+and validates EVERY line:
+1. Any line matching `^- ` that is not `---` must match `^- \[[ x]\] ` (checkbox).
+2. Any header matching `^## \d{4}-\d{2}-\d{2}` must match
+   `^## \d{4}-\d{2}-\d{2} \d{2}:\d{2} \| .+ \| .+`  (i.e. `## YYYY-MM-DD HH:MM | slug | title`).
+3. Every dated entry must be closed by a `---` line before the next dated header / EOF.
+Returns `{decision:'block', reason:…}` listing violations, else `{decision:'approve'}`.
+NO append-only / no-deletion enforcement — format only.
+
+### `.claude/hooks/validate-todo-format.mjs`
+Acts only when path is `TODO.md`. Validates full reconstructed content; flags any line
+matching `^- (?!\[[ x]\] )` (a bare `- ` that is not a checkbox). Indented detail lines,
+`#` headings, and blank lines are allowed. Format only.
+
+---
+
+## 3. Implications for an archive design (not yet implemented)
+
+- Name archive files so they DON'T end in `/MANUAL_STEPS.md` or `/TODO.md`
+  (e.g. `MANUAL_STEPS.archive.md`, `TODO.archive.md`) → exempt from the validators,
+  so archived items can keep `[x]`, `~~strikethrough~~`, or any legacy formatting.
+- File shapes differ, which affects how each archives:
+  - `MANUAL_STEPS.md` = dated whole-entry blocks (`## YYYY-MM-DD HH:MM | slug | title`
+    + why-context + checkbox steps + `---`). Archive by moving the whole block.
+  - `TODO.md` = topic sections (`## Topic`) with `**Context:**` blocks and `[x]`
+    items interleaved among `[ ]` items. "Done" work is scattered WITHIN live sections,
+    not standalone blocks — archive by lifting completed items / whole shipped sections.
+- A Bash-tool edit (e.g. `sed`) bypasses the validators if you ever need to fix
+  pre-existing violations that no single Edit can resolve (full-file validation + the
+  edit being non-contiguous).
+
+---
+
+## 4. Deployment context (so this handoff is self-contained)
+
+This rules discussion arose during the PatchMaven → Vercel deployment work.
+Deployment plan: `~/.claude/plans/playful-frolicking-eclipse.md`.
+Open work tracked in the session task list (Phases 1–5) and in the
+`## 2026-06-26 | vercel-deployment` entry now in `MANUAL_STEPS.md`.


### PR DESCRIPTION
Tidies up the working tree left after PR #221 by tracking the docs worth keeping and ignoring the transient artifacts.

## Tracked
- **`INSIGHTS.md`** — the accumulated cross-session insights log (a tracked living log by convention).
- **`docs/manual-steps-todo-rules-handoff.md`** — the handoff that motivated the living-checklist convention; kept as provenance for #221.
- **`PRODUCT.md`** — the dashboard's design-context / brand doc (NOC-wallboard aesthetic, density principles).

## Ignored
- `.gitignore` now excludes local agent/lint caches (`.agents/`, `.claudelint-cache/`) and throwaway session screenshots (`t2.1-*.png`).

Docs/config only — no code changes. typecheck + full suite (2809) pass via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)