### PR TITLE
feat(board): BOARD.md parser, writer & types (Portfolio Command Deck — Phase 1, PR 2)

### DIFF
--- a/src/lib/boardWriter.ts
+++ b/src/lib/boardWriter.ts
@@ -82,6 +82,7 @@ export function backfillIds(content: string): {
   changed: boolean;
 } {
   const ids = collectIds(content);
+  const eol = detectEol(content);
   const lines = content.split(/\r?\n/);
   let changed = false;
   for (let i = 0; i < lines.length; i++) {
@@ -101,7 +102,7 @@ export function backfillIds(content: string): {
       changed = true;
     }
   }
-  return { content: changed ? lines.join("\n") : content, changed };
+  return { content: changed ? lines.join(eol) : content, changed };
 }
 
 // ── Line formatting ────────────────────────────────────────────────────────
@@ -112,10 +113,25 @@ function sanitizeTitle(s: string): string {
   return t;
 }
 
+/**
+ * Normalize a label to the parser's `#([A-Za-z0-9][\w-]*)` grammar so it
+ * round-trips losslessly. Without this, a label like "needs review" serializes
+ * as `#needs review` and reparses as just `needs` (with "review" bleeding into
+ * the title). Characters outside [A-Za-z0-9_-] collapse to a hyphen; the first
+ * character must be alphanumeric. "needs review" → "needs-review".
+ */
+function slugLabel(raw: string): string {
+  return raw
+    .replace(/^#+/, "")
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, "-")
+    .replace(/^[^A-Za-z0-9]+/, "")
+    .replace(/-+/g, "-")
+    .replace(/-+$/, "");
+}
+
 function cleanLabels(labels: string[] | undefined): string[] {
-  return (labels ?? [])
-    .map((l) => l.replace(/^#/, "").trim())
-    .filter(Boolean);
+  return (labels ?? []).map(slugLabel).filter(Boolean);
 }
 
 interface IssueLineFields {
@@ -161,10 +177,19 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** Index of the line carrying this ^e-/^i- ref, or -1. */
-function findRefLine(lines: string[], id: string): number {
+/** Dominant end-of-line of `content`, so writes preserve CRLF vs LF. */
+function detectEol(content: string): string {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+/**
+ * Index of the *issue row* carrying this `^i-` ref, or -1. Restricted to issue
+ * rows (ISSUE_LINE_RE) so a ref mentioned in a detail line, epic description,
+ * or comment is never mistaken for the issue itself and mutated/removed.
+ */
+function findIssueLine(lines: string[], id: string): number {
   const re = new RegExp("\\^" + escapeRegExp(id) + "(?![A-Za-z0-9])");
-  return lines.findIndex((l) => re.test(l));
+  return lines.findIndex((l) => ISSUE_LINE_RE.test(l) && re.test(l));
 }
 
 function findEpicHeaderLine(lines: string[], epicId: string): number {
@@ -244,6 +269,7 @@ export function applyAddIssue(content: string, issue: NewIssue): string {
     worktree: issue.worktree,
     sessionId: issue.sessionId,
   });
+  const eol = detectEol(content);
   const lines = content.split(/\r?\n/);
 
   let headerIdx: number;
@@ -256,13 +282,14 @@ export function applyAddIssue(content: string, issue: NewIssue): string {
     if (headerIdx === -1) {
       // No Inbox section yet — append one.
       const body = content.replace(/\s*$/, "");
-      return backfillIds(`${body}\n\n## Inbox\n${line}\n`).content;
+      return backfillIds(`${body}${eol}${eol}## Inbox${eol}${line}${eol}`)
+        .content;
     }
   }
 
   const at = containerInsertIndex(lines, headerIdx);
   lines.splice(at, 0, line);
-  return backfillIds(lines.join("\n")).content;
+  return backfillIds(lines.join(eol)).content;
 }
 
 export function applyAddEpic(
@@ -284,18 +311,20 @@ export function applyAddEpic(
     for (const dl of opts.description.split(/\r?\n/)) epicLines.push(`> ${dl}`);
   }
 
+  const eol = detectEol(content);
   const lines = content.split(/\r?\n/);
   const inboxIdx = lines.findIndex((l) => INBOX_HDR_RE.test(l));
   if (inboxIdx === -1) {
     const body = content.replace(/\s*$/, "");
-    return backfillIds(`${body}\n\n${epicLines.join("\n")}\n`).content;
+    return backfillIds(`${body}${eol}${eol}${epicLines.join(eol)}${eol}`)
+      .content;
   }
 
   // Insert the epic just before the Inbox (Inbox stays last), blank-separated.
   const insert = [...epicLines, ""];
   if (inboxIdx > 0 && lines[inboxIdx - 1].trim() !== "") insert.unshift("");
   lines.splice(inboxIdx, 0, ...insert);
-  return backfillIds(lines.join("\n")).content;
+  return backfillIds(lines.join(eol)).content;
 }
 
 export function applySetIssueStatus(
@@ -303,15 +332,16 @@ export function applySetIssueStatus(
   id: string,
   status: BoardStatus,
 ): string {
+  const eol = detectEol(content);
   const lines = content.split(/\r?\n/);
-  const p = findRefLine(lines, id);
+  const p = findIssueLine(lines, id);
   if (p === -1)
     throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
   const issue = findIssue(parseBoardMd(content), id);
   if (!issue) throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
   const indent = lines[p].match(/^\s*/)![0];
   lines[p] = indent + formatIssueLine({ ...issue, status });
-  return backfillIds(lines.join("\n")).content;
+  return backfillIds(lines.join(eol)).content;
 }
 
 export function applyEditIssue(
@@ -319,8 +349,9 @@ export function applyEditIssue(
   id: string,
   patch: Partial<Pick<NewIssue, "title" | "priority" | "labels">>,
 ): string {
+  const eol = detectEol(content);
   const lines = content.split(/\r?\n/);
-  const p = findRefLine(lines, id);
+  const p = findIssueLine(lines, id);
   if (p === -1)
     throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
   const issue = findIssue(parseBoardMd(content), id);
@@ -334,7 +365,7 @@ export function applyEditIssue(
       priority: "priority" in patch ? patch.priority : issue.priority,
       labels: patch.labels !== undefined ? patch.labels : issue.labels,
     });
-  return backfillIds(lines.join("\n")).content;
+  return backfillIds(lines.join(eol)).content;
 }
 
 export function applyMoveIssue(
@@ -342,8 +373,9 @@ export function applyMoveIssue(
   id: string,
   toEpicId: string | "inbox",
 ): string {
+  const eol = detectEol(content);
   const lines = content.split(/\r?\n/);
-  const p = findRefLine(lines, id);
+  const p = findIssueLine(lines, id);
   if (p === -1)
     throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
   const end = issueSpanEnd(lines, p);
@@ -354,8 +386,9 @@ export function applyMoveIssue(
   if (toEpicId === "inbox") {
     headerIdx = lines.findIndex((l) => INBOX_HDR_RE.test(l));
     if (headerIdx === -1) {
-      const body = lines.join("\n").replace(/\s*$/, "");
-      return backfillIds(`${body}\n\n## Inbox\n${span.join("\n")}\n`).content;
+      const body = lines.join(eol).replace(/\s*$/, "");
+      return backfillIds(`${body}${eol}${eol}## Inbox${eol}${span.join(eol)}${eol}`)
+        .content;
     }
   } else {
     headerIdx = findEpicHeaderLine(lines, toEpicId);
@@ -365,7 +398,7 @@ export function applyMoveIssue(
 
   const at = containerInsertIndex(lines, headerIdx);
   lines.splice(at, 0, ...span);
-  return backfillIds(lines.join("\n")).content;
+  return backfillIds(lines.join(eol)).content;
 }
 
 export function applyReorderIssue(
@@ -373,8 +406,9 @@ export function applyReorderIssue(
   id: string,
   newOrder: number,
 ): string {
+  const eol = detectEol(content);
   const lines = content.split(/\r?\n/);
-  const p = findRefLine(lines, id);
+  const p = findIssueLine(lines, id);
   if (p === -1)
     throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
 
@@ -414,7 +448,7 @@ export function applyReorderIssue(
   const k = Math.max(0, Math.min(newOrder, issueIdxs.length));
   const at = k < issueIdxs.length ? issueIdxs[k] : bodyEnd;
   lines.splice(at, 0, ...span);
-  return backfillIds(lines.join("\n")).content;
+  return backfillIds(lines.join(eol)).content;
 }
 
 // ── Async public API (canonical-resolved, locked, atomic, re-parsed) ───────

--- a/src/lib/boardWriter.ts
+++ b/src/lib/boardWriter.ts
@@ -1,0 +1,487 @@
+import { promises as fs } from "fs";
+import path from "path";
+import {
+  BoardInfo,
+  BoardIssue,
+  BoardStatus,
+  BoardPriority,
+} from "./types";
+import { parseBoardMd } from "./scanner/boardMd";
+import { canonicalProjectDir } from "./canonicalProjectPath";
+import { writeFileAtomic, withFileLock } from "./atomicWrite";
+
+// ── Serializing BOARD.md writer ────────────────────────────────────────────
+//
+// Every mutation: canonical-path-resolved → file-locked → atomic-written →
+// re-parsed (so the returned BoardInfo matches disk). The pure `applyXxx`
+// transforms below take content → content (and run ID backfill), so they are
+// fully unit-testable without fs; the exported async methods wrap them with the
+// read/lock/write/re-parse plumbing.
+//
+// Edits are line-targeted: the writer locates the exact source line via the
+// stable ^e-/^i- ref the parser recorded, and rewrites (or splices) only that
+// line, preserving all other hand formatting.
+
+const SKELETON = "# Board\n\n<!-- minder-board: v1 -->\n";
+
+export class BoardWriteError extends Error {
+  constructor(
+    message: string,
+    public code: "EMPTY_TITLE" | "NOT_FOUND" | "BAD_TARGET",
+  ) {
+    super(message);
+    this.name = "BoardWriteError";
+  }
+}
+
+// ── Line classifiers (shared with the parser's grammar) ────────────────────
+const HEADER_RE = /^##\s/;
+const EPIC_HDR_RE = /^##\s+Epic:/i;
+const INBOX_HDR_RE = /^##\s+Inbox\b/i;
+const ISSUE_LINE_RE = /^\s*-\s*\[[ xX>]\]\s+/;
+const DETAIL_RE = /^\s{2,}\S/;
+const STATUS_TOKEN_RE = /\[(backlog|todo|doing|review|done|triage)\]/;
+
+/** Checkbox glyph for a status — keeps the markdown readable as a checklist. */
+const STATUS_GLYPH: Record<BoardStatus, string> = {
+  backlog: " ",
+  todo: " ",
+  doing: ">",
+  review: ">",
+  done: "x",
+  triage: " ",
+};
+
+// ── ID generation + backfill (P2: random base36 surrogate keys) ────────────
+
+/** Random short surrogate key — STABLE across edits. Never a content hash. */
+export function genBoardId(kind: "e" | "i", existing: Set<string>): string {
+  let id: string;
+  do {
+    const rand = Math.random().toString(36).slice(2).padEnd(4, "0").slice(0, 4);
+    id = `${kind}-${rand}`;
+  } while (existing.has(id));
+  existing.add(id);
+  return id;
+}
+
+/** Every ^e-/^i- id already present, so generation avoids collisions. */
+export function collectIds(content: string): Set<string> {
+  const ids = new Set<string>();
+  for (const m of content.matchAll(/\^([ei]-[A-Za-z0-9]+)/g)) ids.add(m[1]);
+  return ids;
+}
+
+/**
+ * Insert a `^e-`/`^i-` ref on any epic/issue line that lacks one. New refs go
+ * just before the `[status]` token (or at end of line if none), so they sit
+ * with the rest of the metadata.
+ */
+export function backfillIds(content: string): {
+  content: string;
+  changed: boolean;
+} {
+  const ids = collectIds(content);
+  const lines = content.split(/\r?\n/);
+  let changed = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const isEpic = EPIC_HDR_RE.test(line);
+    const isIssue = ISSUE_LINE_RE.test(line);
+    if ((isEpic || isIssue) && !/\^[ei]-/.test(line)) {
+      const id = genBoardId(isEpic ? "e" : "i", ids);
+      const statusIdx = line.search(STATUS_TOKEN_RE);
+      if (statusIdx !== -1) {
+        lines[i] =
+          `${line.slice(0, statusIdx).trimEnd()}  ^${id}  ` +
+          line.slice(statusIdx).trimStart();
+      } else {
+        lines[i] = `${line.trimEnd()}  ^${id}`;
+      }
+      changed = true;
+    }
+  }
+  return { content: changed ? lines.join("\n") : content, changed };
+}
+
+// ── Line formatting ────────────────────────────────────────────────────────
+
+function sanitizeTitle(s: string): string {
+  const t = s.replace(/[\r\n\t]+/g, " ").trim();
+  if (!t) throw new BoardWriteError("Title is empty", "EMPTY_TITLE");
+  return t;
+}
+
+function cleanLabels(labels: string[] | undefined): string[] {
+  return (labels ?? [])
+    .map((l) => l.replace(/^#/, "").trim())
+    .filter(Boolean);
+}
+
+interface IssueLineFields {
+  id?: string;
+  title: string;
+  status: BoardStatus;
+  priority?: BoardPriority;
+  labels?: string[];
+  worktree?: string;
+  sessionId?: string;
+}
+
+/** Render an issue line. ID omitted when empty — backfill assigns it on write. */
+function formatIssueLine(f: IssueLineFields): string {
+  const parts = [`- [${STATUS_GLYPH[f.status]}] ${f.title}`];
+  if (f.id) parts.push(`^${f.id}`);
+  parts.push(`[${f.status}]`);
+  if (f.priority) parts.push(`!${f.priority}`);
+  for (const l of cleanLabels(f.labels)) parts.push(`#${l}`);
+  if (f.worktree) parts.push(`@wt:${f.worktree}`);
+  if (f.sessionId) parts.push(`~session:${f.sessionId}`);
+  return parts.join("  ");
+}
+
+function formatEpicHeader(f: {
+  id?: string;
+  title: string;
+  status: BoardStatus;
+  priority?: BoardPriority;
+  labels?: string[];
+}): string {
+  const parts = [`## Epic: ${f.title}`];
+  if (f.id) parts.push(`^${f.id}`);
+  parts.push(`[${f.status}]`);
+  if (f.priority) parts.push(`!${f.priority}`);
+  for (const l of cleanLabels(f.labels)) parts.push(`@${l}`);
+  return parts.join("  ");
+}
+
+// ── Locators ─────────────────────────────────────────────────────────────
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Index of the line carrying this ^e-/^i- ref, or -1. */
+function findRefLine(lines: string[], id: string): number {
+  const re = new RegExp("\\^" + escapeRegExp(id) + "(?![A-Za-z0-9])");
+  return lines.findIndex((l) => re.test(l));
+}
+
+function findEpicHeaderLine(lines: string[], epicId: string): number {
+  const re = new RegExp("\\^" + escapeRegExp(epicId) + "(?![A-Za-z0-9])");
+  return lines.findIndex((l) => EPIC_HDR_RE.test(l) && re.test(l));
+}
+
+/** First index at/after `start` that begins a new `## ` section, else length. */
+function blockEnd(lines: string[], start: number): number {
+  let j = start + 1;
+  while (j < lines.length && !HEADER_RE.test(lines[j])) j++;
+  return j;
+}
+
+/** Exclusive end of an issue's span (its line + contiguous detail lines). */
+function issueSpanEnd(lines: string[], p: number): number {
+  let j = p + 1;
+  while (
+    j < lines.length &&
+    DETAIL_RE.test(lines[j]) &&
+    !ISSUE_LINE_RE.test(lines[j])
+  )
+    j++;
+  return j;
+}
+
+/** Where to insert a new issue within a container (after its last issue). */
+function containerInsertIndex(lines: string[], headerIdx: number): number {
+  const end = blockEnd(lines, headerIdx);
+  let insertAt = -1;
+  for (let i = headerIdx + 1; i < end; i++) {
+    if (ISSUE_LINE_RE.test(lines[i])) {
+      insertAt = issueSpanEnd(lines, i);
+      i = insertAt - 1;
+    }
+  }
+  if (insertAt === -1) {
+    // No issues yet — insert after the header, its blockquote, and any comment.
+    let i = headerIdx + 1;
+    while (i < end && (/^\s*>/.test(lines[i]) || /^\s*<!--/.test(lines[i]))) i++;
+    insertAt = i;
+  }
+  return insertAt;
+}
+
+function findIssue(
+  model: BoardInfo | undefined,
+  id: string,
+): BoardIssue | undefined {
+  if (!model) return undefined;
+  for (const e of model.epics) {
+    const hit = e.issues.find((i) => i.id === id);
+    if (hit) return hit;
+  }
+  return model.inbox.find((i) => i.id === id);
+}
+
+// ── Pure transforms (content → content, ID-backfilled) ─────────────────────
+
+export interface NewIssue {
+  title: string;
+  epicId?: string; // omit ⇒ Inbox
+  status?: BoardStatus; // default "todo"
+  priority?: BoardPriority;
+  labels?: string[];
+  worktree?: string; // @wt:
+  sessionId?: string; // ~session:
+}
+
+export function applyAddIssue(content: string, issue: NewIssue): string {
+  const title = sanitizeTitle(issue.title);
+  const line = formatIssueLine({
+    title,
+    status: issue.status ?? "todo",
+    priority: issue.priority,
+    labels: issue.labels,
+    worktree: issue.worktree,
+    sessionId: issue.sessionId,
+  });
+  const lines = content.split(/\r?\n/);
+
+  let headerIdx: number;
+  if (issue.epicId) {
+    headerIdx = findEpicHeaderLine(lines, issue.epicId);
+    if (headerIdx === -1)
+      throw new BoardWriteError(`Epic ${issue.epicId} not found`, "BAD_TARGET");
+  } else {
+    headerIdx = lines.findIndex((l) => INBOX_HDR_RE.test(l));
+    if (headerIdx === -1) {
+      // No Inbox section yet — append one.
+      const body = content.replace(/\s*$/, "");
+      return backfillIds(`${body}\n\n## Inbox\n${line}\n`).content;
+    }
+  }
+
+  const at = containerInsertIndex(lines, headerIdx);
+  lines.splice(at, 0, line);
+  return backfillIds(lines.join("\n")).content;
+}
+
+export function applyAddEpic(
+  content: string,
+  title: string,
+  opts?: {
+    status?: BoardStatus;
+    priority?: BoardPriority;
+    description?: string;
+  },
+): string {
+  const header = formatEpicHeader({
+    title: sanitizeTitle(title),
+    status: opts?.status ?? "backlog",
+    priority: opts?.priority,
+  });
+  const epicLines = [header];
+  if (opts?.description) {
+    for (const dl of opts.description.split(/\r?\n/)) epicLines.push(`> ${dl}`);
+  }
+
+  const lines = content.split(/\r?\n/);
+  const inboxIdx = lines.findIndex((l) => INBOX_HDR_RE.test(l));
+  if (inboxIdx === -1) {
+    const body = content.replace(/\s*$/, "");
+    return backfillIds(`${body}\n\n${epicLines.join("\n")}\n`).content;
+  }
+
+  // Insert the epic just before the Inbox (Inbox stays last), blank-separated.
+  const insert = [...epicLines, ""];
+  if (inboxIdx > 0 && lines[inboxIdx - 1].trim() !== "") insert.unshift("");
+  lines.splice(inboxIdx, 0, ...insert);
+  return backfillIds(lines.join("\n")).content;
+}
+
+export function applySetIssueStatus(
+  content: string,
+  id: string,
+  status: BoardStatus,
+): string {
+  const lines = content.split(/\r?\n/);
+  const p = findRefLine(lines, id);
+  if (p === -1)
+    throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
+  const issue = findIssue(parseBoardMd(content), id);
+  if (!issue) throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
+  const indent = lines[p].match(/^\s*/)![0];
+  lines[p] = indent + formatIssueLine({ ...issue, status });
+  return backfillIds(lines.join("\n")).content;
+}
+
+export function applyEditIssue(
+  content: string,
+  id: string,
+  patch: Partial<Pick<NewIssue, "title" | "priority" | "labels">>,
+): string {
+  const lines = content.split(/\r?\n/);
+  const p = findRefLine(lines, id);
+  if (p === -1)
+    throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
+  const issue = findIssue(parseBoardMd(content), id);
+  if (!issue) throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
+  const indent = lines[p].match(/^\s*/)![0];
+  lines[p] =
+    indent +
+    formatIssueLine({
+      ...issue,
+      title: patch.title !== undefined ? sanitizeTitle(patch.title) : issue.title,
+      priority: "priority" in patch ? patch.priority : issue.priority,
+      labels: patch.labels !== undefined ? patch.labels : issue.labels,
+    });
+  return backfillIds(lines.join("\n")).content;
+}
+
+export function applyMoveIssue(
+  content: string,
+  id: string,
+  toEpicId: string | "inbox",
+): string {
+  const lines = content.split(/\r?\n/);
+  const p = findRefLine(lines, id);
+  if (p === -1)
+    throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
+  const end = issueSpanEnd(lines, p);
+  const span = lines.slice(p, end);
+  lines.splice(p, end - p);
+
+  let headerIdx: number;
+  if (toEpicId === "inbox") {
+    headerIdx = lines.findIndex((l) => INBOX_HDR_RE.test(l));
+    if (headerIdx === -1) {
+      const body = lines.join("\n").replace(/\s*$/, "");
+      return backfillIds(`${body}\n\n## Inbox\n${span.join("\n")}\n`).content;
+    }
+  } else {
+    headerIdx = findEpicHeaderLine(lines, toEpicId);
+    if (headerIdx === -1)
+      throw new BoardWriteError(`Epic ${toEpicId} not found`, "BAD_TARGET");
+  }
+
+  const at = containerInsertIndex(lines, headerIdx);
+  lines.splice(at, 0, ...span);
+  return backfillIds(lines.join("\n")).content;
+}
+
+export function applyReorderIssue(
+  content: string,
+  id: string,
+  newOrder: number,
+): string {
+  const lines = content.split(/\r?\n/);
+  const p = findRefLine(lines, id);
+  if (p === -1)
+    throw new BoardWriteError(`Issue ${id} not found`, "NOT_FOUND");
+
+  // Capture the owning header before removal so the container bounds stay
+  // correct even when this is the container's only issue.
+  let headerIdx = -1;
+  for (let i = p; i >= 0; i--) {
+    if (HEADER_RE.test(lines[i])) {
+      headerIdx = i;
+      break;
+    }
+  }
+  const bodyStart = headerIdx === -1 ? 0 : headerIdx + 1;
+
+  const end = issueSpanEnd(lines, p);
+  const span = lines.slice(p, end);
+  lines.splice(p, end - p);
+
+  // Body end on the reduced array, derived from the captured header.
+  let bodyEnd: number;
+  if (headerIdx === -1) {
+    bodyEnd = 0;
+    while (bodyEnd < lines.length && !HEADER_RE.test(lines[bodyEnd])) bodyEnd++;
+  } else {
+    bodyEnd = blockEnd(lines, headerIdx);
+  }
+
+  // Primary-line index of each remaining sibling issue.
+  const issueIdxs: number[] = [];
+  for (let i = bodyStart; i < bodyEnd; i++) {
+    if (ISSUE_LINE_RE.test(lines[i])) {
+      issueIdxs.push(i);
+      i = issueSpanEnd(lines, i) - 1;
+    }
+  }
+
+  const k = Math.max(0, Math.min(newOrder, issueIdxs.length));
+  const at = k < issueIdxs.length ? issueIdxs[k] : bodyEnd;
+  lines.splice(at, 0, ...span);
+  return backfillIds(lines.join("\n")).content;
+}
+
+// ── Async public API (canonical-resolved, locked, atomic, re-parsed) ───────
+
+async function mutate(
+  projectPath: string,
+  transform: (content: string) => string,
+): Promise<BoardInfo | undefined> {
+  const dir = await canonicalProjectDir(projectPath);
+  const filePath = path.join(dir, "BOARD.md");
+  return withFileLock(filePath, async () => {
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") content = SKELETON;
+      else throw err;
+    }
+    const next = transform(content);
+    if (next !== content) await writeFileAtomic(filePath, next);
+    return parseBoardMd(next);
+  });
+}
+
+export function addIssue(
+  projectPath: string,
+  issue: NewIssue,
+): Promise<BoardInfo | undefined> {
+  return mutate(projectPath, (c) => applyAddIssue(c, issue));
+}
+
+export function addEpic(
+  projectPath: string,
+  title: string,
+  opts?: { status?: BoardStatus; priority?: BoardPriority; description?: string },
+): Promise<BoardInfo | undefined> {
+  return mutate(projectPath, (c) => applyAddEpic(c, title, opts));
+}
+
+export function setIssueStatus(
+  projectPath: string,
+  id: string,
+  status: BoardStatus,
+): Promise<BoardInfo | undefined> {
+  return mutate(projectPath, (c) => applySetIssueStatus(c, id, status));
+}
+
+export function editIssue(
+  projectPath: string,
+  id: string,
+  patch: Partial<Pick<NewIssue, "title" | "priority" | "labels">>,
+): Promise<BoardInfo | undefined> {
+  return mutate(projectPath, (c) => applyEditIssue(c, id, patch));
+}
+
+export function moveIssue(
+  projectPath: string,
+  id: string,
+  toEpicId: string | "inbox",
+): Promise<BoardInfo | undefined> {
+  return mutate(projectPath, (c) => applyMoveIssue(c, id, toEpicId));
+}
+
+export function reorderIssue(
+  projectPath: string,
+  id: string,
+  newOrder: number,
+): Promise<BoardInfo | undefined> {
+  return mutate(projectPath, (c) => applyReorderIssue(c, id, newOrder));
+}

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -22,6 +22,7 @@ export const FEATURE_FLAG_KEYS: readonly FeatureFlagKey[] = [
   "agentView",
   "claudeStatusAlerts",
   "configLint",
+  "scanBoard",
 ] as const;
 
 /** Human-readable metadata for the Settings UI. Empty groups are fine —
@@ -185,6 +186,16 @@ export const FEATURE_FLAG_META: readonly FeatureFlagMeta[] = [
     group: "passive",
     appliesAt: "scan",
     wired: true,
+  },
+  {
+    key: "scanBoard",
+    label: "Scan BOARD.md",
+    description: "Reads BOARD.md (epics → issues) from each project for the Board.",
+    group: "passive",
+    appliesAt: "scan",
+    // Wired in PR 3 (scanner integration). Until then the flag persists but no
+    // scanner reads it — the Settings UI shows the standard unwired hint.
+    wired: false,
   },
 ];
 

--- a/src/lib/scanner/boardMd.ts
+++ b/src/lib/scanner/boardMd.ts
@@ -1,0 +1,218 @@
+import { promises as fs } from "fs";
+import path from "path";
+import {
+  BoardInfo,
+  BoardEpic,
+  BoardIssue,
+  BoardStatus,
+  BoardPriority,
+} from "../types";
+
+// ── BOARD.md grammar (roadmap §6.2) ────────────────────────────────────────
+//
+//   # Board — <project>
+//   <!-- minder-board: v1 -->
+//
+//   ## Epic: <title> ^e-<id>  [<status>]  !<priority>  @<tag>…
+//   > <optional blockquote description line(s)>
+//
+//   - [ ] <title> ^i-<id>  [<status>]  !<prio>  #<label>…  @wt:<branch>  ~session:<id>
+//     <optional indented detail line(s)>
+//   - [>] <doing item> ^i-<id>
+//   - [x] <done item>  ^i-<id>
+//
+//   ## Inbox
+//   - [ ] (finding) <title> ^i-<id>  [triage]  @wt:<branch>  ~session:<id>
+//
+// The parser is deliberately tolerant of hand edits: missing IDs, missing
+// status tokens (status then derives from the checkbox glyph), extra
+// whitespace, and bare `- [ ] thing` lines all parse.
+
+const ID_RE = /\^([ei])-([A-Za-z0-9]+)/;
+const STATUS_RE = /\[(backlog|todo|doing|review|done|triage)\]/;
+const PRIORITY_RE = /!(high|med|low)\b/;
+const WT_RE = /@wt:(\S+)/;
+const SESSION_RE = /~session:(\S+)/;
+// Global — used by both parseLabels (matchAll) and cleanTitle (replace).
+// matchAll clones the regex internally and .replace resets lastIndex on
+// completion, so sharing this instance across the two is safe.
+const LABEL_G = /#([A-Za-z0-9][\w-]*)/g;
+const EPIC_HEADER_RE = /^##\s+Epic:\s*(.*)$/i;
+const INBOX_HEADER_RE = /^##\s+Inbox\b/i;
+const ISSUE_RE = /^\s*-\s*\[([ x>])\]\s+(.*)$/i;
+
+function glyphToStatus(glyph: string): BoardStatus {
+  if (glyph.toLowerCase() === "x") return "done";
+  if (glyph === ">") return "doing";
+  return "todo";
+}
+
+/** Strip every recognised token from a title fragment, leaving prose. */
+function cleanTitle(s: string): string {
+  return s
+    .replace(ID_RE, "")
+    .replace(STATUS_RE, "")
+    .replace(PRIORITY_RE, "")
+    .replace(WT_RE, "")
+    .replace(SESSION_RE, "")
+    .replace(LABEL_G, "")
+    .replace(/@\S+/g, "") // any remaining @tags (already captured separately)
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+function parseLabels(s: string): string[] {
+  return [...s.matchAll(LABEL_G)].map((m) => m[1]);
+}
+
+/**
+ * Parse BOARD.md content into a hierarchical BoardInfo. Pure (no FS).
+ * Returns undefined when the file holds no epics or issues.
+ */
+export function parseBoardMd(content: string): BoardInfo | undefined {
+  const lines = content.split(/\r?\n/);
+  const epics: BoardEpic[] = [];
+  const inbox: BoardIssue[] = [];
+
+  let currentEpic: BoardEpic | null = null;
+  let inInbox = false;
+  let lastIssue: BoardIssue | null = null;
+  let epicOrder = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const line = raw.trimEnd();
+
+    // Epic header: `## Epic: <title> …`
+    const epicM = line.match(EPIC_HEADER_RE);
+    if (epicM) {
+      inInbox = false;
+      lastIssue = null;
+      const idM = line.match(ID_RE);
+      const statusM = line.match(STATUS_RE);
+      const prioM = line.match(PRIORITY_RE);
+      // Epic tags are `@foo` that are NOT `@wt:` provenance.
+      const tags = (line.match(/@\S+/g) || [])
+        .filter((t) => !t.startsWith("@wt:"))
+        .map((t) => t.slice(1));
+      currentEpic = {
+        id: idM && idM[1] === "e" ? `e-${idM[2]}` : "",
+        title: cleanTitle(epicM[1]),
+        status: (statusM?.[1] as BoardStatus) ?? "backlog",
+        priority: prioM?.[1] as BoardPriority | undefined,
+        labels: tags,
+        line: i + 1,
+        order: epicOrder++,
+        issues: [],
+      };
+      epics.push(currentEpic);
+      continue;
+    }
+
+    // Inbox header: `## Inbox`
+    if (INBOX_HEADER_RE.test(line)) {
+      inInbox = true;
+      currentEpic = null;
+      lastIssue = null;
+      continue;
+    }
+
+    // Epic description blockquote — only the `>` lines directly under the epic
+    // header, before its first issue.
+    if (currentEpic && !lastIssue && /^\s*>\s?/.test(line)) {
+      const text = line.replace(/^\s*>\s?/, "");
+      currentEpic.description = currentEpic.description
+        ? `${currentEpic.description}\n${text}`
+        : text;
+      continue;
+    }
+
+    // Issue line: `- [ ] …` / `- [>] …` / `- [x] …`
+    const issueM = line.match(ISSUE_RE);
+    if (issueM) {
+      const [, glyph, rest] = issueM;
+      const idM = rest.match(ID_RE);
+      const statusM = rest.match(STATUS_RE);
+      const prioM = rest.match(PRIORITY_RE);
+      const wtM = rest.match(WT_RE);
+      const sessM = rest.match(SESSION_RE);
+      // Issues before any epic/Inbox header fall into the Inbox so nothing is
+      // silently dropped.
+      const container = inInbox ? inbox : currentEpic?.issues ?? inbox;
+      const issue: BoardIssue = {
+        id: idM && idM[1] === "i" ? `i-${idM[2]}` : "",
+        title: cleanTitle(rest),
+        // Explicit [status] token wins; otherwise derive from the glyph.
+        status: (statusM?.[1] as BoardStatus) ?? glyphToStatus(glyph),
+        priority: prioM?.[1] as BoardPriority | undefined,
+        labels: parseLabels(rest),
+        epicId: inInbox ? undefined : currentEpic?.id || undefined,
+        worktree: wtM?.[1],
+        sessionId: sessM?.[1],
+        line: i + 1,
+        order: container.length,
+      };
+      container.push(issue);
+      lastIssue = issue;
+      continue;
+    }
+
+    // Indented continuation line → detail of the last issue. Uses the raw line
+    // so leading indentation is what's tested.
+    if (lastIssue && /^\s{2,}\S/.test(raw)) {
+      const text = raw.trim();
+      lastIssue.detail = lastIssue.detail
+        ? `${lastIssue.detail}\n${text}`
+        : text;
+      continue;
+    }
+
+    // A blank line ends detail capture for the current issue (but keeps the
+    // epic context, so the next issue still attaches to this epic).
+    if (line.trim() === "") lastIssue = null;
+  }
+
+  const total =
+    epics.length +
+    epics.reduce((n, e) => n + e.issues.length, 0) +
+    inbox.length;
+
+  if (total === 0) return undefined;
+  return { epics, inbox, total };
+}
+
+/** Read BOARD.md from a project root. Returns undefined if absent/empty. */
+export async function scanBoardMd(
+  projectPath: string,
+): Promise<BoardInfo | undefined> {
+  try {
+    // Literal filename in the join (not a parameter) so static analysis sees a
+    // fixed path component — mirrors the todoMd / insightsMd scanners.
+    const content = await fs.readFile(
+      path.join(projectPath, "BOARD.md"),
+      "utf-8",
+    );
+    return parseBoardMd(content);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * On-demand read of BOARD.archive.md (the done/history lane). The scan
+ * orchestrator never reads archive files — same convention as scanTodoArchive —
+ * so active board counts stay clean.
+ */
+export async function scanBoardArchive(
+  projectPath: string,
+): Promise<BoardInfo | undefined> {
+  try {
+    const content = await fs.readFile(
+      path.join(projectPath, "BOARD.archive.md"),
+      "utf-8",
+    );
+    return parseBoardMd(content);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/scanner/boardMd.ts
+++ b/src/lib/scanner/boardMd.ts
@@ -146,7 +146,10 @@ export function parseBoardMd(content: string): BoardInfo | undefined {
         status: (statusM?.[1] as BoardStatus) ?? glyphToStatus(glyph),
         priority: prioM?.[1] as BoardPriority | undefined,
         labels: parseLabels(rest),
-        epicId: inInbox ? undefined : currentEpic?.id || undefined,
+        // Preserve "" for issues under a not-yet-backfilled epic: epicId is
+        // only undefined for genuine Inbox/orphan items, so `epicId !==
+        // undefined` reliably means "belongs to an epic" even pre-backfill.
+        epicId: inInbox ? undefined : currentEpic ? currentEpic.id : undefined,
         worktree: wtM?.[1],
         sessionId: sessM?.[1],
         line: i + 1,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,6 +71,9 @@ export interface ProjectData {
   // Insights
   insights?: InsightsInfo;
 
+  // Board (BOARD.md epics → issues)
+  board?: BoardInfo;
+
   // Worktree overlays
   worktrees?: WorktreeOverlay[];
 
@@ -480,6 +483,52 @@ export interface InsightsInfo {
   total: number;
 }
 
+// ── Board (BOARD.md — epics → issues) ──────────────────────────────────────
+// Roadmap §6.4 hierarchical model. Parsed by src/lib/scanner/boardMd.ts and
+// carried on ProjectData.board. Stable IDs (^e-/^i-) are random base36
+// surrogate keys assigned by the writer, NOT content hashes — they must survive
+// title edits and reorders so the index keys the same item across mutations.
+export type BoardStatus =
+  | "backlog"
+  | "todo"
+  | "doing"
+  | "review"
+  | "done"
+  | "triage";
+export type BoardPriority = "high" | "med" | "low";
+
+export interface BoardIssue {
+  id: string;                 // "i-xxxx" ("" until the writer backfills it)
+  title: string;
+  status: BoardStatus;
+  priority?: BoardPriority;
+  labels: string[];
+  epicId?: string;            // undefined for Inbox items
+  worktree?: string;          // @wt:<branch> provenance
+  sessionId?: string;         // ~session:<id> provenance
+  detail?: string;            // indented detail lines, newline-joined
+  line: number;               // 1-based source line, for write-back
+  order: number;              // 0-based position within its container
+}
+
+export interface BoardEpic {
+  id: string;                 // "e-xxxx" ("" until the writer backfills it)
+  title: string;
+  status: BoardStatus;
+  priority?: BoardPriority;
+  labels: string[];
+  description?: string;       // leading `>` blockquote, newline-joined
+  line: number;
+  order: number;
+  issues: BoardIssue[];
+}
+
+export interface BoardInfo {
+  epics: BoardEpic[];
+  inbox: BoardIssue[];        // items under `## Inbox`
+  total: number;              // epics + all epic issues + inbox issues
+}
+
 export interface WorktreeOverlay {
   branch: string;           // e.g. "feature/gitwc"
   worktreePath: string;     // full path to worktree directory
@@ -528,7 +577,8 @@ export type FeatureFlagKey =
   | "gsdPlanning"
   | "agentView"
   | "claudeStatusAlerts"
-  | "configLint";
+  | "configLint"
+  | "scanBoard";
 
 /** Claude Code lifecycle hook event names sent in the hook stdin payload. */
 export type HookEventName =

--- a/tests/boardMd.test.ts
+++ b/tests/boardMd.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  parseBoardMd,
+  scanBoardMd,
+  scanBoardArchive,
+} from "@/lib/scanner/boardMd";
+
+// Mock fs so the scan helpers don't hit the real filesystem.
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+import { promises as fs } from "fs";
+const mockReadFile = vi.mocked(fs.readFile);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("parseBoardMd — structure", () => {
+  it("parses an epic with nested issues, extracting IDs/status/priority/labels", () => {
+    const md = `# Board — myapp
+<!-- minder-board: v1 -->
+
+## Epic: Authentication ^e-a1b2  [doing]  !high  @security
+> Ship Clerk auth end to end.
+> Second description line.
+
+- [ ] Wire ClerkProvider ^i-c3d4  [todo]  !med  #frontend
+- [>] Add middleware ^i-e5f6  [doing]  #backend
+- [x] Spike Clerk ^i-g7h8  [done]
+`;
+    const board = parseBoardMd(md)!;
+    expect(board).toBeDefined();
+    expect(board.epics).toHaveLength(1);
+    expect(board.inbox).toHaveLength(0);
+
+    const epic = board.epics[0];
+    expect(epic.id).toBe("e-a1b2");
+    expect(epic.title).toBe("Authentication");
+    expect(epic.status).toBe("doing");
+    expect(epic.priority).toBe("high");
+    expect(epic.labels).toEqual(["security"]);
+    expect(epic.description).toBe(
+      "Ship Clerk auth end to end.\nSecond description line.",
+    );
+    expect(epic.order).toBe(0);
+    expect(epic.issues).toHaveLength(3);
+
+    const [i0, i1, i2] = epic.issues;
+    expect(i0).toMatchObject({
+      id: "i-c3d4",
+      title: "Wire ClerkProvider",
+      status: "todo",
+      priority: "med",
+      labels: ["frontend"],
+      epicId: "e-a1b2",
+      order: 0,
+    });
+    expect(i1).toMatchObject({ id: "i-e5f6", status: "doing", order: 1 });
+    expect(i2).toMatchObject({ id: "i-g7h8", status: "done", order: 2 });
+  });
+
+  it("counts epics + epic issues + inbox issues in total", () => {
+    const md = `## Epic: One ^e-1
+- [ ] a ^i-1
+- [ ] b ^i-2
+
+## Inbox
+- [ ] c ^i-3
+`;
+    const board = parseBoardMd(md)!;
+    // 1 epic + 2 epic issues + 1 inbox issue
+    expect(board.total).toBe(4);
+  });
+
+  it("returns a board for an epic header with no issues", () => {
+    const board = parseBoardMd("## Epic: Empty ^e-x  [backlog]\n")!;
+    expect(board.epics).toHaveLength(1);
+    expect(board.epics[0].issues).toHaveLength(0);
+    expect(board.total).toBe(1);
+  });
+});
+
+describe("parseBoardMd — status derivation", () => {
+  it("derives status from the glyph when no [status] token is present", () => {
+    const board = parseBoardMd(
+      "## Epic: E ^e-1\n- [ ] todo item\n- [>] doing item\n- [x] done item\n",
+    )!;
+    const [a, b, c] = board.epics[0].issues;
+    expect(a.status).toBe("todo");
+    expect(b.status).toBe("doing");
+    expect(c.status).toBe("done");
+  });
+
+  it("lets an explicit [status] token win over the glyph", () => {
+    // [x] glyph but [review] token → review (token wins).
+    const board = parseBoardMd("## Epic: E ^e-1\n- [x] item ^i-1  [review]\n")!;
+    expect(board.epics[0].issues[0].status).toBe("review");
+  });
+
+  it("handles an uppercase [X] glyph as done", () => {
+    const board = parseBoardMd("## Epic: E ^e-1\n- [X] item\n")!;
+    expect(board.epics[0].issues[0].status).toBe("done");
+  });
+});
+
+describe("parseBoardMd — Inbox", () => {
+  it("places Inbox items in inbox with epicId undefined", () => {
+    const md = `## Inbox
+- [ ] triage me ^i-1  [triage]
+`;
+    const board = parseBoardMd(md)!;
+    expect(board.epics).toHaveLength(0);
+    expect(board.inbox).toHaveLength(1);
+    expect(board.inbox[0]).toMatchObject({
+      id: "i-1",
+      title: "triage me",
+      status: "triage",
+      epicId: undefined,
+      order: 0,
+    });
+  });
+
+  it("keeps the (finding) prefix on agent-pushed inbox lines", () => {
+    const md = `## Inbox
+- [ ] (finding) Hardcoded secret ^i-1  [triage]  @wt:fix-y  ~session:s9
+`;
+    const issue = parseBoardMd(md)!.inbox[0];
+    expect(issue.title).toBe("(finding) Hardcoded secret");
+    expect(issue.worktree).toBe("fix-y");
+    expect(issue.sessionId).toBe("s9");
+  });
+
+  it("routes issues appearing before any header into the Inbox", () => {
+    const board = parseBoardMd("- [ ] orphan item ^i-1\n")!;
+    expect(board.inbox).toHaveLength(1);
+    expect(board.inbox[0].title).toBe("orphan item");
+  });
+});
+
+describe("parseBoardMd — provenance and labels", () => {
+  it("captures @wt:/~session: provenance and excludes @wt: from labels", () => {
+    const md =
+      "## Epic: E ^e-1\n- [ ] task ^i-1  #alpha  #beta  @wt:feature-x  ~session:abc123\n";
+    const issue = parseBoardMd(md)!.epics[0].issues[0];
+    expect(issue.labels).toEqual(["alpha", "beta"]);
+    expect(issue.worktree).toBe("feature-x");
+    expect(issue.sessionId).toBe("abc123");
+    // @wt: is provenance, not a label.
+    expect(issue.labels).not.toContain("wt:feature-x");
+  });
+
+  it("collects epic @tags into labels but never @wt:", () => {
+    const board = parseBoardMd(
+      "## Epic: E ^e-1  @security  @wt:should-not-appear\n",
+    )!;
+    expect(board.epics[0].labels).toEqual(["security"]);
+  });
+});
+
+describe("parseBoardMd — tolerance of hand edits", () => {
+  it("parses a bare `- [ ] thing` with empty id and todo status", () => {
+    const board = parseBoardMd("## Epic: E ^e-1\n- [ ] just a title\n")!;
+    expect(board.epics[0].issues[0]).toMatchObject({
+      id: "",
+      title: "just a title",
+      status: "todo",
+    });
+  });
+
+  it("parses an epic with no ID as id ''", () => {
+    const board = parseBoardMd("## Epic: No ID Yet\n- [ ] x\n")!;
+    expect(board.epics[0].id).toBe("");
+    expect(board.epics[0].title).toBe("No ID Yet");
+  });
+
+  it("attaches indented detail lines to the preceding issue", () => {
+    const md = `## Epic: E ^e-1
+- [ ] do it ^i-1
+  details line one
+  details line two
+- [ ] next ^i-2
+`;
+    const [first, second] = parseBoardMd(md)!.epics[0].issues;
+    expect(first.detail).toBe("details line one\ndetails line two");
+    expect(second.detail).toBeUndefined();
+  });
+
+  it("does not bleed detail across a blank line", () => {
+    const md = `## Epic: E ^e-1
+- [ ] item ^i-1
+
+  orphaned indented prose
+`;
+    expect(parseBoardMd(md)!.epics[0].issues[0].detail).toBeUndefined();
+  });
+
+  it("returns undefined for an empty or prose-only file", () => {
+    expect(parseBoardMd("")).toBeUndefined();
+    expect(parseBoardMd("   \n\n  \n")).toBeUndefined();
+    expect(
+      parseBoardMd("# Board — x\n<!-- minder-board: v1 -->\n\njust prose\n"),
+    ).toBeUndefined();
+  });
+
+  it("handles CRLF line endings", () => {
+    const board = parseBoardMd("## Epic: E ^e-1\r\n- [ ] item ^i-1\r\n")!;
+    expect(board.epics[0].issues[0].title).toBe("item");
+  });
+});
+
+describe("scanBoardMd", () => {
+  it("reads BOARD.md and parses it", async () => {
+    mockReadFile.mockResolvedValue("## Epic: E ^e-1\n- [ ] item ^i-1\n");
+    const board = await scanBoardMd("C:\\dev\\fake");
+    expect(mockReadFile).toHaveBeenCalledWith(
+      expect.stringMatching(/BOARD\.md$/),
+      "utf-8",
+    );
+    expect(board?.total).toBe(2);
+  });
+
+  it("returns undefined when BOARD.md is absent", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    expect(await scanBoardMd("C:\\dev\\fake")).toBeUndefined();
+  });
+});
+
+describe("scanBoardArchive", () => {
+  it("reads BOARD.archive.md, not BOARD.md", async () => {
+    mockReadFile.mockResolvedValue("## Epic: Shipped ^e-1\n- [x] done ^i-1\n");
+    await scanBoardArchive("C:\\dev\\fake");
+    expect(mockReadFile).toHaveBeenCalledWith(
+      expect.stringMatching(/BOARD\.archive\.md$/),
+      "utf-8",
+    );
+  });
+
+  it("returns undefined when the archive is absent", async () => {
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    expect(await scanBoardArchive("C:\\dev\\fake")).toBeUndefined();
+  });
+});

--- a/tests/boardMd.test.ts
+++ b/tests/boardMd.test.ts
@@ -175,6 +175,16 @@ describe("parseBoardMd — tolerance of hand edits", () => {
     expect(board.epics[0].title).toBe("No ID Yet");
   });
 
+  it("keeps epicId '' (not undefined) for issues under a not-yet-backfilled epic", () => {
+    // Regression (PR #224 review): an un-ided epic's id is "", and its issues
+    // must NOT have that coerced to undefined — undefined is the Inbox/orphan
+    // sentinel, so `epicId !== undefined` must still mean "belongs to an epic".
+    const board = parseBoardMd("## Epic: No ID Yet\n- [ ] x\n")!;
+    const issue = board.epics[0].issues[0];
+    expect(issue.epicId).toBe("");
+    expect(issue.epicId).not.toBeUndefined();
+  });
+
   it("attaches indented detail lines to the preceding issue", () => {
     const md = `## Epic: E ^e-1
 - [ ] do it ^i-1

--- a/tests/boardWriter.test.ts
+++ b/tests/boardWriter.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  genBoardId,
+  collectIds,
+  backfillIds,
+  applyAddIssue,
+  applyAddEpic,
+  applySetIssueStatus,
+  applyEditIssue,
+  applyMoveIssue,
+  applyReorderIssue,
+  addIssue,
+  BoardWriteError,
+} from "@/lib/boardWriter";
+import { parseBoardMd } from "@/lib/scanner/boardMd";
+
+// Mock fs for the async wiring test. The pure applyXxx transforms below don't
+// touch fs, so they're unaffected.
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    rename: vi.fn(async () => undefined),
+  },
+}));
+
+import { promises as fs } from "fs";
+const mockReadFile = vi.mocked(fs.readFile);
+const mockWriteFile = vi.mocked(fs.writeFile);
+const mockRename = vi.mocked(fs.rename);
+
+beforeEach(() => vi.clearAllMocks());
+
+const SAMPLE = `# Board — myapp
+<!-- minder-board: v1 -->
+
+## Epic: Auth ^e-aaaa  [doing]  !high
+> Ship auth.
+
+- [ ] Wire provider ^i-1111  [todo]  #frontend
+- [>] Add middleware ^i-2222  [doing]
+- [x] Spike ^i-3333  [done]
+
+## Epic: Billing ^e-bbbb  [backlog]
+
+- [ ] Stripe setup ^i-4444  [todo]
+
+## Inbox
+- [ ] (finding) leak ^i-5555  [triage]  @wt:fix-y  ~session:s9
+`;
+
+describe("genBoardId", () => {
+  it("returns a kind-prefixed id and records it", () => {
+    const seen = new Set<string>();
+    const id = genBoardId("i", seen);
+    expect(id).toMatch(/^i-[a-z0-9]{4}$/);
+    expect(seen.has(id)).toBe(true);
+  });
+
+  it("avoids collisions with existing ids", () => {
+    // Pre-seed every 4-char id but one is impossible; instead assert it never
+    // returns an id already in the set across many draws.
+    const seen = new Set<string>();
+    const ids = Array.from({ length: 200 }, () => genBoardId("e", seen));
+    expect(new Set(ids).size).toBe(ids.length); // all unique
+    ids.forEach((id) => expect(id.startsWith("e-")).toBe(true));
+  });
+});
+
+describe("collectIds", () => {
+  it("extracts every ^e-/^i- id", () => {
+    const ids = collectIds(SAMPLE);
+    expect(ids).toContain("e-aaaa");
+    expect(ids).toContain("i-1111");
+    expect(ids).toContain("i-5555");
+    expect(ids.size).toBe(7);
+  });
+});
+
+describe("backfillIds", () => {
+  it("assigns ids to bare epic and issue lines, leaving existing ones intact", () => {
+    const input = `## Epic: New One
+- [ ] bare issue
+- [ ] kept ^i-keep  [todo]
+`;
+    const { content, changed } = backfillIds(input);
+    expect(changed).toBe(true);
+
+    const board = parseBoardMd(content)!;
+    expect(board.epics[0].id).toMatch(/^e-[a-z0-9]{4}$/); // backfilled
+    expect(board.epics[0].issues[0].id).toMatch(/^i-[a-z0-9]{4}$/); // backfilled
+    expect(board.epics[0].issues[1].id).toBe("i-keep"); // untouched
+  });
+
+  it("is a no-op when every line already has an id", () => {
+    const { changed } = backfillIds(SAMPLE);
+    expect(changed).toBe(false);
+  });
+
+  it("never collides a backfilled id with an existing one", () => {
+    const input = `## Epic: A ^e-zzzz
+- [ ] one
+- [ ] two
+- [ ] three
+`;
+    const ids = collectIds(backfillIds(input).content);
+    expect(ids.size).toBe(4); // e-zzzz + 3 fresh, all distinct
+  });
+});
+
+describe("applyAddIssue", () => {
+  it("inserts an issue under the target epic with a backfilled id", () => {
+    const out = applyAddIssue(SAMPLE, {
+      title: "New task",
+      epicId: "e-aaaa",
+      priority: "med",
+      labels: ["backend"],
+    });
+    const board = parseBoardMd(out)!;
+    const auth = board.epics.find((e) => e.id === "e-aaaa")!;
+    const added = auth.issues.find((i) => i.title === "New task")!;
+    expect(added).toBeDefined();
+    expect(added.id).toMatch(/^i-[a-z0-9]{4}$/);
+    expect(added.priority).toBe("med");
+    expect(added.labels).toEqual(["backend"]);
+    expect(added.status).toBe("todo");
+    // Inserted after the epic's existing issues.
+    expect(auth.issues[auth.issues.length - 1].title).toBe("New task");
+  });
+
+  it("appends to the existing Inbox when no epicId is given", () => {
+    const out = applyAddIssue(SAMPLE, { title: "triage this" });
+    const board = parseBoardMd(out)!;
+    expect(board.inbox.map((i) => i.title)).toContain("triage this");
+    // Did not disturb the existing inbox finding.
+    expect(board.inbox.map((i) => i.title)).toContain("(finding) leak");
+  });
+
+  it("creates an Inbox section when none exists", () => {
+    const noInbox = `## Epic: A ^e-a\n- [ ] one ^i-1\n`;
+    const out = applyAddIssue(noInbox, { title: "fresh" });
+    const board = parseBoardMd(out)!;
+    expect(board.inbox).toHaveLength(1);
+    expect(board.inbox[0].title).toBe("fresh");
+  });
+
+  it("throws BAD_TARGET for an unknown epic", () => {
+    expect(() => applyAddIssue(SAMPLE, { title: "x", epicId: "e-nope" })).toThrow(
+      BoardWriteError,
+    );
+  });
+
+  it("throws EMPTY_TITLE for blank titles", () => {
+    expect(() => applyAddIssue(SAMPLE, { title: "   " })).toThrow(BoardWriteError);
+  });
+});
+
+describe("applyAddEpic", () => {
+  it("adds an epic with a description before the Inbox", () => {
+    const out = applyAddEpic(SAMPLE, "Observability", {
+      status: "todo",
+      description: "Wire OTEL.",
+    });
+    const board = parseBoardMd(out)!;
+    const epic = board.epics.find((e) => e.title === "Observability")!;
+    expect(epic).toBeDefined();
+    expect(epic.id).toMatch(/^e-[a-z0-9]{4}$/);
+    expect(epic.status).toBe("todo");
+    expect(epic.description).toBe("Wire OTEL.");
+    // Inbox remains the last section.
+    const inboxLine = out.indexOf("## Inbox");
+    const epicLine = out.indexOf("## Epic: Observability");
+    expect(epicLine).toBeLessThan(inboxLine);
+  });
+
+  it("appends an epic at EOF when no Inbox exists", () => {
+    const out = applyAddEpic("## Epic: A ^e-a\n- [ ] x ^i-1\n", "B");
+    const board = parseBoardMd(out)!;
+    expect(board.epics.map((e) => e.title)).toEqual(["A", "B"]);
+  });
+});
+
+describe("applySetIssueStatus", () => {
+  it("syncs both the checkbox glyph and the [status] token", () => {
+    const out = applySetIssueStatus(SAMPLE, "i-1111", "done");
+    // The raw line should now carry an [x] glyph and a [done] token.
+    const line = out.split("\n").find((l) => l.includes("^i-1111"))!;
+    expect(line).toMatch(/-\s*\[x\]/);
+    expect(line).toContain("[done]");
+    expect(parseBoardMd(out)!.epics[0].issues[0].status).toBe("done");
+  });
+
+  it("throws NOT_FOUND for an unknown id", () => {
+    expect(() => applySetIssueStatus(SAMPLE, "i-zzzz", "done")).toThrow(
+      BoardWriteError,
+    );
+  });
+});
+
+describe("applyEditIssue", () => {
+  it("patches title, priority and labels while preserving the id", () => {
+    const out = applyEditIssue(SAMPLE, "i-1111", {
+      title: "Renamed",
+      priority: "low",
+      labels: ["x", "y"],
+    });
+    const issue = parseBoardMd(out)!.epics[0].issues.find((i) => i.id === "i-1111")!;
+    expect(issue.title).toBe("Renamed");
+    expect(issue.priority).toBe("low");
+    expect(issue.labels).toEqual(["x", "y"]);
+  });
+});
+
+describe("applyMoveIssue", () => {
+  it("moves an issue from an epic into the Inbox", () => {
+    const out = applyMoveIssue(SAMPLE, "i-1111", "inbox");
+    const board = parseBoardMd(out)!;
+    expect(board.epics[0].issues.find((i) => i.id === "i-1111")).toBeUndefined();
+    const moved = board.inbox.find((i) => i.id === "i-1111")!;
+    expect(moved).toBeDefined();
+    expect(moved.epicId).toBeUndefined();
+  });
+
+  it("moves an inbox issue into a target epic", () => {
+    const out = applyMoveIssue(SAMPLE, "i-5555", "e-bbbb");
+    const board = parseBoardMd(out)!;
+    expect(board.inbox.find((i) => i.id === "i-5555")).toBeUndefined();
+    const billing = board.epics.find((e) => e.id === "e-bbbb")!;
+    const moved = billing.issues.find((i) => i.id === "i-5555")!;
+    expect(moved).toBeDefined();
+    expect(moved.epicId).toBe("e-bbbb");
+  });
+
+  it("carries the issue's detail lines along on a move", () => {
+    const withDetail = `## Epic: A ^e-a
+- [ ] task ^i-1
+  detail one
+  detail two
+
+## Inbox
+- [ ] other ^i-2
+`;
+    const out = applyMoveIssue(withDetail, "i-1", "inbox");
+    const moved = parseBoardMd(out)!.inbox.find((i) => i.id === "i-1")!;
+    expect(moved.detail).toBe("detail one\ndetail two");
+  });
+});
+
+describe("applyReorderIssue", () => {
+  it("reorders an issue within its epic", () => {
+    // Auth epic order: i-1111, i-2222, i-3333. Move i-3333 to position 0.
+    const out = applyReorderIssue(SAMPLE, "i-3333", 0);
+    const ids = parseBoardMd(out)!.epics[0].issues.map((i) => i.id);
+    expect(ids).toEqual(["i-3333", "i-1111", "i-2222"]);
+  });
+
+  it("clamps an out-of-range order to the end", () => {
+    const out = applyReorderIssue(SAMPLE, "i-1111", 99);
+    const ids = parseBoardMd(out)!.epics[0].issues.map((i) => i.id);
+    expect(ids).toEqual(["i-2222", "i-3333", "i-1111"]);
+  });
+});
+
+describe("round-trip stability", () => {
+  it("preserves every other item's id/status/order across a mutation", () => {
+    const before = parseBoardMd(SAMPLE)!;
+    const out = applySetIssueStatus(SAMPLE, "i-2222", "review");
+    const after = parseBoardMd(out)!;
+
+    // Target changed.
+    expect(after.epics[0].issues[1].status).toBe("review");
+    // Everything else identical: ids, ordering, counts.
+    expect(after.total).toBe(before.total);
+    expect(after.epics.map((e) => e.id)).toEqual(before.epics.map((e) => e.id));
+    expect(after.epics[0].issues.map((i) => i.id)).toEqual(
+      before.epics[0].issues.map((i) => i.id),
+    );
+    expect(after.inbox.map((i) => i.id)).toEqual(before.inbox.map((i) => i.id));
+    // Provenance on the untouched inbox finding survives.
+    expect(after.inbox[0].worktree).toBe("fix-y");
+    expect(after.inbox[0].sessionId).toBe("s9");
+  });
+
+  it("is idempotent under parse→serialize→parse", () => {
+    // Adding then re-parsing twice yields a structurally identical board.
+    const once = applyAddIssue(SAMPLE, { title: "stable", epicId: "e-bbbb" });
+    const twiceParsed = parseBoardMd(once)!;
+    // Re-serializing the same content (no change) must keep ids stable.
+    const noop = applySetIssueStatus(once, "i-1111", "todo");
+    const reParsed = parseBoardMd(noop)!;
+    expect(reParsed.total).toBe(twiceParsed.total);
+    expect(reParsed.epics.map((e) => e.id)).toEqual(
+      twiceParsed.epics.map((e) => e.id),
+    );
+  });
+});
+
+describe("addIssue (async wiring)", () => {
+  it("resolves the canonical BOARD.md path, atomic-writes, and returns the board", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    mockReadFile.mockRejectedValue(enoent); // no BOARD.md and no .minder.json
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const result = await addIssue("C:\\dev\\scratch-proj", { title: "first" });
+
+    // writeFileAtomic writes a temp file then renames onto BOARD.md.
+    expect(mockWriteFile).toHaveBeenCalledOnce();
+    const written = mockWriteFile.mock.calls[0][1] as string;
+    expect(written).toContain("first");
+    const renameTarget = mockRename.mock.calls[0][1] as string;
+    expect(renameTarget.endsWith("BOARD.md")).toBe(true);
+
+    expect(result?.inbox.map((i) => i.title)).toContain("first");
+  });
+});

--- a/tests/boardWriter.test.ts
+++ b/tests/boardWriter.test.ts
@@ -295,6 +295,72 @@ describe("round-trip stability", () => {
   });
 });
 
+describe("PR #224 review fixes", () => {
+  // Fix B — EOL preservation
+  it("preserves CRLF line endings through a mutation", () => {
+    const crlf = SAMPLE.replace(/\n/g, "\r\n");
+    const out = applySetIssueStatus(crlf, "i-1111", "done");
+    // No lone LF should remain — every newline is part of a CRLF pair.
+    expect(out.includes("\r\n")).toBe(true);
+    expect(/(^|[^\r])\n/.test(out)).toBe(false);
+    // And the change still applied.
+    expect(parseBoardMd(out)!.epics[0].issues[0].status).toBe("done");
+  });
+
+  it("preserves LF line endings (no CR introduced)", () => {
+    const out = applySetIssueStatus(SAMPLE, "i-1111", "done");
+    expect(out.includes("\r")).toBe(false);
+  });
+
+  it("keeps CRLF when appending a brand-new Inbox section", () => {
+    const crlf = "## Epic: A ^e-a\r\n- [ ] one ^i-1\r\n";
+    const out = applyAddIssue(crlf, { title: "fresh" });
+    expect(out.includes("\r\n")).toBe(true);
+    expect(/(^|[^\r])\n/.test(out)).toBe(false);
+    expect(parseBoardMd(out)!.inbox[0].title).toBe("fresh");
+  });
+
+  // Fix C — label slug normalization
+  it("slug-normalizes labels so they round-trip losslessly", () => {
+    const out = applyAddIssue(SAMPLE, {
+      title: "task",
+      epicId: "e-aaaa",
+      labels: ["needs review", "C++", "_leading"],
+    });
+    const issue = parseBoardMd(out)!.epics
+      .find((e) => e.id === "e-aaaa")!
+      .issues.find((i) => i.title === "task")!;
+    expect(issue.labels).toEqual(["needs-review", "C", "leading"]);
+    // The extra word must not have bled into the title.
+    expect(issue.title).toBe("task");
+  });
+
+  // Fix D — issue-ref lookup restricted to issue rows
+  it("does not mutate a ^i- ref that only appears in a detail/prose line", () => {
+    const md = `## Epic: A ^e-a
+- [ ] real issue ^i-1111  [todo]
+  see also ^i-2222 for context
+- [ ] other ^i-2222  [todo]
+`;
+    // Targeting i-2222 must rewrite the actual issue row, not the detail line
+    // above it that merely mentions ^i-2222.
+    const out = applySetIssueStatus(md, "i-2222", "done");
+    const lines = out.split("\n");
+    // The detail line is untouched.
+    expect(lines.find((l) => l.includes("see also"))).toBe(
+      "  see also ^i-2222 for context",
+    );
+    // The real i-2222 row flipped to done.
+    expect(parseBoardMd(out)!.epics[0].issues.find((i) => i.id === "i-2222")!.status).toBe(
+      "done",
+    );
+    // i-1111 untouched.
+    expect(parseBoardMd(out)!.epics[0].issues.find((i) => i.id === "i-1111")!.status).toBe(
+      "todo",
+    );
+  });
+});
+
 describe("addIssue (async wiring)", () => {
   it("resolves the canonical BOARD.md path, atomic-writes, and returns the board", async () => {
     const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });


### PR DESCRIPTION
## Portfolio Command Deck — Phase 1, PR 2: Board parser / writer / types

Implements **Group B (Tasks B1–B3)** of the [Phase 1 plan](docs/superpowers/plans/2026-06-27-portfolio-command-deck-phase-1.md). Pure logic, heavily tested, **no UI and no wired consumer** — this is the core of the board, ready for PR 3 (scanner + API) to wire up.

### What's here

| Task | Content |
|------|---------|
| **B1 — types + flag** | `BoardStatus`/`BoardPriority`/`BoardIssue`/`BoardEpic`/`BoardInfo` in `types.ts`; `board?` on `ProjectData`; new `scanBoard` feature flag (`wired:false` until PR 3) |
| **B2 — parser + scanner** | `src/lib/scanner/boardMd.ts` — `parseBoardMd` (tolerant hierarchical parser) + `scanBoardMd` / `scanBoardArchive` |
| **B3 — writer** | `src/lib/boardWriter.ts` — serializing writer: `addIssue`/`addEpic`/`setIssueStatus`/`editIssue`/`moveIssue`/`reorderIssue` + ID generation/backfill |

### Design notes

- **Tolerant parser.** Derives status from the checkbox glyph (`[ ]`→todo, `[>]`→doing, `[x]`→done) when the explicit `[status]` token is absent; treats a missing `^e-`/`^i-` ID as `""` (the writer backfills). Captures `@wt:`/`~session:` provenance and `#labels`; attaches indented detail lines.
- **Minder is the single serializing writer (roadmap D2).** Every mutation is canonical-path-resolved (via `canonicalProjectDir` from PR 1), file-locked (`withFileLock`), atomic-written (`writeFileAtomic`), then re-parsed so the returned `BoardInfo` matches disk.
- **Stable IDs are random base36 surrogate keys (P2), never content hashes** — assigned on every write, so a hand-authored board gets Minder-assigned IDs the first time it's touched and they survive title edits/reorders.
- **Line-targeted edits.** The writer locates the exact source line via the stable `^e-`/`^i-` ref and rewrites (or splices, for move/reorder) only that line — all other hand formatting is byte-preserved. `setIssueStatus` syncs the checkbox glyph and `[status]` token together. Move/reorder carry an issue's indented detail lines along; reorder captures the owning header before removal so reordering a container's only issue can't misfire.

### No CHANGELOG / help docs yet — by design

PR 2 has no user-facing behavior (nothing scans `BOARD.md`, no API, the flag is inert). The plan defers the user-facing CHANGELOG entry and help docs to PR 4, when the board actually ships. The only visible surface is an inert "Scan BOARD.md" toggle in Settings, marked unwired.

### Verification

- `pnpm typecheck` — clean
- `pnpm test` — **2858 passing** | 1 skipped | 1 todo (was 2813 on `main`; +45 board tests: 21 `boardMd` + 24 `boardWriter`)
- Highest-value coverage: grammar/tolerance (parser) and **round-trip stability** (other items' id/status/order survive a mutation) + ID backfill collision-safety (writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
